### PR TITLE
ci: workflows. disable clang-tidy

### DIFF
--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -55,37 +55,3 @@ jobs:
           verbose: true
           flags: differential
 
-  clang-tidy-differential:
-    runs-on: ubuntu-latest
-    container: ros:humble
-    needs: build-and-test-differential
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Remove exec_depend
-        uses: autowarefoundation/autoware-github-actions/remove-exec-depend@v1
-
-      - name: Get modified packages
-        id: get-modified-packages
-        uses: autowarefoundation/autoware-github-actions/get-modified-packages@v1
-
-      - name: Get modified files
-        id: get-modified-files
-        uses: tj-actions/changed-files@v35
-        with:
-          files: |
-            **/*.cpp
-            **/*.hpp
-
-      - name: Run clang-tidy
-        if: ${{ steps.get-modified-files.outputs.all_changed_files != '' }}
-        uses: autowarefoundation/autoware-github-actions/clang-tidy@v1
-        with:
-          rosdistro: humble
-          target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
-          target-files: ${{ steps.get-modified-files.outputs.all_changed_files }}
-          clang-tidy-config-url: https://raw.githubusercontent.com/autowarefoundation/autoware/main/.clang-tidy
-          build-depends-repos: build_depends.repos


### PR DESCRIPTION
## Description

Disable clang-tidy

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
