### PR TITLE
fix(hw_interfaces): fix the lossy nanoseconds extraction

### DIFF
--- a/nebula_hw_interfaces/src/nebula_hesai_hw_interfaces/hesai_hw_interface.cpp
+++ b/nebula_hw_interfaces/src/nebula_hesai_hw_interfaces/hesai_hw_interface.cpp
@@ -189,8 +189,7 @@ void HesaiHwInterface::ReceiveCloudPacketCallback(const std::vector<uint8_t> & b
   auto now_nanosecs =
     std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
   pandar_packet.stamp.sec = static_cast<int>(now_secs);
-  pandar_packet.stamp.nanosec =
-    static_cast<int>((now_nanosecs / 1000000000. - static_cast<double>(now_secs)) * 1000000000);
+  pandar_packet.stamp.nanosec = static_cast<std::uint32_t>(now_nanosecs % 1000000000);
   scan_cloud_ptr_->packets.emplace_back(pandar_packet);
 
   int current_phase = 0;

--- a/nebula_hw_interfaces/src/nebula_hesai_hw_interfaces/hesai_hw_interface.cpp
+++ b/nebula_hw_interfaces/src/nebula_hesai_hw_interfaces/hesai_hw_interface.cpp
@@ -189,7 +189,7 @@ void HesaiHwInterface::ReceiveCloudPacketCallback(const std::vector<uint8_t> & b
   auto now_nanosecs =
     std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
   pandar_packet.stamp.sec = static_cast<int>(now_secs);
-  pandar_packet.stamp.nanosec = static_cast<std::uint32_t>(now_nanosecs % 1000000000);
+  pandar_packet.stamp.nanosec = static_cast<std::uint32_t>(now_nanosecs % 1'000'000'000);
   scan_cloud_ptr_->packets.emplace_back(pandar_packet);
 
   int current_phase = 0;

--- a/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
+++ b/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
@@ -72,7 +72,7 @@ void VelodyneHwInterface::ReceiveCloudPacketCallback(const std::vector<uint8_t> 
     std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
   velodyne_packet.data = packet_data;
   velodyne_packet.stamp.sec = static_cast<int>(now_secs);
-  velodyne_packet.stamp.nanosec = static_cast<std::uint32_t>(now_nanosecs % 1000000000);
+  velodyne_packet.stamp.nanosec = static_cast<std::uint32_t>(now_nanosecs % 1'000'000'000);
   scan_cloud_ptr_->packets.emplace_back(velodyne_packet);
   processed_packets_++;
 

--- a/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
+++ b/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
@@ -72,8 +72,7 @@ void VelodyneHwInterface::ReceiveCloudPacketCallback(const std::vector<uint8_t> 
     std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
   velodyne_packet.data = packet_data;
   velodyne_packet.stamp.sec = static_cast<int>(now_secs);
-  velodyne_packet.stamp.nanosec =
-    static_cast<int>((now_nanosecs / 1000000000. - static_cast<double>(now_secs)) * 1000000000);
+  velodyne_packet.stamp.nanosec = static_cast<std::uint32_t>(now_nanosecs % 1000000000);
   scan_cloud_ptr_->packets.emplace_back(velodyne_packet);
   processed_packets_++;
 


### PR DESCRIPTION
## PR Type

- Bug Fix

## Related Links

None.

## Description
```cpp
// old
packet.stamp.nanosec = static_cast<int>((now_nanosecs / 1000000000. - static_cast<double>(now_secs)) * 1000000000);
// new
packet.stamp.nanosec = static_cast<std::uint32_t>(now_nanosecs % 1000000000);
```
The first line of code you provided appears to have a bug related to the calculation of the nanoseconds portion of a timestamp. Here's the breakdown:

1. **First Line Analysis:**
   - `packet.stamp.nanosec = static_cast<int>((now_nanosecs / 1000000000. - static_cast<double>(now_secs)) * 1000000000);`
   - This line seems to be trying to calculate the nanoseconds part by taking the total nanoseconds (`now_nanosecs`), dividing it by 1 billion (to get the seconds part), and then subtracting the seconds part (`now_secs`) from it. This result is then multiplied by 1 billion to convert it back to nanoseconds. 
   - The issue here is in the calculation method. When you divide `now_nanosecs` by 1 billion and then subtract `now_secs`, you might not get an accurate nanoseconds part because of potential floating-point precision errors. The calculation also unnecessarily converts values to a `double` and then back to an `int`, which can introduce additional precision errors.

2. **Second Line Fix:**
   - `packet.stamp.nanosec = static_cast<std::uint32_t>(now_nanosecs % 1000000000);`
   - This line simplifies the process by using the modulo operator (`%`). It effectively gets the remainder of `now_nanosecs` when divided by 1 billion, which directly gives the nanoseconds part without needing to convert to seconds first. 
   - Using modulo is a common and more reliable method for extracting the smaller unit (nanoseconds in this case) from a larger time value (like total nanoseconds). It avoids the precision issues of floating-point arithmetic.

In summary, the first line has a potential precision issue due to unnecessary floating-point calculations and conversions, while the second line efficiently and accurately calculates the nanoseconds part using the modulo operation.


## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [x] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [x] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
