### PR TITLE
feate(nebula): convert to sexagesimal degress and absolute time to match aw

### DIFF
--- a/nebula_common/include/nebula_common/nebula_common.hpp
+++ b/nebula_common/include/nebula_common/nebula_common.hpp
@@ -491,7 +491,17 @@ inline ReturnMode ReturnModeFromString(const std::string & return_mode)
   const pcl::PointCloud<PointXYZIRCAEDT>::ConstPtr & input_pointcloud);
 
 pcl::PointCloud<PointXYZIRADT>::Ptr convertPointXYZIRCAEDTToPointXYZIRADT(
-  const pcl::PointCloud<PointXYZIRCAEDT>::ConstPtr & input_pointcloud);
+  const pcl::PointCloud<PointXYZIRCAEDT>::ConstPtr & input_pointcloud, double stamp);
+
+/// @brief Converts degrees to radians
+/// @param radians
+/// @return degrees
+static inline float deg2rad(double degrees) { return degrees * M_PI / 180.0; }
+
+/// @brief Converts radians to degrees
+/// @param radians
+/// @return degrees
+static inline float rad2deg(double radians) { return radians * 180.0 / M_PI; }
 }  // namespace drivers
 }  // namespace nebula
 

--- a/nebula_common/src/nebula_common.cpp
+++ b/nebula_common/src/nebula_common.cpp
@@ -47,7 +47,7 @@ pcl::PointCloud<PointXYZIR>::Ptr convertPointXYZIRCAEDTToPointXYZIR(
 }
 
 pcl::PointCloud<PointXYZIRADT>::Ptr convertPointXYZIRCAEDTToPointXYZIRADT(
-  const pcl::PointCloud<PointXYZIRCAEDT>::ConstPtr & input_pointcloud)
+  const pcl::PointCloud<PointXYZIRCAEDT>::ConstPtr & input_pointcloud, const double stamp)
 {
   pcl::PointCloud<PointXYZIRADT>::Ptr output_pointcloud(new pcl::PointCloud<PointXYZIRADT>);
   output_pointcloud->reserve(input_pointcloud->points.size());
@@ -58,9 +58,9 @@ pcl::PointCloud<PointXYZIRADT>::Ptr convertPointXYZIRCAEDTToPointXYZIRADT(
     point.z = p.z;
     point.intensity = p.intensity;
     point.ring = p.channel;
-    point.azimuth = p.azimuth;
+    point.azimuth = rad2deg(p.azimuth);
     point.distance = p.distance;
-    point.time_stamp = static_cast<double>(input_pointcloud->header.stamp) + p.time_stamp*10e-9;
+    point.time_stamp = static_cast<double>(stamp) + p.time_stamp*10e-9;
     output_pointcloud->points.emplace_back(point);
   }
 

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/hesai_scan_decoder.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/hesai_scan_decoder.hpp
@@ -33,11 +33,6 @@ protected:
   /// @brief Calibration for this decoder
   std::shared_ptr<drivers::HesaiCalibrationConfiguration> sensor_calibration_;
 
-  /// @brief Converts an input degree value to the radian value
-  /// @param degrees
-  /// @return radians
-  static inline float deg2rad(double degrees) { return degrees * M_PI / 180.0; }
-
 public:
   HesaiScanDecoder(HesaiScanDecoder && c) = delete;
   HesaiScanDecoder & operator=(HesaiScanDecoder && c) = delete;

--- a/nebula_ros/src/hesai/hesai_decoder_ros_wrapper.cpp
+++ b/nebula_ros/src/hesai/hesai_decoder_ros_wrapper.cpp
@@ -91,7 +91,7 @@ void HesaiDriverRosWrapper::ReceiveScanMsgCallback(
     aw_points_ex_pub_->get_subscription_count() > 0 ||
     aw_points_ex_pub_->get_intra_process_subscription_count() > 0) {
     const auto autoware_ex_cloud =
-      nebula::drivers::convertPointXYZIRCAEDTToPointXYZIRADT(pointcloud);
+      nebula::drivers::convertPointXYZIRCAEDTToPointXYZIRADT(pointcloud, std::get<1>(pointcloud_ts));
     auto ros_pc_msg_ptr = std::make_unique<sensor_msgs::msg::PointCloud2>();
     pcl::toROSMsg(*autoware_ex_cloud, *ros_pc_msg_ptr);
     ros_pc_msg_ptr->header.stamp =

--- a/nebula_ros/src/velodyne/velodyne_decoder_ros_wrapper.cpp
+++ b/nebula_ros/src/velodyne/velodyne_decoder_ros_wrapper.cpp
@@ -74,7 +74,7 @@ void VelodyneDriverRosWrapper::ReceiveScanMsgCallback(
     aw_points_ex_pub_->get_subscription_count() > 0 ||
     aw_points_ex_pub_->get_intra_process_subscription_count() > 0) {
     const auto autoware_ex_cloud =
-      nebula::drivers::convertPointXYZIRCAEDTToPointXYZIRADT(pointcloud);
+      nebula::drivers::convertPointXYZIRCAEDTToPointXYZIRADT(pointcloud, 0.0);//velodyne drivers originally doesn't use absolute time
     auto ros_pc_msg_ptr = std::make_unique<sensor_msgs::msg::PointCloud2>();
     pcl::toROSMsg(*autoware_ex_cloud, *ros_pc_msg_ptr);
     ros_pc_msg_ptr->header.stamp =


### PR DESCRIPTION
## PR Type
- Improvement


## Related Links
https://tier4.atlassian.net/browse/RT1-2587


## Description

Convert to sexagesimal degrees to match autoware specification.
Convert point stamp to absolute time to match autoware specification.

## Review Procedure

Verify the point cloud for Autoware published in `/aw_points_ex`
1. Contains sexagesimal degrees in the `azimuth`
2. Contains absolute time stamp in the `time_stamp` field (only for Hesai).

