### PR TITLE
perf(hw_interface): write packet data directly into the message

### DIFF
--- a/nebula_hw_interfaces/src/nebula_hesai_hw_interfaces/hesai_hw_interface.cpp
+++ b/nebula_hw_interfaces/src/nebula_hesai_hw_interfaces/hesai_hw_interface.cpp
@@ -178,11 +178,9 @@ void HesaiHwInterface::ReceiveCloudPacketCallback(const std::vector<uint8_t> & b
     PrintDebug("Invalid Packet: " + std::to_string(buffer.size()));
     return;
   }
-  uint32_t buffer_size = buffer.size();
-  std::array<uint8_t, MTU_SIZE> packet_data{};
-  std::copy_n(std::make_move_iterator(buffer.begin()), buffer_size, packet_data.begin());
+  const uint32_t buffer_size = buffer.size();
   pandar_msgs::msg::PandarPacket pandar_packet;
-  pandar_packet.data = packet_data;
+  std::copy_n(std::make_move_iterator(buffer.begin()), buffer_size, pandar_packet.data.begin());
   pandar_packet.size = buffer_size;
   auto now = std::chrono::system_clock::now();
   auto now_secs = std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch()).count();

--- a/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
+++ b/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
@@ -62,15 +62,13 @@ Status VelodyneHwInterface::RegisterScanCallback(
 void VelodyneHwInterface::ReceiveCloudPacketCallback(const std::vector<uint8_t> & buffer)
 {
   // Process current packet
-  uint32_t buffer_size = buffer.size();
-  std::array<uint8_t, 1206> packet_data{};
-  std::copy_n(std::make_move_iterator(buffer.begin()), buffer_size, packet_data.begin());
+  const uint32_t buffer_size = buffer.size();
   velodyne_msgs::msg::VelodynePacket velodyne_packet;
+  std::copy_n(std::make_move_iterator(buffer.begin()), buffer_size, velodyne_packet.data.begin());
   auto now = std::chrono::system_clock::now();
   auto now_secs = std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch()).count();
   auto now_nanosecs =
     std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
-  velodyne_packet.data = packet_data;
   velodyne_packet.stamp.sec = static_cast<int>(now_secs);
   velodyne_packet.stamp.nanosec = static_cast<std::uint32_t>(now_nanosecs % 1'000'000'000);
   scan_cloud_ptr_->packets.emplace_back(velodyne_packet);


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Improvement

## Related Links

None.

## Description

Before this change, in the driver, every time a UDP packet is received, it is first written to a `std::array` object, then copied into the message.
With this change, the UDP packets are directly read into the message, avoiding the overhead.

Their types are the same so it won't cause an issue.

Small note: also made the buffer size variable `const` since it doesn't change over time.

## Review Procedure

<!-- Explain how to review this PR. -->
You could:
- double check the types.
- test on pcap data.

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [x] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
