### PR TITLE
fix(nebula_ros): limit cloud_max_angle param to 359 #44

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,8 +200,8 @@ Parameters shared by all supported models:
 | gnss_port       | uint16 | 2369            |                   | GNSS port       |
 | frequency_ms    | uint16 | 100             | milliseconds, > 0 | Time per scan   |
 | packet_mtu_size | uint16 | 1500            |                   | Packet MTU size |
-| cloud_min_angle | uint16 | 0               | degrees [0, 360]  | FoV start angle |
-| cloud_max_angle | uint16 | 359             | degrees [0, 360]  | FoV end angle   |
+| cloud_min_angle | uint16 | 0               | degrees [0, 360)  | FoV start angle |
+| cloud_max_angle | uint16 | 359             | degrees [0, 360)  | FoV end angle   |
 
 #### Driver parameters
 
@@ -211,8 +211,8 @@ Parameters shared by all supported models:
 | calibration_file | string |          |                      | LiDAR calibration file                  |
 | min_range        | double | 0.3      | meters, >= 0.3       | Minimum point range published           |
 | max_range        | double | 300.0    | meters, <= 300.0     | Maximum point range published           |
-| cloud_min_angle  | uint16 | 0        | degrees [0, 360]     | FoV start angle                         |
-| cloud_max_angle  | uint16 | 359      | degrees [0, 360]     | FoV end angle                           |
+| cloud_min_angle  | uint16 | 0        | degrees [0, 360)     | FoV start angle                         |
+| cloud_max_angle  | uint16 | 359      | degrees [0, 360)     | FoV end angle                           |
 
 ## Software design overview
 

--- a/nebula_ros/launch/velodyne_launch_all_hw.xml
+++ b/nebula_ros/launch/velodyne_launch_all_hw.xml
@@ -14,7 +14,7 @@
     <arg name="packet_mtu_size" default="1500" description="Packet MTU size"/>
     <arg name="rotation_speed" default="600" description="Motor RPM, the sensor's internal spin rate."/>
     <arg name="cloud_min_angle" default="0" description="Field of View, start degrees."/>
-    <arg name="cloud_max_angle" default="360" description="Field of View, end degrees."/>
+    <arg name="cloud_max_angle" default="359" description="Field of View, end degrees."/>
     <arg name="diag_span" default="1000" description="milliseconds"/>
 
     <arg name="setup_sensor" default="True" description="Enable sensor setup on hw-driver."/>

--- a/nebula_ros/src/velodyne/velodyne_decoder_ros_wrapper.cpp
+++ b/nebula_ros/src/velodyne/velodyne_decoder_ros_wrapper.cpp
@@ -214,7 +214,7 @@ Status VelodyneDriverRosWrapper::GetParameters(
       descriptor.dynamic_typing = false;
       descriptor.additional_constraints = "";
       rcl_interfaces::msg::IntegerRange range;
-      range.set__from_value(0).set__to_value(360).set__step(1);
+      range.set__from_value(0).set__to_value(359).set__step(1);
       descriptor.integer_range = {range};
       this->declare_parameter<uint16_t>("cloud_min_angle", 0, descriptor);
       sensor_configuration.cloud_min_angle = this->get_parameter("cloud_min_angle").as_int();
@@ -226,9 +226,9 @@ Status VelodyneDriverRosWrapper::GetParameters(
       descriptor.dynamic_typing = false;
       descriptor.additional_constraints = "";
       rcl_interfaces::msg::IntegerRange range;
-      range.set__from_value(0).set__to_value(360).set__step(1);
+      range.set__from_value(0).set__to_value(359).set__step(1);
       descriptor.integer_range = {range};
-      this->declare_parameter<uint16_t>("cloud_max_angle", 360, descriptor);
+      this->declare_parameter<uint16_t>("cloud_max_angle", 359, descriptor);
       sensor_configuration.cloud_max_angle = this->get_parameter("cloud_max_angle").as_int();
     }
   } else {

--- a/nebula_ros/src/velodyne/velodyne_hw_interface_ros_wrapper.cpp
+++ b/nebula_ros/src/velodyne/velodyne_hw_interface_ros_wrapper.cpp
@@ -180,7 +180,7 @@ Status VelodyneHwInterfaceRosWrapper::GetParameters(
     descriptor.dynamic_typing = false;
     descriptor.additional_constraints = "";
     rcl_interfaces::msg::IntegerRange range;
-    range.set__from_value(0).set__to_value(360).set__step(1);
+    range.set__from_value(0).set__to_value(359).set__step(1);
     descriptor.integer_range = {range};
     this->declare_parameter<uint16_t>("cloud_min_angle", 0, descriptor);
     sensor_configuration.cloud_min_angle = this->get_parameter("cloud_min_angle").as_int();
@@ -192,9 +192,9 @@ Status VelodyneHwInterfaceRosWrapper::GetParameters(
     descriptor.dynamic_typing = false;
     descriptor.additional_constraints = "";
     rcl_interfaces::msg::IntegerRange range;
-    range.set__from_value(0).set__to_value(360).set__step(1);
+    range.set__from_value(0).set__to_value(359).set__step(1);
     descriptor.integer_range = {range};
-    this->declare_parameter<uint16_t>("cloud_max_angle", 360, descriptor);
+    this->declare_parameter<uint16_t>("cloud_max_angle", 359, descriptor);
     sensor_configuration.cloud_max_angle = this->get_parameter("cloud_max_angle").as_int();
   }
 


### PR DESCRIPTION
## PR Type

- Bug Fix

## Related Links

The issue: https://github.com/tier4/nebula/issues/44

## Description

This PR changes default `cloud_max_angle` to 359 and also limits `cloud_min_angle` and `cloud_max_angle` to 359. By doing those, it fixes https://github.com/tier4/nebula/issues/44 .

## Review Procedure

Range of the parameters, default values of them and readme can be checked.

## Remarks

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
