### PR TITLE
fix(velodyne): remove unused large variable/copy

### DIFF
--- a/nebula_ros/src/velodyne/velodyne_decoder_ros_wrapper.cpp
+++ b/nebula_ros/src/velodyne/velodyne_decoder_ros_wrapper.cpp
@@ -45,9 +45,6 @@ void VelodyneDriverRosWrapper::ReceiveScanMsgCallback(
 {
   auto t_start = std::chrono::high_resolution_clock::now();
 
-  // take packets out of scan msg
-  std::vector<velodyne_msgs::msg::VelodynePacket> pkt_msgs = scan_msg->packets;
-
   std::tuple<nebula::drivers::NebulaPointCloudPtr, double> pointcloud_ts =
     driver_ptr_->ConvertScanToPointcloud(scan_msg);
   nebula::drivers::NebulaPointCloudPtr pointcloud = std::get<0>(pointcloud_ts);


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Bug Fix

## Related Links

None.

## Description

Entire Velodyne scan was copied into an unused variable. This PR removes the variable.

Hopefully the compiler already optimizes this out but just to be sure, it's better to remove it.

## Review Procedure

- Check if it compiles
- Check if variable is really unused?

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [x] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [x] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
