### PR TITLE
perf(nebula): optimize AT128 decoder performance

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -21,6 +21,9 @@
     "vccint",
     "adctp",
     "Adctp",
-    
+    "stds",
+    "nproc",
+    "nohup",
+    "schedutil"
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ build/
 install/
 log/
 
+# profiling
+profiling_output/
+
 # Python
 srv/_*.py
 *.pyc

--- a/README.md
+++ b/README.md
@@ -47,26 +47,6 @@ Show results:
 colcon test-result --all
 ```
 
-## How to evaluate performance
-
-You can evaluate Nebula performance on a given rosbag and sensor model using the below tools.
-The profiling runner is most accurate when assigning isolated cores via the `-c <core_id>`.
-CPU frequencies are locked/unlocked automatically by the runner to increase repeatability.
-
-Run profiling for each version you want to compare:
-
-```bash
-./scripts/profiling_runner.bash baseline -m Pandar64 -b ~/my_rosbag -c 2 -t 20 -n 3
-git checkout my_improved_branch
-./scripts/profiling_runner.bash improved -m Pandar64 -b ~/my_rosbag -c 2 -t 20 -n 3
-```
-Show results:
-
-```bash
-pip3 install scripts/requirements.txt  # first-time setup
-python3 scripts/plot_times.py baseline improved
-```
-
 ## Generic launch file
 
 You can easily run the sensor hardware interface, the sensor hardware monitor and sensor driver using (e.g. Pandar64):
@@ -237,3 +217,24 @@ Parameters shared by all supported models:
 ## Software design overview
 
 ![DriverOrganization](docs/diagram.png)
+
+
+## How to evaluate performance
+
+You can evaluate Nebula performance on a given rosbag and sensor model using the below tools.
+The profiling runner is most accurate when assigning isolated cores via the `-c <core_id>`.
+CPU frequencies are locked/unlocked automatically by the runner to increase repeatability.
+
+Run profiling for each version you want to compare:
+
+```bash
+./scripts/profiling_runner.bash baseline -m Pandar64 -b ~/my_rosbag -c 2 -t 20 -n 3
+git checkout my_improved_branch
+./scripts/profiling_runner.bash improved -m Pandar64 -b ~/my_rosbag -c 2 -t 20 -n 3
+```
+Show results:
+
+```bash
+pip3 install scripts/requirements.txt  # first-time setup
+python3 scripts/plot_times.py baseline improved
+```

--- a/README.md
+++ b/README.md
@@ -37,39 +37,59 @@ colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
 
 Run tests:
 
-```
+```bash
 colcon test --event-handlers console_cohesion+ --packages-above nebula_common
 ```
 
 Show results:
 
-```
+```bash
 colcon test-result --all
+```
+
+## How to evaluate performance
+
+You can evaluate Nebula performance on a given rosbag and sensor model using the below tools.
+The profiling runner is most accurate when assigning isolated cores via the `-c <core_id>`.
+CPU frequencies are locked/unlocked automatically by the runner to increase repeatability.
+
+Run profiling for each version you want to compare:
+
+```bash
+./scripts/profiling_runner.bash baseline -m Pandar64 -b ~/my_rosbag -c 2 -t 20 -n 3
+git checkout my_improved_branch
+./scripts/profiling_runner.bash improved -m Pandar64 -b ~/my_rosbag -c 2 -t 20 -n 3
+```
+Show results:
+
+```bash
+pip3 install scripts/requirements.txt  # first-time setup
+python3 scripts/plot_times.py baseline improved
 ```
 
 ## Generic launch file
 
 You can easily run the sensor hardware interface, the sensor hardware monitor and sensor driver using (e.g. Pandar64):
 
-```
+```bash
 ros2 launch nebula_ros nebula_launch.py sensor_model:=Pandar64
 ```
 
 If you don't want to launch the hardware (i.e. when you are working from a rosbag), set the `launch_hw` flag to false:
 
-```
+```bash
 ros2 launch nebula_ros nebula_launch.py sensor_model:=Pandar64 launch_hw:=false
 ```
 
 If you don't want the hardware driver to perform the sensor configuration communication (i.e. limited number of connections) set the `setup_sensor` flag to false:
 
-```
+```bash
 ros2 launch nebula_ros nebula_launch.py sensor_model:=Pandar64 setup_sensor:=false
 ```
 
 You should ideally provide a config file for your specific sensor, but default ones are provided `nebula_drivers/config`:
 
-```
+```bash
 ros2 launch nebula_ros nebula_launch.py sensor_model:=Pandar64 config_file:=your_sensor.yaml
 ```
 

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_at_decoder.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_at_decoder.hpp
@@ -31,6 +31,11 @@ const uint16_t MAX_AZIMUTH_DEGREE_NUM = 36000;
 const uint16_t LIDAR_AZIMUTH_UNIT = 256;
 const uint32_t MAX_AZI_LEN = 36000 * 256;
 
+/// @brief The resolution of one scan (in single return mode)
+const uint16_t SCAN_POINTS_NUM = 1200 * LASER_COUNT;
+/// @brief This sensor supports a maximum of 2 returns (= dual return)
+const uint16_t MAX_RETURN_COUNT = 2;
+
 /// @brief Hesai LiDAR decoder (AT128)
 class PandarATDecoder : public HesaiScanDecoder
 {

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_at_decoder.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_at_decoder.hpp
@@ -79,6 +79,10 @@ private:
   /// @param block_id target block
   /// @return Point cloud
   drivers::NebulaPointCloudPtr convert(size_t block_id) override;
+  /// @brief Convert to point cloud (without temporary buffer)
+  /// @param block_id target block
+  /// @param out_pc Point cloud to append the decoded points to
+  void convert(size_t block_id, NebulaPointCloudPtr & out_pc);
   /// @brief Convert to point cloud for dual return
   /// @param block_id target block
   /// @return Point cloud
@@ -93,13 +97,8 @@ private:
   std::array<float, BLOCKS_PER_PACKET> block_offset_dual_{};
   std::array<float, BLOCKS_PER_PACKET> block_offset_triple_{};
 
-  std::vector<float> m_elevation_rad_map_;
-  std::vector<float> m_sin_elevation_map_;
-  std::vector<float> m_cos_elevation_map_;
-
-  std::vector<float> m_azimuth_rad_map_;
-  std::vector<float> m_sin_azimuth_map_;
-  std::vector<float> m_cos_azimuth_map_;
+  std::vector<float> m_sin_map_;
+  std::vector<float> m_cos_map_;
 
   Packet packet_{};
 

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_at_decoder.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_at_decoder.hpp
@@ -32,7 +32,7 @@ const uint16_t LIDAR_AZIMUTH_UNIT = 256;
 const uint32_t MAX_AZI_LEN = 36000 * 256;
 
 /// @brief The resolution of one scan (in single return mode)
-const uint16_t SCAN_POINTS_NUM = 1200 * LASER_COUNT;
+const uint32_t SCAN_POINTS_NUM = 1200 * LASER_COUNT;
 /// @brief This sensor supports a maximum of 2 returns (= dual return)
 const uint16_t MAX_RETURN_COUNT = 2;
 

--- a/nebula_decoders/src/nebula_decoders_hesai/decoders/pandar_at_decoder.cpp
+++ b/nebula_decoders/src/nebula_decoders_hesai/decoders/pandar_at_decoder.cpp
@@ -32,19 +32,12 @@ PandarATDecoder::PandarATDecoder(
     azimuth_offset_[laser] = calibration_configuration->azimuth_offset_map[laser];
   }
 
-  m_elevation_rad_map_.resize(MAX_AZI_LEN);
-  m_sin_elevation_map_.resize(MAX_AZI_LEN);
-  m_cos_elevation_map_.resize(MAX_AZI_LEN);
-  m_azimuth_rad_map_.resize(MAX_AZI_LEN);
-  m_sin_azimuth_map_.resize(MAX_AZI_LEN);
-  m_cos_azimuth_map_.resize(MAX_AZI_LEN);
+  m_sin_map_.resize(MAX_AZI_LEN);
+  m_cos_map_.resize(MAX_AZI_LEN);
   for (size_t i = 0; i < MAX_AZI_LEN; ++i) {
-    m_elevation_rad_map_[i] = 2.f * i * M_PI / MAX_AZI_LEN;
-    m_sin_elevation_map_[i] = sinf(m_elevation_rad_map_[i]);
-    m_cos_elevation_map_[i] = cosf(m_elevation_rad_map_[i]);
-    m_azimuth_rad_map_[i] = 2.f * i * M_PI / MAX_AZI_LEN;
-    m_sin_azimuth_map_[i] = sinf(m_azimuth_rad_map_[i]);
-    m_cos_azimuth_map_[i] = cosf(m_azimuth_rad_map_[i]);
+    const float rad = 2.f * i * M_PI / MAX_AZI_LEN;
+    m_sin_map_[i] = sinf(rad);
+    m_cos_map_[i] = cosf(rad);
   }
 
   dual_return_distance_threshold_ = sensor_configuration_->dual_return_distance_threshold;
@@ -58,13 +51,15 @@ PandarATDecoder::PandarATDecoder(
 
   scan_pc_.reset(new NebulaPointCloud);
   overflow_pc_.reset(new NebulaPointCloud);
+  scan_pc_->reserve(1200 * 128);
+  overflow_pc_->reserve(1200 * 128);
 }
 
 bool PandarATDecoder::hasScanned() { return has_scanned_; }
 
 std::tuple<drivers::NebulaPointCloudPtr, double> PandarATDecoder::get_pointcloud()
 {
-  return std::make_tuple(scan_pc_, scan_timestamp_);
+  return std::make_tuple(overflow_pc_, scan_timestamp_);
 }
 
 int PandarATDecoder::unpack(const pandar_msgs::msg::PandarPacket & pandar_packet)
@@ -75,8 +70,6 @@ int PandarATDecoder::unpack(const pandar_msgs::msg::PandarPacket & pandar_packet
   }
 
   if (has_scanned_) {
-    scan_pc_ = overflow_pc_;
-    overflow_pc_.reset(new NebulaPointCloud);
     has_scanned_ = false;
   }
 
@@ -96,17 +89,19 @@ int PandarATDecoder::unpack(const pandar_msgs::msg::PandarPacket & pandar_packet
       field = (field + 1) % correction_configuration_->frameNumber;
       count++;
     }
+
+    // The field (= mirror) has changed, meaning the previous scan is complete
     if (last_field_ != field) {
       if (max_azimuth_ < azimuth) {
         max_azimuth_ = azimuth;
       }
       scan_timestamp_ = packet_.unix_second + static_cast<double>(packet_.usec) / 1000000.f;
-      auto block_pc = convert(block_id);
-      *overflow_pc_ += *block_pc;
+      std::swap(scan_pc_, overflow_pc_);
+      scan_pc_->points.clear();
+      convert(block_id, scan_pc_);
       has_scanned_ = true;
     } else {
-      auto block_pc = convert(block_id);
-      *scan_pc_ += *block_pc;
+      convert(block_id, scan_pc_);
     }
     last_azimuth_ = azimuth;
     last_field_ = field;
@@ -171,10 +166,10 @@ void PandarATDecoder::CalcXTPointXYZIT(
     point.distance = unit.distance;
     point.elevation = 2.f * elevation * M_PI / MAX_AZI_LEN;
     {
-      float xyDistance = unit.distance * m_cos_elevation_map_[elevation];
-      point.x = static_cast<float>(xyDistance * m_sin_azimuth_map_[azimuth]);
-      point.y = static_cast<float>(xyDistance * m_cos_azimuth_map_[azimuth]);
-      point.z = static_cast<float>(unit.distance * m_sin_elevation_map_[elevation]);
+      float xyDistance = unit.distance * m_cos_map_[elevation];
+      point.x = xyDistance * m_sin_map_[azimuth];
+      point.y = xyDistance * m_cos_map_[azimuth];
+      point.z = unit.distance * m_sin_map_[elevation];
     }
     if (scan_timestamp_ < 0) {  // invalid timestamp
       scan_timestamp_ = packet_.unix_second + static_cast<double>(packet_.usec) / 1000000.;
@@ -227,17 +222,18 @@ void PandarATDecoder::CalcXTPointXYZIT(
   }
 }
 
+void PandarATDecoder::convert(size_t block_id, NebulaPointCloudPtr & out_pc) {
+  CalcXTPointXYZIT(block_id, static_cast<int>(packet_.header.chLaserNumber), out_pc);
+}
+
 drivers::NebulaPointCloudPtr PandarATDecoder::convert(size_t block_id)
 {
-  NebulaPointCloudPtr block_pc(new NebulaPointCloud);
-  CalcXTPointXYZIT(block_id, static_cast<int>(packet_.header.chLaserNumber), block_pc);
-
-  return block_pc;
+  throw std::runtime_error("Not implemented");
 }
 
 drivers::NebulaPointCloudPtr PandarATDecoder::convert_dual(size_t block_id)
 {
-  return convert(block_id);
+  throw std::runtime_error("Not implemented");
 }
 
 bool PandarATDecoder::parsePacket(const pandar_msgs::msg::PandarPacket & pandar_packet)

--- a/nebula_decoders/src/nebula_decoders_hesai/decoders/pandar_at_decoder.cpp
+++ b/nebula_decoders/src/nebula_decoders_hesai/decoders/pandar_at_decoder.cpp
@@ -50,9 +50,9 @@ PandarATDecoder::PandarATDecoder(
   last_field_ = -1;
 
   scan_pc_.reset(new NebulaPointCloud);
+  scan_pc_->reserve(SCAN_POINTS_NUM * MAX_RETURN_COUNT);
   overflow_pc_.reset(new NebulaPointCloud);
-  scan_pc_->reserve(1200 * 128);
-  overflow_pc_->reserve(1200 * 128);
+  overflow_pc_->reserve(SCAN_POINTS_NUM * MAX_RETURN_COUNT);
 }
 
 bool PandarATDecoder::hasScanned() { return has_scanned_; }

--- a/nebula_ros/include/nebula_ros/hesai/hesai_decoder_ros_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/hesai/hesai_decoder_ros_wrapper.hpp
@@ -13,6 +13,8 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
 
+#include <chrono>
+
 #include "pandar_msgs/msg/pandar_packet.hpp"
 #include "pandar_msgs/msg/pandar_scan.hpp"
 

--- a/nebula_ros/launch/nebula_launch.py
+++ b/nebula_ros/launch/nebula_launch.py
@@ -102,6 +102,10 @@ def launch_setup(context, *args, **kwargs):
         target_container=LaunchConfiguration("container"),
     )
 
+    container_kwargs = {}
+    if LaunchConfiguration("debug_logging").perform(context) == "true":
+        container_kwargs["ros_arguments"] = ['--log-level', 'debug']
+    
     container = ComposableNodeContainer(
         name="nebula_ros_node",
         namespace="",
@@ -110,6 +114,7 @@ def launch_setup(context, *args, **kwargs):
         composable_node_descriptions=nodes,
         output="screen",
         condition=LaunchConfigurationEquals("container", ""),
+        **container_kwargs,
     )
 
     group = GroupAction(
@@ -135,6 +140,7 @@ def generate_launch_description():
             add_launch_arg("return_mode", "Dual"),
             add_launch_arg("launch_hw", "true"),
             add_launch_arg("setup_sensor", "true"),
+            add_launch_arg("debug_logging", "false"),
         ]
         + [OpaqueFunction(function=launch_setup)]
     )

--- a/nebula_ros/src/hesai/hesai_decoder_ros_wrapper.cpp
+++ b/nebula_ros/src/hesai/hesai_decoder_ros_wrapper.cpp
@@ -56,6 +56,8 @@ HesaiDriverRosWrapper::HesaiDriverRosWrapper(const rclcpp::NodeOptions & options
 void HesaiDriverRosWrapper::ReceiveScanMsgCallback(
   const pandar_msgs::msg::PandarScan::SharedPtr scan_msg)
 {
+  auto t_start = std::chrono::high_resolution_clock::now();
+
   std::tuple<nebula::drivers::NebulaPointCloudPtr, double> pointcloud_ts =
     driver_ptr_->ConvertScanToPointcloud(scan_msg);
   nebula::drivers::NebulaPointCloudPtr pointcloud = std::get<0>(pointcloud_ts);
@@ -95,6 +97,9 @@ void HesaiDriverRosWrapper::ReceiveScanMsgCallback(
       rclcpp::Time(SecondsToChronoNanoSeconds(std::get<1>(pointcloud_ts)).count());
     PublishCloud(std::move(ros_pc_msg_ptr), aw_points_ex_pub_);
   }
+
+  auto runtime = std::chrono::high_resolution_clock::now() - t_start;
+  RCLCPP_DEBUG(get_logger(), "PROFILING {'d_total': %lu, 'n_out': %lu}", runtime.count(), pointcloud->size());
 }
 
 void HesaiDriverRosWrapper::PublishCloud(

--- a/nebula_ros/src/hesai/hesai_decoder_ros_wrapper.cpp
+++ b/nebula_ros/src/hesai/hesai_decoder_ros_wrapper.cpp
@@ -56,9 +56,6 @@ HesaiDriverRosWrapper::HesaiDriverRosWrapper(const rclcpp::NodeOptions & options
 void HesaiDriverRosWrapper::ReceiveScanMsgCallback(
   const pandar_msgs::msg::PandarScan::SharedPtr scan_msg)
 {
-  // take packets out of scan msg
-  std::vector<pandar_msgs::msg::PandarPacket> pkt_msgs = scan_msg->packets;
-
   std::tuple<nebula::drivers::NebulaPointCloudPtr, double> pointcloud_ts =
     driver_ptr_->ConvertScanToPointcloud(scan_msg);
   nebula::drivers::NebulaPointCloudPtr pointcloud = std::get<0>(pointcloud_ts);

--- a/scripts/plot_times.py
+++ b/scripts/plot_times.py
@@ -1,0 +1,88 @@
+#%%
+
+import os
+import pandas as pd
+import re
+import glob
+import argparse
+from matplotlib import pyplot as plt
+
+def parse_logs(run_name):
+    dfs = []
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    glob_pattern = os.path.join(script_dir, f"../profiling_output/{run_name}-[0-9].log")
+    for path in glob.glob(glob_pattern):
+        with open(path) as f:
+            lines = f.readlines()
+            lines = filter(lambda line: "PROFILING" in line, lines)
+            lines = [re.sub(r'.*PROFILING (\{.*?\}).*', r'\1', line) for line in lines]
+            records = [eval(line) for line in lines]
+
+        dfs.append(pd.DataFrame(records))
+
+    df = pd.concat(dfs)
+    
+    for col in [c for c in df.columns if c.startswith("d_")]:
+        df[col] /= 1e6  # ns to ms
+    df['d_total'] = sum([df[c] for c in df.columns if c.startswith("d_")]) # type: ignore
+    return df
+
+def plot_timing_comparison(run_names):
+    scenario_dfs = {
+        run_name: parse_logs(run_name) for run_name in run_names
+    }
+
+    n_cols = sum(1 for c in next(iter(scenario_dfs.values())).columns if c.startswith("d_"))
+
+    fig, axs = plt.subplots(1 + n_cols, figsize=(10, 10), num="Timing comparison")
+    ax_d = axs[0]
+    ax_n = ax_d.twinx()
+    ax_n.set_ylabel("# points published")
+    boxes = axs[1:]
+
+    for i, (label, df) in enumerate(scenario_dfs.items()):
+        durations = df['d_total']
+
+        ax_d.plot(durations.index, durations, label=label, linestyle='', marker='.')
+        for col in filter(lambda col: col.startswith("n_"), df.columns):
+            ax_n.plot(df.index, df[col], label=f"{label}::{col}", linestyle='', marker='.', color='black')
+        
+        d_columns = [col for col in df.columns if col.startswith("d_")]
+        n_cols = len(d_columns)
+        for j, col in enumerate(d_columns):
+            if (i == 0):
+                boxes[j].set_ylabel(f"{col} (ms)")
+            boxes[j].boxplot(df[col], positions=[i], labels=[label])
+
+        ax_d.legend(loc="upper right")
+        ax_d.set_ylabel("time (ms)")
+        ax_d.set_xlabel("iteration")
+
+    df_means = pd.DataFrame({
+        label: df.describe().loc["mean"] for label, df in scenario_dfs.items()
+    })
+
+    df_stds = pd.DataFrame({
+        label: df.describe().loc["std"] for label, df in scenario_dfs.items()
+    })
+
+    df_means = df_means.rename(index=lambda label: f"{label} AVG")
+    df_stds = df_stds.rename(index=lambda label: f"{label} STD")
+
+    df_stat = pd.concat([df_means, df_stds], axis=0)
+
+    baseline_name = run_names[0]
+    df_base = df_stat[baseline_name]
+    for label in df_base.index:
+        df_stat.loc[f"{label} % rel to {baseline_name}", :] = df_stat.loc[label, :] / df_base.loc[label] * 100
+
+    print(df_stat.to_markdown())
+    plt.show()
+# %%
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("run_names", nargs='+', help="The names of the runs to plot, as entered in test_runner.bash (e.g. 'baseline', 'optimized')\nAll files of the form <run-name>-[0-9].log will be plotted.")
+    args = parser.parse_args()
+
+    plot_timing_comparison(args.run_names)

--- a/scripts/profiling_runner.bash
+++ b/scripts/profiling_runner.bash
@@ -1,0 +1,151 @@
+#!/usr/bin/bash
+
+# Configuration
+
+print_usage () {
+    # Print optionally passed error message
+    if [ -n "$1" ]
+    then
+        echo "$1"
+    fi
+    echo "Usage: $0 <run_name> [-t|--timeout <timeout>] [-m|--sensor-model <sensor_model>] [-n|--n-runs <n_runs>] [-f|--maxfreq <maxfreq>] [-c|--taskset-cores <core1[,core2,...]>] [-b|--rosbag-path <rosbag_path>]"
+    echo "  -t|--runtime:       runtime for each test run (default: $runtime s)"
+    echo "  -m|--sensor-model:  the model name of the sensor to evaluate Nebula on (e.g. 'Pandar64')"
+    echo "  -n|--n-runs:        number of runs per test (default: $n_runs)"
+    echo "  -f|--maxfreq:       frequency to set all CPU cores to (default: $maxfreq Hz)"
+    echo "  -c|--taskset-cores: cores to run Nebula on. Ideally isolated cores. (default: $taskset_cores)"
+    echo "  -b|--rosbag-path:   path to rosbag file"
+}
+
+# Default parameters
+runtime=20                          # seconds (rosbag runtime is timeout-3s for startup)
+n_runs=3                            # number of runs per test
+maxfreq=2300000                     # 2.3 GHz
+n_cores=$(nproc --all)              # number of cores of the CPU
+taskset_cores=0-$(( $n_cores - 1 )) # cores to run Nebula on
+nebula_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )
+
+if [ $# -lt 1 ]
+then
+    print_usage "No run name specified"
+    exit 1
+fi
+
+run_name=$1
+shift
+
+#do the parsing
+while [[ $# -gt 0 ]]
+do
+    key="$1"
+
+    case $key in
+        -t|--runtime)
+            runtime="$2"
+            shift
+            shift
+            ;;
+        -m|--sensor-model)
+            sensor_model="$2"
+            shift
+            shift
+            ;;
+        -n|--n-runs)
+            n_runs="$2"
+            shift
+            shift
+            ;;
+        -f|--maxfreq)
+            maxfreq="$2"
+            shift
+            shift
+            ;;
+        -c|--taskset-cores)
+            taskset_cores="$2"
+            shift
+            shift
+            ;;
+        -d|--nebula-dir)
+            nebula_dir="$2"
+            shift
+            shift
+            ;;
+        -b|--rosbag-path)
+            rosbag_path="$2"
+            shift
+            shift
+            ;;
+        *)
+            print_usage "Unknown option $1"
+            exit 1
+            ;;
+    esac
+done
+# Enf of configuration
+
+if [ -z "$rosbag_path" ] 
+then
+    print_usage "No --rosbag-path specified"
+    exit 1
+fi
+
+if [ -z "$sensor_model" ] 
+then
+    print_usage "No --sensor-model specified"
+    exit 1
+fi
+
+echo "Nebula home is $nebula_dir"
+output_dir="$nebula_dir/profiling_output"
+mkdir -p "$output_dir"
+echo "Outputting to '$output_dir/$run_name-[1-$n_runs].log'"
+
+cd "$nebula_dir"
+
+lockfreq () {
+    for (( i=0; i<$n_cores; i++ ))
+    do
+        echo userspace | sudo tee /sys/devices/system/cpu/cpufreq/policy$i/scaling_governor > /dev/null
+        echo $maxfreq | sudo tee /sys/devices/system/cpu/cpufreq/policy$i/scaling_setspeed > /dev/null
+        echo -n "CPU $i's frequency is: "
+        sudo cat /sys/devices/system/cpu/cpu$i/cpufreq/cpuinfo_cur_freq
+    done
+
+    sudo sh -c "echo 0 > /sys/devices/system/cpu/cpufreq/boost"
+}
+
+unlockfreq () {
+    for (( i=0; i<$n_cores; i++ ))
+    do
+        echo schedutil | sudo tee /sys/devices/system/cpu/cpufreq/policy$i/scaling_governor > /dev/null
+        echo -n "CPU $i's frequency is: "
+        sudo cat /sys/devices/system/cpu/cpu$i/cpufreq/cpuinfo_cur_freq
+    done
+
+    sudo sh -c "echo 1 > /sys/devices/system/cpu/cpufreq/boost"
+}
+
+echo "Setting up for compiling"
+unlockfreq
+
+colcon build --symlink-install --packages-up-to nebula_ros --cmake-args -DCMAKE_BUILD_TYPE=Release || exit 1
+source "$nebula_dir/install/setup.bash"
+
+ros2 daemon stop
+ros2 daemon start
+
+echo "Setting up for test run"
+lockfreq
+
+for (( i=1; i<=$n_runs; i++ ))
+do
+    echo "Running iteration $i of $n_runs"
+    # set the log level to debug for all ros 2 nodes
+
+    timeout -s INT $runtime taskset -c "$taskset_cores" ros2 launch nebula_ros nebula_launch.py "sensor_model:=$sensor_model" launch_hw:=false debug_logging:=true > "$output_dir/$run_name-$i.log" 2>&1 &
+    (sleep 3 && timeout -s KILL $(( $runtime - 3 )) nohup ros2 bag play -l "$rosbag_path") > /dev/null &
+    wait
+done
+
+echo "Unlocking frequency"
+unlockfreq

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,3 @@
+pandas
+tabulate
+matplotlib


### PR DESCRIPTION
## PR Type

- Improvement

## Related Links

--

## Description

This PR improves performance of the Hesai AT128 decoder by approx. 23% without changing the logical output.
To achieve this, three changes have been made:
* Decoding points directly to `scan_pc_` and `overflow_pc_` instead of temporary buffers and re-using the buffers (~ 11%point improvement)
* Removing unused copy operation for incoming scan packets (~ 9%point improvement)
* Combining azimuth and elevation sin/cos lookup tables as they were exact duplicates (~ 4%point improvement)

Points were decoded in `convert(block_id)` to a temporary PointCloud, the contents of which were then copied to `scan_pc_` or `overflow_pc_` respectively. This caused avoidable latency. Now, depending on whether the current block being decoded is in a new frame/scan or not, `convert(block_id, pcl)` decodes those points directly into the right buffer.

Further, `overflow_pc_` was reallocated on each full scan, causing avoidable heap allocations.
Because each incoming `PandarScan` message always contains a full scan (albeit not necessarily aligned to our phase setting), `scan_decoder->get_pointcloud()` will be called exactly once in `ConvertScanToPointCloud`. Thus, it is guaranteed that one of `scan_pc_` and `overflow_pc_` can always be used for decoding, and the other as the output buffer.
Once a scan is complete, the buffers are swapped and the `overflow_pc_` is `clear`ed (not reallocated).

No changes have been made to the base class, the new function is an overloaded version of the existing one (which has been changed to throw a "not implemented" error).

![f7249549-193f-4193-a43a-ef47260f2416](https://github.com/tier4/nebula/assets/6088931/0bf4cdb1-5a3a-4d75-9e75-017a8412c6b7)

|                     |Before|Optimized|
|-----------------|---------|--------------|
|duration AVG        |7.972725 ms      |6.147384 ms|
|duration STD         |0.759695       |0.613904|
|duration AVG % rel. to before        |100.000000      | **77.105188** |
|duration STD % rel. to before    |100.000000      |80.809372|

All measurements have been made on an Intel Core i7-12700H with
* TurboBoost disabled
* All cores set to 2.3 GHz
* Thread pair 2/3 isolated
* Nebula `taskset` to core 2

Measurements were repeated 3 times and ran for 37s each (~370 iterations).

## Review Procedure

To confirm logical equality with the previous implementation, a rosbag of recorded AT128 packets can be used.
To confirm performance improvement, I provide the scripts and logging that yielded the above charts:
```
scripts/
    test_runner.bash  # runs the driver for 3 iterations on a given rosbag
    plot_times.py     # takes the logs from test_runner.bash and creates a plot like the one above
```
The test runner locks/unlocks core frequencies and `taskset`s nebula onto the specified core(s). Ideally, the taskset cores are isolated (cf. [Autoware performance measurement guide](https://autowarefoundation.github.io/autoware-documentation/main/how-to-guides/integrating-autoware/tuning-parameters-and-performance/evaluating-real-time-performance/#prepare-separated-cores))

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

*PR Author should check the checkboxes below when creating the PR.*
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

*Reviewers should check the checkboxes below before approval.*
- [x] Commits are properly organized and messages are according to the guideline
- [x] (Optional) Unit tests have been written for new behavior
- [x] PR title describes the changes

## Post-Review Checklist for the PR Author

*PR Author should check the checkboxes below before merging.*
- [x] All open points are addressed and tracked via issues or tickets

## CI Checks

- *Build and test for PR*: Required to pass before the merge.