### PR TITLE
refactor(hesai_hw_interface): remove mention of Velodyne sensors in Hesai code

### DIFF
--- a/nebula_hw_interfaces/src/nebula_hesai_hw_interfaces/hesai_hw_interface.cpp
+++ b/nebula_hw_interfaces/src/nebula_hesai_hw_interfaces/hesai_hw_interface.cpp
@@ -3202,16 +3202,10 @@ int HesaiHwInterface::NebulaModelToHesaiModelNo(nebula::drivers::SensorModel mod
       return 40;
     case SensorModel::HESAI_PANDARAT128:
       return 48;
-    case SensorModel::VELODYNE_VLS128:
-    case SensorModel::VELODYNE_HDL64:
-    case SensorModel::VELODYNE_VLP32:
-    case SensorModel::VELODYNE_VLP32MR:
-    case SensorModel::VELODYNE_HDL32:
-    case SensorModel::VELODYNE_VLP16:
-    case SensorModel::UNKNOWN:
+    // All other vendors and unknown sensors
+    default:
       return -1;
   }
-  return -1;
 }
 void HesaiHwInterface::SetTargetModel(int model) { target_model_no = model; }
 void HesaiHwInterface::SetTargetModel(nebula::drivers::SensorModel model) { target_model_no = NebulaModelToHesaiModelNo(model); }


### PR DESCRIPTION
`NebulaModelToHesaiModelNo` was explicitly handling Velodyne models, while it should really just handle everything that is `not Hesai` the same. Because of this, PR #77 and future sensor additions cause warnings in this piece of code (enum value XYZ not handled).

## PR Type

- Improvement

## Description

The function on question now has a generic `default` case for any non-Hesai sensors. Functionally it is exactly the same as before.

## Review Procedure

Confirm there are no build warnings like "Enum value XYZW not handled in switch statement", confirm in the diff that the code is equivalent.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
