### PR TITLE
fix(velodyne): allow setup_sensor False

### DIFF
--- a/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
+++ b/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
@@ -29,8 +29,6 @@ Status VelodyneHwInterface::InitializeSensorConfiguration(
 Status VelodyneHwInterface::SetSensorConfiguration(
   std::shared_ptr<SensorConfigurationBase> sensor_configuration)
 {
-  InitializeSensorConfiguration(sensor_configuration);
-
   VelodyneStatus status = CheckAndSetConfigBySnapshotAsync();
   Status rt = status;
   return rt;

--- a/nebula_ros/src/velodyne/velodyne_hw_interface_ros_wrapper.cpp
+++ b/nebula_ros/src/velodyne/velodyne_hw_interface_ros_wrapper.cpp
@@ -23,9 +23,12 @@ VelodyneHwInterfaceRosWrapper::VelodyneHwInterfaceRosWrapper(const rclcpp::NodeO
   RCLCPP_INFO_STREAM(this->get_logger(), "Initialize sensor_configuration");
   std::shared_ptr<drivers::SensorConfigurationBase> sensor_cfg_ptr =
     std::make_shared<drivers::VelodyneSensorConfiguration>(sensor_configuration_);
-  RCLCPP_INFO_STREAM(this->get_logger(), "hw_interface_.SetSensorConfiguration");
+  RCLCPP_INFO_STREAM(this->get_logger(), "hw_interface_.InitializeSensorConfiguration");
+  hw_interface_.InitializeSensorConfiguration(
+    std::static_pointer_cast<drivers::SensorConfigurationBase>(sensor_cfg_ptr));
 
   if (this->setup_sensor) {
+    RCLCPP_INFO_STREAM(this->get_logger(), "hw_interface_.SetSensorConfiguration");
     hw_interface_.SetSensorConfiguration(
       std::static_pointer_cast<drivers::SensorConfigurationBase>(sensor_cfg_ptr));
     updateParameters();


### PR DESCRIPTION
## PR Type

- Bug Fix

## Description

Allows Velodyne sensors to use `sensor_setup:=False` regardless of the launch and sensor setup.

Fixes https://github.com/tier4/nebula/issues/53

## Review Procedure

Launch 
`ros2 launch nebula_ros velodyne_launch_all_hw.xml sensor_model:=SENSOR setup_sensor:=False`

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
