### PR TITLE
fix(robosense): use correct field to check time sync status

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -38,6 +38,7 @@
     "Difop",
     "gptp",
     "Idat",
-    "Vdat"
+    "Vdat",
+    "manc"
   ]
 }

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/decoders/bpearl_v3.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/decoders/bpearl_v3.hpp
@@ -269,14 +269,12 @@ public:
 
   bool getSyncStatus(const robosense_packet::bpearl_v3::InfoPacket & info_packet)
   {
-    switch (info_packet.time_sync_mode.value()) {
-      case SYNC_MODE_GPS_FLAG:
+    switch (info_packet.sync_status.value()) {
+      case SYNC_STATUS_INVALID_FLAG:
+        return false;
+      case SYNC_STATUS_GPS_SUCCESS_FLAG:
         return true;
-      case SYNC_MODE_E2E_FLAG:
-        return true;
-      case SYNC_MODE_P2P_FLAG:
-        return true;
-      case SYNC_MODE_GPTP_FLAG:
+      case SYNC_STATUS_PTP_SUCCESS_FLAG:
         return true;
       default:
         return false;

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/decoders/bpearl_v4.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/decoders/bpearl_v4.hpp
@@ -241,14 +241,12 @@ public:
 
   bool getSyncStatus(const robosense_packet::bpearl_v4::InfoPacket & info_packet)
   {
-    switch (info_packet.time_sync_mode.value()) {
-      case SYNC_MODE_GPS_FLAG:
+    switch (info_packet.time_sync_state.value()) {
+      case SYNC_STATUS_INVALID_FLAG:
+        return false;
+      case SYNC_STATUS_GPS_SUCCESS_FLAG:
         return true;
-      case SYNC_MODE_E2E_FLAG:
-        return true;
-      case SYNC_MODE_P2P_FLAG:
-        return true;
-      case SYNC_MODE_GPTP_FLAG:
+      case SYNC_STATUS_PTP_SUCCESS_FLAG:
         return true;
       default:
         return false;

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/decoders/helios.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/decoders/helios.hpp
@@ -280,14 +280,12 @@ public:
 
   bool getSyncStatus(const robosense_packet::helios::InfoPacket & info_packet)
   {
-    switch (info_packet.time_sync_mode.value()) {
-      case SYNC_MODE_GPS_FLAG:
+    switch (info_packet.sync_status.value()) {
+      case SYNC_STATUS_INVALID_FLAG:
+        return false;
+      case SYNC_STATUS_GPS_SUCCESS_FLAG:
         return true;
-      case SYNC_MODE_E2E_FLAG:
-        return true;
-      case SYNC_MODE_P2P_FLAG:
-        return true;
-      case SYNC_MODE_GPTP_FLAG:
+      case SYNC_STATUS_PTP_SUCCESS_FLAG:
         return true;
       default:
         return false;


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Bug Fix

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description

<!-- Describe what this PR changes. -->

Currently, to get the time synchronization status, wrong field is used. If the sensor doesn't have time synchronization, driver doesn't start.

The current checked field is `time_sync_mode` states the mode that was set on web interface such as GPS or PTP.

This PR fixes this issue by checking `sync_status` field which is the correct way to see time synchronization status.

## Review Procedure

<!-- Explain how to review this PR. -->

You can use pcap files to test: https://github.com/tier4/nebula/pull/77#issuecomment-1831496822

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [x] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [x] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
