### PR TITLE
perf: unpack velodyne packets in parallel

### DIFF
--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/decoders/parallel_unpack.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/decoders/parallel_unpack.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "nebula_common/point_types.hpp"
+
+#include <vector>
+
+namespace nebula
+{
+
+namespace drivers
+{
+class ParallelUnpack
+{
+protected:
+  std::vector<drivers::NebulaPointCloud> packet_clouds_;
+
+public:
+  void reset_packet_clouds(const size_t & n_packets, const int & n_pts_per_packet)
+  {
+    packet_clouds_.clear();
+    packet_clouds_.resize(n_packets);
+    for (auto & packet_cloud : packet_clouds_) {
+      packet_cloud.points.reserve(n_pts_per_packet);
+    }
+  }
+
+  void append_point(const drivers::NebulaPoint & point, const size_t & packet_idx)
+  {
+    packet_clouds_[packet_idx].points.push_back(point);
+  }
+};
+}  // namespace drivers
+
+}  // namespace nebula

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/decoders/velodyne_scan_decoder.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/decoders/velodyne_scan_decoder.hpp
@@ -167,7 +167,8 @@ public:
 
   /// @brief Virtual function for parsing and shaping VelodynePacket
   /// @param pandar_packet
-  virtual void unpack(const velodyne_msgs::msg::VelodynePacket & velodyne_packet) = 0;
+  virtual void unpack(
+    const velodyne_msgs::msg::VelodynePacket & velodyne_packet, const size_t & packet_index) = 0;
   /// @brief Virtual function for parsing VelodynePacket based on packet structure
   /// @param pandar_packet
   /// @return Resulting flag

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/decoders/vlp16_decoder.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/decoders/vlp16_decoder.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "nebula_decoders/nebula_decoders_velodyne/decoders/parallel_unpack.hpp"
 #include "nebula_decoders/nebula_decoders_velodyne/decoders/velodyne_scan_decoder.hpp"
 
 #include "velodyne_msgs/msg/velodyne_packet.hpp"
@@ -13,9 +14,9 @@ namespace drivers
 {
 namespace vlp16
 {
-  constexpr uint32_t MAX_POINTS = 300000;
+constexpr uint32_t MAX_POINTS = 300000;
 /// @brief Velodyne LiDAR decoder (VLP16)
-class Vlp16Decoder : public VelodyneScanDecoder
+class Vlp16Decoder : public VelodyneScanDecoder, public ParallelUnpack
 {
 public:
   /// @brief Constructor
@@ -26,7 +27,9 @@ public:
     const std::shared_ptr<drivers::VelodyneCalibrationConfiguration> & calibration_configuration);
   /// @brief Parsing and shaping VelodynePacket
   /// @param velodyne_packet
-  void unpack(const velodyne_msgs::msg::VelodynePacket & velodyne_packet) override;
+  void unpack(
+    const velodyne_msgs::msg::VelodynePacket & velodyne_packet,
+    const size_t & packet_index) override;
   /// @brief Get the flag indicating whether one cycle is ready
   /// @return Readied
   bool hasScanned() override;

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/decoders/vlp16_decoder.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/decoders/vlp16_decoder.hpp
@@ -14,7 +14,7 @@ namespace drivers
 {
 namespace vlp16
 {
-constexpr uint32_t MAX_POINTS = 300000;
+  constexpr uint32_t MAX_POINTS = 300000;
 /// @brief Velodyne LiDAR decoder (VLP16)
 class Vlp16Decoder : public VelodyneScanDecoder, public ParallelUnpack
 {

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/decoders/vlp32_decoder.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/decoders/vlp32_decoder.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "nebula_decoders/nebula_decoders_velodyne/decoders/parallel_unpack.hpp"
 #include "nebula_decoders/nebula_decoders_velodyne/decoders/velodyne_scan_decoder.hpp"
 
 #include "velodyne_msgs/msg/velodyne_packet.hpp"
@@ -14,7 +15,7 @@ namespace drivers
 namespace vlp32
 {
 /// @brief Velodyne LiDAR decoder (VLP32)
-class Vlp32Decoder : public VelodyneScanDecoder
+class Vlp32Decoder : public VelodyneScanDecoder, public ParallelUnpack
 {
 public:
   /// @brief Constructor
@@ -25,7 +26,9 @@ public:
     const std::shared_ptr<drivers::VelodyneCalibrationConfiguration> & calibration_configuration);
   /// @brief Parsing and shaping VelodynePacket
   /// @param velodyne_packet
-  void unpack(const velodyne_msgs::msg::VelodynePacket & velodyne_packet) override;
+  void unpack(
+    const velodyne_msgs::msg::VelodynePacket & velodyne_packet,
+    const size_t & packet_index) override;
   /// @brief Get the flag indicating whether one cycle is ready
   /// @return Readied
   bool hasScanned() override;

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/decoders/vls128_decoder.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/decoders/vls128_decoder.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "nebula_decoders/nebula_decoders_velodyne/decoders/velodyne_scan_decoder.hpp"
+#include "nebula_decoders/nebula_decoders_velodyne/decoders/parallel_unpack.hpp"
 
 #include "velodyne_msgs/msg/velodyne_packet.hpp"
 #include "velodyne_msgs/msg/velodyne_scan.hpp"
@@ -14,7 +15,7 @@ namespace drivers
 namespace vls128
 {
 /// @brief Velodyne LiDAR decoder (VLS128)
-class Vls128Decoder : public VelodyneScanDecoder
+class Vls128Decoder : public VelodyneScanDecoder, public ParallelUnpack
 {
 public:
   /// @brief Constructor
@@ -25,7 +26,9 @@ public:
     const std::shared_ptr<drivers::VelodyneCalibrationConfiguration> & calibration_configuration);
   /// @brief Parsing and shaping VelodynePacket
   /// @param velodyne_packet
-  void unpack(const velodyne_msgs::msg::VelodynePacket & velodyne_packet) override;
+  void unpack(
+    const velodyne_msgs::msg::VelodynePacket & velodyne_packet,
+    const size_t & packet_index) override;
   /// @brief Get the flag indicating whether one cycle is ready
   /// @return Readied
   bool hasScanned() override;

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/velodyne_driver.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/velodyne_driver.hpp
@@ -8,11 +8,15 @@
 #include "nebula_decoders/nebula_decoders_common/nebula_driver_base.hpp"
 #include "nebula_decoders/nebula_decoders_velodyne/decoders/velodyne_scan_decoder.hpp"
 
+#include <range/v3/view/enumerate.hpp>
+
 #include "velodyne_msgs/msg/velodyne_packet.hpp"
 #include "velodyne_msgs/msg/velodyne_scan.hpp"
 
 #include <pcl_conversions/pcl_conversions.h>
 
+#include <algorithm>
+#include <execution>
 #include <iostream>
 #include <stdexcept>
 #include <string>

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/velodyne_driver.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/velodyne_driver.hpp
@@ -8,8 +8,6 @@
 #include "nebula_decoders/nebula_decoders_common/nebula_driver_base.hpp"
 #include "nebula_decoders/nebula_decoders_velodyne/decoders/velodyne_scan_decoder.hpp"
 
-#include <range/v3/view/enumerate.hpp>
-
 #include "velodyne_msgs/msg/velodyne_packet.hpp"
 #include "velodyne_msgs/msg/velodyne_scan.hpp"
 

--- a/nebula_decoders/src/nebula_decoders_velodyne/decoders/vlp16_decoder.cpp
+++ b/nebula_decoders/src/nebula_decoders_velodyne/decoders/vlp16_decoder.cpp
@@ -30,34 +30,31 @@ Vlp16Decoder::Vlp16Decoder(
   }
   // timing table calculation, from velodyne user manual p.64
   timing_offsets_.resize(BLOCKS_PER_PACKET);
-  for (size_t i = 0; i < timing_offsets_.size(); ++i) {
+  for (size_t i=0; i < timing_offsets_.size(); ++i){
     timing_offsets_[i].resize(32);
   }
   double full_firing_cycle_s = 55.296 * 1e-6;
   double single_firing_s = 2.304 * 1e-6;
   double data_block_index, data_point_index;
-  bool dual_mode = sensor_configuration_->return_mode == ReturnMode::DUAL;
+  bool dual_mode = sensor_configuration_->return_mode==ReturnMode::DUAL;
   // compute timing offsets
-  for (size_t x = 0; x < timing_offsets_.size(); ++x) {
-    for (size_t y = 0; y < timing_offsets_[x].size(); ++y) {
-      if (dual_mode) {
+  for (size_t x = 0; x < timing_offsets_.size(); ++x){
+    for (size_t y = 0; y < timing_offsets_[x].size(); ++y){
+      if (dual_mode){
         data_block_index = (x - (x % 2)) + (y / 16);
-      } else {
+      }
+      else{
         data_block_index = (x * 2) + (y / 16);
       }
       data_point_index = y % 16;
-      timing_offsets_[x][y] =
-        (full_firing_cycle_s * data_block_index) + (single_firing_s * data_point_index);
+      timing_offsets_[x][y] = (full_firing_cycle_s * data_block_index) + (single_firing_s * data_point_index);
     }
   }
 
   phase_ = (uint16_t)round(sensor_configuration_->scan_phase * 100);
 }
 
-bool Vlp16Decoder::hasScanned()
-{
-  return has_scanned_;
-}
+bool Vlp16Decoder::hasScanned() { return has_scanned_; }
 
 std::tuple<drivers::NebulaPointCloudPtr, double> Vlp16Decoder::get_pointcloud()
 {
@@ -68,14 +65,12 @@ std::tuple<drivers::NebulaPointCloudPtr, double> Vlp16Decoder::get_pointcloud()
   double phase = angles::from_degrees(sensor_configuration_->scan_phase);
   if (!scan_pc_->points.empty()) {
     auto current_azimuth = scan_pc_->points.back().azimuth;
-    auto phase_diff =
-      static_cast<size_t>(angles::to_degrees(2 * M_PI + current_azimuth - phase)) % 360;
+    auto phase_diff = static_cast<size_t>(angles::to_degrees(2*M_PI + current_azimuth - phase)) % 360;
     while (phase_diff < M_PI_2 && !scan_pc_->points.empty()) {
       overflow_pc_->points.push_back(scan_pc_->points.back());
       scan_pc_->points.pop_back();
       current_azimuth = scan_pc_->points.back().azimuth;
-      phase_diff =
-        static_cast<size_t>(angles::to_degrees(2 * M_PI + current_azimuth - phase)) % 360;
+      phase_diff = static_cast<size_t>(angles::to_degrees(2*M_PI + current_azimuth - phase)) % 360;
     }
     overflow_pc_->width = overflow_pc_->points.size();
     scan_pc_->width = scan_pc_->points.size();
@@ -237,7 +232,7 @@ void Vlp16Decoder::unpack(
                 const float z_coord = distance * sin_vert_angle;       // velodyne z
                 const uint8_t intensity = current_block.data[k + 2];
 
-                double point_time_offset = timing_offsets_[block][firing * 16 + dsr];
+                double point_time_offset =  timing_offsets_[block][firing * 16 + dsr];
 
                 // Determine return type.
                 uint8_t return_type;
@@ -249,10 +244,9 @@ void Vlp16Decoder::unpack(
                        other_return.bytes[1] == current_return.bytes[1])) {
                       return_type = static_cast<uint8_t>(drivers::ReturnType::IDENTICAL);
                     } else {
-                      const uint8_t other_intensity = block % 2
-                                                        ? raw->blocks[block - 1].data[k + 2]
-                                                        : raw->blocks[block + 1].data[k + 2];
-                      bool first = current_return.uint > other_return.uint;
+                      const uint8_t other_intensity = block % 2 ? raw->blocks[block - 1].data[k + 2]
+                                                              : raw->blocks[block + 1].data[k + 2];
+                      bool first = current_return.uint > other_return.uint ;
                       bool strongest = intensity > other_intensity;
                       if (other_intensity == intensity) {
                         strongest = !first;
@@ -288,8 +282,9 @@ void Vlp16Decoder::unpack(
                 current_point.azimuth = rotation_radians_[azimuth_corrected];
                 current_point.elevation = sin_vert_angle;
                 auto point_ts = block_timestamp - scan_timestamp_ + point_time_offset;
-                if (point_ts < 0) point_ts = 0;
-                current_point.time_stamp = static_cast<uint32_t>(point_ts * 1e9);
+                if (point_ts < 0)
+                  point_ts = 0;
+                current_point.time_stamp = static_cast<uint32_t>(point_ts*1e9);
                 current_point.intensity = intensity;
                 current_point.distance = distance;
 

--- a/nebula_decoders/src/nebula_decoders_velodyne/decoders/vlp32_decoder.cpp
+++ b/nebula_decoders/src/nebula_decoders_velodyne/decoders/vlp32_decoder.cpp
@@ -31,33 +31,30 @@ Vlp32Decoder::Vlp32Decoder(
   phase_ = (uint16_t)round(sensor_configuration_->scan_phase * 100);
 
   timing_offsets_.resize(12);
-  for (size_t i = 0; i < timing_offsets_.size(); ++i) {
+  for (size_t i=0; i < timing_offsets_.size(); ++i){
     timing_offsets_[i].resize(32);
   }
   // constants
-  double full_firing_cycle = 55.296 * 1e-6;  // seconds
-  double single_firing = 2.304 * 1e-6;       // seconds
+  double full_firing_cycle = 55.296 * 1e-6; // seconds
+  double single_firing = 2.304 * 1e-6; // seconds
   double dataBlockIndex, dataPointIndex;
   bool dual_mode = sensor_configuration_->return_mode == ReturnMode::DUAL;
   // compute timing offsets
-  for (size_t x = 0; x < timing_offsets_.size(); ++x) {
-    for (size_t y = 0; y < timing_offsets_[x].size(); ++y) {
-      if (dual_mode) {
+  for (size_t x = 0; x < timing_offsets_.size(); ++x){
+    for (size_t y = 0; y < timing_offsets_[x].size(); ++y){
+      if (dual_mode){
         dataBlockIndex = x / 2;
-      } else {
+      }
+      else{
         dataBlockIndex = x;
       }
       dataPointIndex = y / 2;
-      timing_offsets_[x][y] =
-        (full_firing_cycle * dataBlockIndex) + (single_firing * dataPointIndex);
+      timing_offsets_[x][y] = (full_firing_cycle * dataBlockIndex) + (single_firing * dataPointIndex);
     }
   }
 }
 
-bool Vlp32Decoder::hasScanned()
-{
-  return has_scanned_;
-}
+bool Vlp32Decoder::hasScanned() { return has_scanned_; }
 
 std::tuple<drivers::NebulaPointCloudPtr, double> Vlp32Decoder::get_pointcloud()
 {
@@ -68,12 +65,12 @@ std::tuple<drivers::NebulaPointCloudPtr, double> Vlp32Decoder::get_pointcloud()
   double phase = angles::from_degrees(sensor_configuration_->scan_phase);
   if (!scan_pc_->points.empty()) {
     auto current_azimuth = scan_pc_->points.back().azimuth;
-    auto phase_diff = (2 * M_PI + current_azimuth - phase);
+    auto phase_diff = (2*M_PI + current_azimuth - phase);
     while (phase_diff < M_PI_2 && !scan_pc_->points.empty()) {
       overflow_pc_->points.push_back(scan_pc_->points.back());
       scan_pc_->points.pop_back();
       current_azimuth = scan_pc_->points.back().azimuth;
-      phase_diff = (2 * M_PI + current_azimuth - phase);
+      phase_diff = (2*M_PI + current_azimuth - phase);
     }
     overflow_pc_->width = overflow_pc_->points.size();
     scan_pc_->width = scan_pc_->points.size();
@@ -82,10 +79,7 @@ std::tuple<drivers::NebulaPointCloudPtr, double> Vlp32Decoder::get_pointcloud()
   return std::make_tuple(scan_pc_, scan_timestamp_);
 }
 
-int Vlp32Decoder::pointsPerPacket()
-{
-  return BLOCKS_PER_PACKET * SCANS_PER_BLOCK;
-}
+int Vlp32Decoder::pointsPerPacket() { return BLOCKS_PER_PACKET * SCANS_PER_BLOCK; }
 
 void Vlp32Decoder::reset_pointcloud(size_t n_pts)
 {
@@ -315,8 +309,9 @@ void Vlp32Decoder::unpack(
           current_point.azimuth = rotation_radians_[block.rotation];
           current_point.elevation = sin_vert_angle;
           auto point_ts = block_timestamp - scan_timestamp_ + point_time_offset;
-          if (point_ts < 0) point_ts = 0;
-          current_point.time_stamp = static_cast<uint32_t>(point_ts * 1e9);
+          if (point_ts < 0)
+            point_ts = 0;
+          current_point.time_stamp = static_cast<uint32_t>(point_ts*1e9);
           current_point.distance = distance;
           current_point.intensity = intensity;
 

--- a/nebula_decoders/src/nebula_decoders_velodyne/decoders/vlp32_decoder.cpp
+++ b/nebula_decoders/src/nebula_decoders_velodyne/decoders/vlp32_decoder.cpp
@@ -31,42 +31,49 @@ Vlp32Decoder::Vlp32Decoder(
   phase_ = (uint16_t)round(sensor_configuration_->scan_phase * 100);
 
   timing_offsets_.resize(12);
-  for (size_t i=0; i < timing_offsets_.size(); ++i){
+  for (size_t i = 0; i < timing_offsets_.size(); ++i) {
     timing_offsets_[i].resize(32);
   }
   // constants
-  double full_firing_cycle = 55.296 * 1e-6; // seconds
-  double single_firing = 2.304 * 1e-6; // seconds
+  double full_firing_cycle = 55.296 * 1e-6;  // seconds
+  double single_firing = 2.304 * 1e-6;       // seconds
   double dataBlockIndex, dataPointIndex;
   bool dual_mode = sensor_configuration_->return_mode == ReturnMode::DUAL;
   // compute timing offsets
-  for (size_t x = 0; x < timing_offsets_.size(); ++x){
-    for (size_t y = 0; y < timing_offsets_[x].size(); ++y){
-      if (dual_mode){
+  for (size_t x = 0; x < timing_offsets_.size(); ++x) {
+    for (size_t y = 0; y < timing_offsets_[x].size(); ++y) {
+      if (dual_mode) {
         dataBlockIndex = x / 2;
-      }
-      else{
+      } else {
         dataBlockIndex = x;
       }
       dataPointIndex = y / 2;
-      timing_offsets_[x][y] = (full_firing_cycle * dataBlockIndex) + (single_firing * dataPointIndex);
+      timing_offsets_[x][y] =
+        (full_firing_cycle * dataBlockIndex) + (single_firing * dataPointIndex);
     }
   }
 }
 
-bool Vlp32Decoder::hasScanned() { return has_scanned_; }
+bool Vlp32Decoder::hasScanned()
+{
+  return has_scanned_;
+}
 
 std::tuple<drivers::NebulaPointCloudPtr, double> Vlp32Decoder::get_pointcloud()
 {
+  for (const auto & cloud : packet_clouds_) {
+    *scan_pc_ += cloud;
+  }
+
   double phase = angles::from_degrees(sensor_configuration_->scan_phase);
   if (!scan_pc_->points.empty()) {
     auto current_azimuth = scan_pc_->points.back().azimuth;
-    auto phase_diff = (2*M_PI + current_azimuth - phase);
+    auto phase_diff = (2 * M_PI + current_azimuth - phase);
     while (phase_diff < M_PI_2 && !scan_pc_->points.empty()) {
       overflow_pc_->points.push_back(scan_pc_->points.back());
       scan_pc_->points.pop_back();
       current_azimuth = scan_pc_->points.back().azimuth;
-      phase_diff = (2*M_PI + current_azimuth - phase);
+      phase_diff = (2 * M_PI + current_azimuth - phase);
     }
     overflow_pc_->width = overflow_pc_->points.size();
     scan_pc_->width = scan_pc_->points.size();
@@ -75,7 +82,10 @@ std::tuple<drivers::NebulaPointCloudPtr, double> Vlp32Decoder::get_pointcloud()
   return std::make_tuple(scan_pc_, scan_timestamp_);
 }
 
-int Vlp32Decoder::pointsPerPacket() { return BLOCKS_PER_PACKET * SCANS_PER_BLOCK; }
+int Vlp32Decoder::pointsPerPacket()
+{
+  return BLOCKS_PER_PACKET * SCANS_PER_BLOCK;
+}
 
 void Vlp32Decoder::reset_pointcloud(size_t n_pts)
 {
@@ -85,6 +95,8 @@ void Vlp32Decoder::reset_pointcloud(size_t n_pts)
   scan_pc_->points.reserve(max_pts_);
   reset_overflow();  // transfer existing overflow points to the cleared pointcloud
   scan_timestamp_ = -1;
+
+  reset_packet_clouds(n_pts, pointsPerPacket());
 }
 
 void Vlp32Decoder::reset_overflow()
@@ -97,7 +109,8 @@ void Vlp32Decoder::reset_overflow()
   overflow_pc_->points.reserve(max_pts_);
 }
 
-void Vlp32Decoder::unpack(const velodyne_msgs::msg::VelodynePacket & velodyne_packet)
+void Vlp32Decoder::unpack(
+  const velodyne_msgs::msg::VelodynePacket & velodyne_packet, const size_t & packet_index)
 {
   const raw_packet_t * raw = (const raw_packet_t *)&velodyne_packet.data[0];
   uint8_t return_mode = velodyne_packet.data[RETURN_MODE_INDEX];
@@ -302,12 +315,12 @@ void Vlp32Decoder::unpack(const velodyne_msgs::msg::VelodynePacket & velodyne_pa
           current_point.azimuth = rotation_radians_[block.rotation];
           current_point.elevation = sin_vert_angle;
           auto point_ts = block_timestamp - scan_timestamp_ + point_time_offset;
-          if (point_ts < 0)
-            point_ts = 0;
-          current_point.time_stamp = static_cast<uint32_t>(point_ts*1e9);
+          if (point_ts < 0) point_ts = 0;
+          current_point.time_stamp = static_cast<uint32_t>(point_ts * 1e9);
           current_point.distance = distance;
           current_point.intensity = intensity;
-          scan_pc_->points.emplace_back(current_point);
+
+          append_point(current_point, packet_index);
         }
       }
     }

--- a/nebula_decoders/src/nebula_decoders_velodyne/decoders/vls128_decoder.cpp
+++ b/nebula_decoders/src/nebula_decoders_velodyne/decoders/vls128_decoder.cpp
@@ -36,28 +36,25 @@ Vls128Decoder::Vls128Decoder(
   }
   // timing table calculation, from velodyne user manual p.64
   timing_offsets_.resize(3);
-  for (size_t i = 0; i < timing_offsets_.size(); ++i) {
-    timing_offsets_[i].resize(17);  // 17 (+1 for the maintenance time after firing group 8)
+  for (size_t i=0; i < timing_offsets_.size(); ++i)
+  {
+    timing_offsets_[i].resize(17); // 17 (+1 for the maintenance time after firing group 8)
   }
   double full_firing_cycle_s = 53.3 * 1e-6;
   double single_firing_s = 2.665 * 1e-6;
   double offset_packet_time = 8.7 * 1e-6;
   // compute timing offsets
-  for (size_t x = 0; x < timing_offsets_.size(); ++x) {
-    for (size_t y = 0; y < timing_offsets_[x].size(); ++y) {
+  for (size_t x = 0; x < timing_offsets_.size(); ++x){
+    for (size_t y = 0; y < timing_offsets_[x].size(); ++y){
       double sequence_index, firing_group_index;
       sequence_index = x;
       firing_group_index = y;
-      timing_offsets_[x][y] = (full_firing_cycle_s * sequence_index) +
-                              (single_firing_s * firing_group_index) - offset_packet_time;
+      timing_offsets_[x][y] = (full_firing_cycle_s * sequence_index) + (single_firing_s * firing_group_index) - offset_packet_time;
     }
   }
 }
 
-bool Vls128Decoder::hasScanned()
-{
-  return has_scanned_;
-}
+bool Vls128Decoder::hasScanned() { return has_scanned_; }
 
 std::tuple<drivers::NebulaPointCloudPtr, double> Vls128Decoder::get_pointcloud()
 {
@@ -68,14 +65,12 @@ std::tuple<drivers::NebulaPointCloudPtr, double> Vls128Decoder::get_pointcloud()
   double phase = angles::from_degrees(sensor_configuration_->scan_phase);
   if (!scan_pc_->points.empty()) {
     auto current_azimuth = scan_pc_->points.back().azimuth;
-    auto phase_diff =
-      static_cast<size_t>(angles::to_degrees(2 * M_PI + current_azimuth - phase)) % 360;
+    auto phase_diff = static_cast<size_t>(angles::to_degrees(2*M_PI + current_azimuth - phase)) % 360;
     while (phase_diff < M_PI_2 && !scan_pc_->points.empty()) {
       overflow_pc_->points.push_back(scan_pc_->points.back());
       scan_pc_->points.pop_back();
       current_azimuth = scan_pc_->points.back().azimuth;
-      phase_diff =
-        static_cast<size_t>(angles::to_degrees(2 * M_PI + current_azimuth - phase)) % 360;
+      phase_diff = static_cast<size_t>(angles::to_degrees(2*M_PI + current_azimuth - phase)) % 360;
     }
     overflow_pc_->width = overflow_pc_->points.size();
     scan_pc_->width = scan_pc_->points.size();
@@ -84,10 +79,7 @@ std::tuple<drivers::NebulaPointCloudPtr, double> Vls128Decoder::get_pointcloud()
   return std::make_tuple(scan_pc_, scan_timestamp_);
 }
 
-int Vls128Decoder::pointsPerPacket()
-{
-  return BLOCKS_PER_PACKET * SCANS_PER_BLOCK;
-}
+int Vls128Decoder::pointsPerPacket() { return BLOCKS_PER_PACKET * SCANS_PER_BLOCK; }
 
 void Vls128Decoder::reset_pointcloud(size_t n_pts)
 {
@@ -261,8 +253,7 @@ void Vls128Decoder::unpack(
               if (scan_timestamp_ < 0) {
                 scan_timestamp_ = block_timestamp;
               }
-              double point_time_offset =
-                timing_offsets_[block / 4][firing_order + laser_number / 64];
+              double point_time_offset = timing_offsets_[block / 4][firing_order + laser_number / 64];
 
               // Determine return type.
               uint8_t return_type;
@@ -313,8 +304,9 @@ void Vls128Decoder::unpack(
               current_point.elevation = sin_vert_angle;
               current_point.distance = distance;
               auto point_ts = block_timestamp - scan_timestamp_ + point_time_offset;
-              if (point_ts < 0) point_ts = 0;
-              current_point.time_stamp = static_cast<uint32_t>(point_ts * 1e9);
+              if (point_ts < 0)
+                point_ts = 0;
+              current_point.time_stamp = static_cast<uint32_t>(point_ts*1e9);
               current_point.intensity = intensity;
 
               append_point(current_point, packet_index);

--- a/nebula_decoders/src/nebula_decoders_velodyne/velodyne_driver.cpp
+++ b/nebula_decoders/src/nebula_decoders_velodyne/velodyne_driver.cpp
@@ -69,10 +69,7 @@ std::tuple<drivers::NebulaPointCloudPtr, double> VelodyneDriver::ConvertScanToPo
   }
   return pointcloud;
 }
-Status VelodyneDriver::GetStatus()
-{
-  return driver_status_;
-}
+Status VelodyneDriver::GetStatus() { return driver_status_; }
 
 }  // namespace drivers
 }  // namespace nebula


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Improvement


## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description

The issue: https://github.com/tier4/nebula/issues/61

## Review Procedure

<!-- Explain how to review this PR. -->
On the `nebula_decoders` package, I have created another interface called `ParallelUnpack`. The decoder classes for each Velodyne model inherits `ParallelUnpack` alongside `VelodyneScanDecoder`.

On the `velodyne_driver.cpp`, I converted the for loop to a parallel `for_each`. The unpack method is called in parallel and every Velodyne packet unpacks into a seperate point cloud. Then, at the end, when `get_pointcloud()` is called, al the clouds are merged into a single one. Overall, the unpack process was speeded up.

## Remarks

<!-- Write remarks as you like if you need them. -->
`VLS-128` produces a lot of packets and processing it takes too much time. This improvement tends to speed up this process.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
