### PR TITLE
fix: get rid of "unused parameter ‘sensor_configuration’" warning for Velodyne

### DIFF
--- a/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_velodyne/velodyne_hw_interface.hpp
+++ b/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_velodyne/velodyne_hw_interface.hpp
@@ -11,11 +11,11 @@
 #if (BOOST_VERSION / 100 == 1074)  // Boost 1.74
 #define BOOST_ALLOW_DEPRECATED_HEADERS
 #endif
+#include "boost_tcp_driver/http_client_driver.hpp"
+#include "boost_udp_driver/udp_driver.hpp"
 #include "nebula_common/velodyne/velodyne_common.hpp"
 #include "nebula_common/velodyne/velodyne_status.hpp"
 #include "nebula_hw_interfaces/nebula_hw_interfaces_common/nebula_hw_interface_base.hpp"
-#include "boost_tcp_driver/http_client_driver.hpp"
-#include "boost_udp_driver/udp_driver.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -243,7 +243,8 @@ public:
   VelodyneStatus GetSnapshotAsync();
   /// @brief Checking the current settings and changing the difference point
   /// @return Resulting status
-  VelodyneStatus CheckAndSetConfigBySnapshotAsync();
+  VelodyneStatus CheckAndSetConfigBySnapshotAsync(
+    std::shared_ptr<VelodyneSensorConfiguration> sensor_configuration);
   /// @brief Setting Motor RPM (async)
   /// @param rpm the RPM of the motor
   /// @return Resulting status

--- a/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
+++ b/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
@@ -29,7 +29,9 @@ Status VelodyneHwInterface::InitializeSensorConfiguration(
 Status VelodyneHwInterface::SetSensorConfiguration(
   std::shared_ptr<SensorConfigurationBase> sensor_configuration)
 {
-  VelodyneStatus status = CheckAndSetConfigBySnapshotAsync();
+  auto velodyne_sensor_configuration =
+    std::static_pointer_cast<VelodyneSensorConfiguration>(sensor_configuration);
+  VelodyneStatus status = CheckAndSetConfigBySnapshotAsync(velodyne_sensor_configuration);
   Status rt = status;
   return rt;
 }
@@ -99,7 +101,10 @@ void VelodyneHwInterface::ReceiveCloudPacketCallback(const std::vector<uint8_t> 
   }
   prev_packet_first_azm_phased_ = packet_first_azm_phased_;
 }
-Status VelodyneHwInterface::CloudInterfaceStop() { return Status::ERROR_1; }
+Status VelodyneHwInterface::CloudInterfaceStop()
+{
+  return Status::ERROR_1;
+}
 
 Status VelodyneHwInterface::GetSensorConfiguration(SensorConfigurationBase & sensor_configuration)
 {
@@ -222,8 +227,7 @@ VelodyneStatus VelodyneHwInterface::CheckAndSetConfig(
     SetFovStartAsync(setting_cloud_min_angle);
     std::cout << "VelodyneHwInterface::parse_json(" << target_key
               << "): " << current_cloud_min_angle << std::endl;
-    std::cout << "sensor_configuration->cloud_min_angle: " << setting_cloud_min_angle
-              << std::endl;
+    std::cout << "sensor_configuration->cloud_min_angle: " << setting_cloud_min_angle << std::endl;
   }
 
   target_key = "config.fov.end";
@@ -237,8 +241,7 @@ VelodyneStatus VelodyneHwInterface::CheckAndSetConfig(
     SetFovEndAsync(setting_cloud_max_angle);
     std::cout << "VelodyneHwInterface::parse_json(" << target_key
               << "): " << current_cloud_max_angle << std::endl;
-    std::cout << "sensor_configuration->cloud_max_angle: " << setting_cloud_max_angle
-              << std::endl;
+    std::cout << "sensor_configuration->cloud_max_angle: " << setting_cloud_max_angle << std::endl;
   }
 
   target_key = "config.host.addr";
@@ -521,8 +524,11 @@ VelodyneStatus VelodyneHwInterface::GetSnapshotAsync()
   return GetSnapshotAsync([this](const std::string & str) { ParseJson(str); });
 }
 
-VelodyneStatus VelodyneHwInterface::CheckAndSetConfigBySnapshotAsync()
+VelodyneStatus VelodyneHwInterface::CheckAndSetConfigBySnapshotAsync(
+  std::shared_ptr<VelodyneSensorConfiguration> sensor_configuration)
 {
+  sensor_configuration_ = sensor_configuration;
+
   return GetSnapshotAsync([this](const std::string & str) {
     auto tree = ParseJson(str);
     std::cout << "ParseJson OK\n";


### PR DESCRIPTION
## PR Type

- Bug Fix

## Related Links

## Description

This PR fixes the `unused parameter ‘sensor_configuration’` warning when building `nebula_hw_interfaces`.
The parameter was unused because it was of type `SensorConfigurationBase` while the function in question needed `VelodyneSensorConfiguration` and used the member variable of the correct type, ignoring the parameter.

The member now gets updated with the casted parameter value.

## Review Procedure

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
