### PR TITLE
test(nebula_tests): remove designated initializers

### DIFF
--- a/nebula_tests/hesai/hesai_ros_decoder_test.hpp
+++ b/nebula_tests/hesai/hesai_ros_decoder_test.hpp
@@ -35,11 +35,11 @@ struct HesaiRosDecoderTestParams
 {
   std::string sensor_model;
   std::string return_mode;
+  std::string calibration_file = "";
+  std::string bag_path;
+  std::string correction_file = "";
   std::string frame_id = "hesai";
   double scan_phase = 0.;
-  std::string calibration_file = "";
-  std::string correction_file = "";
-  std::string bag_path;
   std::string storage_id = "sqlite3";
   std::string format = "cdr";
   std::string target_topic = "/pandar_packets";

--- a/nebula_tests/hesai/hesai_ros_decoder_test_main.cpp
+++ b/nebula_tests/hesai/hesai_ros_decoder_test_main.cpp
@@ -19,40 +19,42 @@ namespace test
 {
 
 const nebula::ros::HesaiRosDecoderTestParams TEST_CONFIGS[6] = {
-  {.sensor_model = "Pandar40P",
-   .return_mode = "Dual",
-   .calibration_file = "Pandar40P.csv",
-   .bag_path = "40p/1673400149412331409"},
   {
-    .sensor_model = "Pandar64",
-    .return_mode = "Dual",
-    .calibration_file = "Pandar64.csv",
-    .bag_path = "64/1673403880599376836",
+    "Pandar40P",
+    "Dual",
+    "Pandar40P.csv",
+    "40p/1673400149412331409",
   },
   {
-    .sensor_model = "PandarAT128",
-    .return_mode = "LastStrongest",
-    .calibration_file = "PandarAT128.csv",
-    .correction_file = "PandarAT128.dat",
-    .bag_path = "at128/1679653308406038376",
+    "Pandar64",
+    "Dual",
+    "Pandar64.csv",
+    "64/1673403880599376836",
   },
   {
-    .sensor_model = "PandarQT64",
-    .return_mode = "Dual",
-    .calibration_file = "PandarQT64.csv",
-    .bag_path = "qt64/1673401195788312575",
+    "PandarAT128",
+    "LastStrongest",
+    "PandarAT128.csv",
+    "at128/1679653308406038376",
+    "PandarAT128.dat",
   },
   {
-    .sensor_model = "PandarXT32",
-    .return_mode = "Dual",
-    .calibration_file = "PandarXT32.csv",
-    .bag_path = "xt32/1673400677802009732",
+    "PandarQT64",
+    "Dual",
+    "PandarQT64.csv",
+    "qt64/1673401195788312575",
   },
   {
-    .sensor_model = "PandarXT32M",
-    .return_mode = "LastStrongest",
-    .calibration_file = "PandarXT32M.csv",
-    .bag_path = "xt32m/1660893203042895158",
+    "PandarXT32",
+    "Dual",
+    "PandarXT32.csv",
+    "xt32/1673400677802009732",
+  },
+  {
+    "PandarXT32M",
+    "LastStrongest",
+    "PandarXT32M.csv",
+    "xt32m/1660893203042895158",
   }};
 
 // Compares geometrical output of decoder against pre-recorded reference pointcloud.
@@ -66,7 +68,7 @@ TEST_P(DecoderTest, TestPcd)
   int check_cnt = 0;
 
   auto scan_callback = [&](
-                         uint64_t msg_timestamp, uint64_t scan_timestamp,
+                         uint64_t msg_timestamp, uint64_t /*scan_timestamp*/,
                          nebula::drivers::NebulaPointCloudPtr pointcloud) {
     if (!pointcloud) return;
 
@@ -97,7 +99,7 @@ TEST_P(DecoderTest, TestTimezone)
   std::vector<uint64_t> decoded_timestamps;
 
   auto scan_callback = [&](
-                         uint64_t msg_timestamp, uint64_t scan_timestamp,
+                         uint64_t /*msg_timestamp*/, uint64_t scan_timestamp,
                          nebula::drivers::NebulaPointCloudPtr pointcloud) {
     if (!pointcloud) return;
     decoded_timestamps.push_back(scan_timestamp);
@@ -133,7 +135,7 @@ TEST_P(DecoderTest, TestTimezone)
   // then compare e.g. the last timestamp to verify that it is not affected
   // by timezone settings
   ASSERT_EQ(decoded_timestamps.size(), decoded_timestamps_cmp.size());
-  ASSERT_GT(decoded_timestamps.size(), 0);
+  ASSERT_GT(decoded_timestamps.size(), 0U);
   EXPECT_EQ(decoded_timestamps.back(), decoded_timestamps_cmp.back());
 }
 


### PR DESCRIPTION
## PR Type

- Improvement

## Related Links



## Description

This PR gets rid of the designated initializers in the `nebula_tests` package which caused compiler warnings as this feature is only supported from C++20 onward.

Also made tiny changes to other parts of the tests that raised warnings (unused parameters etc.). There are now no warnings at all when compiling the tests.

## Review Procedure

```
colcon build --packages-up-to nebula_tests
colcon test --event-handlers console_cohesion+ --packages-select nebula_tests
```

## Remarks



## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
