### PR TITLE
fix(velodyne_decoder): overflow handling in vls128

### DIFF
--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/decoders/velodyne_scan_decoder.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/decoders/velodyne_scan_decoder.hpp
@@ -185,9 +185,9 @@ public:
   virtual std::tuple<drivers::NebulaPointCloudPtr, double> get_pointcloud() = 0;
   /// @brief Resetting point cloud buffer
   /// @param n_pts # of points
-  virtual void reset_pointcloud(size_t n_pts) = 0;
+  virtual void reset_pointcloud(size_t n_pts, double time_stamp) = 0;
   /// @brief Resetting overflowed point cloud buffer
-  virtual void reset_overflow() = 0;
+  virtual void reset_overflow(double time_stamp) = 0;
 };
 
 }  // namespace drivers

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/decoders/vlp16_decoder.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/decoders/vlp16_decoder.hpp
@@ -13,7 +13,7 @@ namespace drivers
 {
 namespace vlp16
 {
-  constexpr uint32_t MAX_POINTS = 300000;
+constexpr uint32_t MAX_POINTS = 300000;
 /// @brief Velodyne LiDAR decoder (VLP16)
 class Vlp16Decoder : public VelodyneScanDecoder
 {
@@ -38,9 +38,9 @@ public:
   std::tuple<drivers::NebulaPointCloudPtr, double> get_pointcloud() override;
   /// @brief Resetting point cloud buffer
   /// @param n_pts # of points
-  void reset_pointcloud(size_t n_pts) override;
+  void reset_pointcloud(size_t n_pts, double time_stamp) override;
   /// @brief Resetting overflowed point cloud buffer
-  void reset_overflow() override;
+  void reset_overflow(double time_stamp) override;
 
 private:
   /// @brief Parsing VelodynePacket based on packet structure

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/decoders/vlp32_decoder.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/decoders/vlp32_decoder.hpp
@@ -37,9 +37,9 @@ public:
   std::tuple<drivers::NebulaPointCloudPtr, double> get_pointcloud() override;
   /// @brief Resetting point cloud buffer
   /// @param n_pts # of points
-  void reset_pointcloud(size_t n_pts) override;
+  void reset_pointcloud(size_t n_pts, double time_stamp) override;
   /// @brief Resetting overflowed point cloud buffer
-  void reset_overflow() override;
+  void reset_overflow(double time_stamp) override;
 
 private:
   /// @brief Parsing VelodynePacket based on packet structure

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/decoders/vls128_decoder.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/decoders/vls128_decoder.hpp
@@ -37,9 +37,9 @@ public:
   std::tuple<drivers::NebulaPointCloudPtr, double> get_pointcloud() override;
   /// @brief Resetting point cloud buffer
   /// @param n_pts # of points
-  void reset_pointcloud(size_t n_pts) override;
+  void reset_pointcloud(size_t n_pts, double time_stamp) override;
   /// @brief Resetting overflowed point cloud buffer
-  void reset_overflow() override;
+  void reset_overflow(double time_stamp) override;
 
 private:
   /// @brief Parsing VelodynePacket based on packet structure
@@ -52,6 +52,7 @@ private:
   float vls_128_laser_azimuth_cache_[16];
   int phase_;
   int max_pts_;
+  double last_block_timestamp_;
   std::vector<std::vector<float>> timing_offsets_;
 };
 

--- a/nebula_decoders/src/nebula_decoders_velodyne/decoders/vlp16_decoder.cpp
+++ b/nebula_decoders/src/nebula_decoders_velodyne/decoders/vlp16_decoder.cpp
@@ -30,43 +30,48 @@ Vlp16Decoder::Vlp16Decoder(
   }
   // timing table calculation, from velodyne user manual p.64
   timing_offsets_.resize(BLOCKS_PER_PACKET);
-  for (size_t i=0; i < timing_offsets_.size(); ++i){
+  for (size_t i = 0; i < timing_offsets_.size(); ++i) {
     timing_offsets_[i].resize(32);
   }
   double full_firing_cycle_s = 55.296 * 1e-6;
   double single_firing_s = 2.304 * 1e-6;
   double data_block_index, data_point_index;
-  bool dual_mode = sensor_configuration_->return_mode==ReturnMode::DUAL;
+  bool dual_mode = sensor_configuration_->return_mode == ReturnMode::DUAL;
   // compute timing offsets
-  for (size_t x = 0; x < timing_offsets_.size(); ++x){
-    for (size_t y = 0; y < timing_offsets_[x].size(); ++y){
-      if (dual_mode){
+  for (size_t x = 0; x < timing_offsets_.size(); ++x) {
+    for (size_t y = 0; y < timing_offsets_[x].size(); ++y) {
+      if (dual_mode) {
         data_block_index = (x - (x % 2)) + (y / 16);
-      }
-      else{
+      } else {
         data_block_index = (x * 2) + (y / 16);
       }
       data_point_index = y % 16;
-      timing_offsets_[x][y] = (full_firing_cycle_s * data_block_index) + (single_firing_s * data_point_index);
+      timing_offsets_[x][y] =
+        (full_firing_cycle_s * data_block_index) + (single_firing_s * data_point_index);
     }
   }
 
   phase_ = (uint16_t)round(sensor_configuration_->scan_phase * 100);
 }
 
-bool Vlp16Decoder::hasScanned() { return has_scanned_; }
+bool Vlp16Decoder::hasScanned()
+{
+  return has_scanned_;
+}
 
 std::tuple<drivers::NebulaPointCloudPtr, double> Vlp16Decoder::get_pointcloud()
 {
   double phase = angles::from_degrees(sensor_configuration_->scan_phase);
   if (!scan_pc_->points.empty()) {
     auto current_azimuth = scan_pc_->points.back().azimuth;
-    auto phase_diff = static_cast<size_t>(angles::to_degrees(2*M_PI + current_azimuth - phase)) % 360;
+    auto phase_diff =
+      static_cast<size_t>(angles::to_degrees(2 * M_PI + current_azimuth - phase)) % 360;
     while (phase_diff < M_PI_2 && !scan_pc_->points.empty()) {
       overflow_pc_->points.push_back(scan_pc_->points.back());
       scan_pc_->points.pop_back();
       current_azimuth = scan_pc_->points.back().azimuth;
-      phase_diff = static_cast<size_t>(angles::to_degrees(2*M_PI + current_azimuth - phase)) % 360;
+      phase_diff =
+        static_cast<size_t>(angles::to_degrees(2 * M_PI + current_azimuth - phase)) % 360;
     }
     overflow_pc_->width = overflow_pc_->points.size();
     scan_pc_->width = scan_pc_->points.size();
@@ -80,16 +85,16 @@ int Vlp16Decoder::pointsPerPacket()
   return BLOCKS_PER_PACKET * VLP16_FIRINGS_PER_BLOCK * VLP16_SCANS_PER_FIRING;
 }
 
-void Vlp16Decoder::reset_pointcloud(size_t n_pts)
+void Vlp16Decoder::reset_pointcloud(size_t n_pts, [[maybe_unused]] double time_stamp)
 {
   scan_pc_->points.clear();
   max_pts_ = n_pts * pointsPerPacket();
   scan_pc_->points.reserve(max_pts_);
-  reset_overflow();  // transfer existing overflow points to the cleared pointcloud
+  reset_overflow(time_stamp);  // transfer existing overflow points to the cleared pointcloud
   scan_timestamp_ = -1;
 }
 
-void Vlp16Decoder::reset_overflow()
+void Vlp16Decoder::reset_overflow([[maybe_unused]] double time_stamp)
 {
   // Add the overflow buffer points
   for (size_t i = 0; i < overflow_pc_->points.size(); i++) {
@@ -225,7 +230,7 @@ void Vlp16Decoder::unpack(const velodyne_msgs::msg::VelodynePacket & velodyne_pa
                 const float z_coord = distance * sin_vert_angle;       // velodyne z
                 const uint8_t intensity = current_block.data[k + 2];
 
-                double point_time_offset =  timing_offsets_[block][firing * 16 + dsr];
+                double point_time_offset = timing_offsets_[block][firing * 16 + dsr];
 
                 // Determine return type.
                 uint8_t return_type;
@@ -237,9 +242,10 @@ void Vlp16Decoder::unpack(const velodyne_msgs::msg::VelodynePacket & velodyne_pa
                        other_return.bytes[1] == current_return.bytes[1])) {
                       return_type = static_cast<uint8_t>(drivers::ReturnType::IDENTICAL);
                     } else {
-                      const uint8_t other_intensity = block % 2 ? raw->blocks[block - 1].data[k + 2]
-                                                              : raw->blocks[block + 1].data[k + 2];
-                      bool first = current_return.uint > other_return.uint ;
+                      const uint8_t other_intensity = block % 2
+                                                        ? raw->blocks[block - 1].data[k + 2]
+                                                        : raw->blocks[block + 1].data[k + 2];
+                      bool first = current_return.uint > other_return.uint;
                       bool strongest = intensity > other_intensity;
                       if (other_intensity == intensity) {
                         strongest = !first;
@@ -275,9 +281,8 @@ void Vlp16Decoder::unpack(const velodyne_msgs::msg::VelodynePacket & velodyne_pa
                 current_point.azimuth = rotation_radians_[azimuth_corrected];
                 current_point.elevation = sin_vert_angle;
                 auto point_ts = block_timestamp - scan_timestamp_ + point_time_offset;
-                if (point_ts < 0)
-                  point_ts = 0;
-                current_point.time_stamp = static_cast<uint32_t>(point_ts*1e9);
+                if (point_ts < 0) point_ts = 0;
+                current_point.time_stamp = static_cast<uint32_t>(point_ts * 1e9);
                 current_point.intensity = intensity;
                 current_point.distance = distance;
                 scan_pc_->points.emplace_back(current_point);

--- a/nebula_decoders/src/nebula_decoders_velodyne/decoders/vlp32_decoder.cpp
+++ b/nebula_decoders/src/nebula_decoders_velodyne/decoders/vlp32_decoder.cpp
@@ -31,42 +31,45 @@ Vlp32Decoder::Vlp32Decoder(
   phase_ = (uint16_t)round(sensor_configuration_->scan_phase * 100);
 
   timing_offsets_.resize(12);
-  for (size_t i=0; i < timing_offsets_.size(); ++i){
+  for (size_t i = 0; i < timing_offsets_.size(); ++i) {
     timing_offsets_[i].resize(32);
   }
   // constants
-  double full_firing_cycle = 55.296 * 1e-6; // seconds
-  double single_firing = 2.304 * 1e-6; // seconds
+  double full_firing_cycle = 55.296 * 1e-6;  // seconds
+  double single_firing = 2.304 * 1e-6;       // seconds
   double dataBlockIndex, dataPointIndex;
   bool dual_mode = sensor_configuration_->return_mode == ReturnMode::DUAL;
   // compute timing offsets
-  for (size_t x = 0; x < timing_offsets_.size(); ++x){
-    for (size_t y = 0; y < timing_offsets_[x].size(); ++y){
-      if (dual_mode){
+  for (size_t x = 0; x < timing_offsets_.size(); ++x) {
+    for (size_t y = 0; y < timing_offsets_[x].size(); ++y) {
+      if (dual_mode) {
         dataBlockIndex = x / 2;
-      }
-      else{
+      } else {
         dataBlockIndex = x;
       }
       dataPointIndex = y / 2;
-      timing_offsets_[x][y] = (full_firing_cycle * dataBlockIndex) + (single_firing * dataPointIndex);
+      timing_offsets_[x][y] =
+        (full_firing_cycle * dataBlockIndex) + (single_firing * dataPointIndex);
     }
   }
 }
 
-bool Vlp32Decoder::hasScanned() { return has_scanned_; }
+bool Vlp32Decoder::hasScanned()
+{
+  return has_scanned_;
+}
 
 std::tuple<drivers::NebulaPointCloudPtr, double> Vlp32Decoder::get_pointcloud()
 {
   double phase = angles::from_degrees(sensor_configuration_->scan_phase);
   if (!scan_pc_->points.empty()) {
     auto current_azimuth = scan_pc_->points.back().azimuth;
-    auto phase_diff = (2*M_PI + current_azimuth - phase);
+    auto phase_diff = (2 * M_PI + current_azimuth - phase);
     while (phase_diff < M_PI_2 && !scan_pc_->points.empty()) {
       overflow_pc_->points.push_back(scan_pc_->points.back());
       scan_pc_->points.pop_back();
       current_azimuth = scan_pc_->points.back().azimuth;
-      phase_diff = (2*M_PI + current_azimuth - phase);
+      phase_diff = (2 * M_PI + current_azimuth - phase);
     }
     overflow_pc_->width = overflow_pc_->points.size();
     scan_pc_->width = scan_pc_->points.size();
@@ -75,19 +78,22 @@ std::tuple<drivers::NebulaPointCloudPtr, double> Vlp32Decoder::get_pointcloud()
   return std::make_tuple(scan_pc_, scan_timestamp_);
 }
 
-int Vlp32Decoder::pointsPerPacket() { return BLOCKS_PER_PACKET * SCANS_PER_BLOCK; }
+int Vlp32Decoder::pointsPerPacket()
+{
+  return BLOCKS_PER_PACKET * SCANS_PER_BLOCK;
+}
 
-void Vlp32Decoder::reset_pointcloud(size_t n_pts)
+void Vlp32Decoder::reset_pointcloud(size_t n_pts, [[maybe_unused]] double time_stamp)
 {
   //  scan_pc_.reset(new NebulaPointCloud);
   scan_pc_->points.clear();
   max_pts_ = n_pts * pointsPerPacket();
   scan_pc_->points.reserve(max_pts_);
-  reset_overflow();  // transfer existing overflow points to the cleared pointcloud
+  reset_overflow(time_stamp);  // transfer existing overflow points to the cleared pointcloud
   scan_timestamp_ = -1;
 }
 
-void Vlp32Decoder::reset_overflow()
+void Vlp32Decoder::reset_overflow([[maybe_unused]] double time_stamp)
 {
   // Add the overflow buffer points
   for (size_t i = 0; i < overflow_pc_->points.size(); i++) {
@@ -302,9 +308,8 @@ void Vlp32Decoder::unpack(const velodyne_msgs::msg::VelodynePacket & velodyne_pa
           current_point.azimuth = rotation_radians_[block.rotation];
           current_point.elevation = sin_vert_angle;
           auto point_ts = block_timestamp - scan_timestamp_ + point_time_offset;
-          if (point_ts < 0)
-            point_ts = 0;
-          current_point.time_stamp = static_cast<uint32_t>(point_ts*1e9);
+          if (point_ts < 0) point_ts = 0;
+          current_point.time_stamp = static_cast<uint32_t>(point_ts * 1e9);
           current_point.distance = distance;
           current_point.intensity = intensity;
           scan_pc_->points.emplace_back(current_point);

--- a/nebula_decoders/src/nebula_decoders_velodyne/decoders/vls128_decoder.cpp
+++ b/nebula_decoders/src/nebula_decoders_velodyne/decoders/vls128_decoder.cpp
@@ -116,16 +116,17 @@ void Vls128Decoder::reset_overflow(double time_stamp)
   }
 
   // Add the overflow buffer points
-  for (size_t i = 0; i < overflow_pc_->points.size(); i++) {
-    auto overflow_point = overflow_pc_->points[i];
+  while (overflow_pc_->points.size() > 0) {
+    auto overflow_point = overflow_pc_->points.back();
 
     // The overflow points had the stamps from the previous pointcloud. These need to be changed to
     // be relative to the overflow's packet timestamp
     double new_timestamp_seconds =
       scan_timestamp_ + 1e-9 * overflow_point.time_stamp - last_block_timestamp_;
-    overflow_point.time_stamp = 1e9 * new_timestamp_seconds;
+    overflow_point.time_stamp = new_timestamp_seconds < 0.0 ? 0.0 : 1e9 * new_timestamp_seconds;
 
     scan_pc_->points.emplace_back(overflow_point);
+    overflow_pc_->points.pop_back();
   }
 
   // When there is overflow, the timestamp becomes the overflow packets' one

--- a/nebula_decoders/src/nebula_decoders_velodyne/decoders/vls128_decoder.cpp
+++ b/nebula_decoders/src/nebula_decoders_velodyne/decoders/vls128_decoder.cpp
@@ -36,37 +36,42 @@ Vls128Decoder::Vls128Decoder(
   }
   // timing table calculation, from velodyne user manual p.64
   timing_offsets_.resize(3);
-  for(size_t i=0; i < timing_offsets_.size(); ++i)
-  {
-    timing_offsets_[i].resize(17); // 17 (+1 for the maintenance time after firing group 8)
+  for (size_t i = 0; i < timing_offsets_.size(); ++i) {
+    timing_offsets_[i].resize(17);  // 17 (+1 for the maintenance time after firing group 8)
   }
   double full_firing_cycle_s = 53.3 * 1e-6;
   double single_firing_s = 2.665 * 1e-6;
   double offset_packet_time = 8.7 * 1e-6;
   // compute timing offsets
-  for (size_t x = 0; x < timing_offsets_.size(); ++x){
-    for (size_t y = 0; y < timing_offsets_[x].size(); ++y){
+  for (size_t x = 0; x < timing_offsets_.size(); ++x) {
+    for (size_t y = 0; y < timing_offsets_[x].size(); ++y) {
       double sequence_index, firing_group_index;
       sequence_index = x;
       firing_group_index = y;
-      timing_offsets_[x][y] = (full_firing_cycle_s * sequence_index) + (single_firing_s * firing_group_index) - offset_packet_time;
+      timing_offsets_[x][y] = (full_firing_cycle_s * sequence_index) +
+                              (single_firing_s * firing_group_index) - offset_packet_time;
     }
   }
 }
 
-bool Vls128Decoder::hasScanned() { return has_scanned_; }
+bool Vls128Decoder::hasScanned()
+{
+  return has_scanned_;
+}
 
 std::tuple<drivers::NebulaPointCloudPtr, double> Vls128Decoder::get_pointcloud()
 {
   double phase = angles::from_degrees(sensor_configuration_->scan_phase);
   if (!scan_pc_->points.empty()) {
     auto current_azimuth = scan_pc_->points.back().azimuth;
-    auto phase_diff = static_cast<size_t>(angles::to_degrees(2*M_PI + current_azimuth - phase)) % 360;
+    auto phase_diff =
+      static_cast<size_t>(angles::to_degrees(2 * M_PI + current_azimuth - phase)) % 360;
     while (phase_diff < M_PI_2 && !scan_pc_->points.empty()) {
       overflow_pc_->points.push_back(scan_pc_->points.back());
       scan_pc_->points.pop_back();
       current_azimuth = scan_pc_->points.back().azimuth;
-      phase_diff = static_cast<size_t>(angles::to_degrees(2*M_PI + current_azimuth - phase)) % 360;
+      phase_diff =
+        static_cast<size_t>(angles::to_degrees(2 * M_PI + current_azimuth - phase)) % 360;
     }
     overflow_pc_->width = overflow_pc_->points.size();
     scan_pc_->width = scan_pc_->points.size();
@@ -75,24 +80,56 @@ std::tuple<drivers::NebulaPointCloudPtr, double> Vls128Decoder::get_pointcloud()
   return std::make_tuple(scan_pc_, scan_timestamp_);
 }
 
-int Vls128Decoder::pointsPerPacket() { return BLOCKS_PER_PACKET * SCANS_PER_BLOCK; }
+int Vls128Decoder::pointsPerPacket()
+{
+  return BLOCKS_PER_PACKET * SCANS_PER_BLOCK;
+}
 
-void Vls128Decoder::reset_pointcloud(size_t n_pts)
+void Vls128Decoder::reset_pointcloud(size_t n_pts, double time_stamp)
 {
   //  scan_pc_.reset(new NebulaPointCloud);
   scan_pc_->points.clear();
   max_pts_ = n_pts * pointsPerPacket();
   scan_pc_->points.reserve(max_pts_);
-  reset_overflow();  // transfer existing overflow points to the cleared pointcloud
-  scan_timestamp_ = -1;
+  reset_overflow(time_stamp);  // transfer existing overflow points to the cleared pointcloud
 }
 
-void Vls128Decoder::reset_overflow()
+void Vls128Decoder::reset_overflow(double time_stamp)
 {
+  if (overflow_pc_->points.size() == 0) {
+    scan_timestamp_ = -1;
+    overflow_pc_->points.reserve(max_pts_);
+    return;
+  }
+
+  // Compute the absolute time stamp of the last point of the overflow pointcloud
+  const double last_overflow_time_stamp =
+    scan_timestamp_ + 1e-9 * overflow_pc_->points.back().time_stamp;
+
+  // Detect cases where there in an inacceptable time differente between the last overflow point and
+  // the first point of the next packet. In that case, there was probably a packet drop so it is
+  // better to ignore the overflow pointcloud
+  if (time_stamp - last_overflow_time_stamp > 0.05) {
+    scan_timestamp_ = -1;
+    overflow_pc_->points.clear();
+    overflow_pc_->points.reserve(max_pts_);
+  }
+
   // Add the overflow buffer points
   for (size_t i = 0; i < overflow_pc_->points.size(); i++) {
-    scan_pc_->points.emplace_back(overflow_pc_->points[i]);
+    auto overflow_point = overflow_pc_->points[i];
+
+    // The overflow points had the stamps from the previous pointcloud. These need to be changed to
+    // be relative to the overflow's packet timestamp
+    double new_timestamp =
+      scan_timestamp_ + 1e-9 * overflow_point.time_stamp - last_block_timestamp_;
+    overflow_point.time_stamp = 1e-9 * new_timestamp;
+
+    scan_pc_->points.emplace_back(overflow_point);
   }
+
+  // When there is overflow, the timestamp becomes the overflow packets' one
+  scan_timestamp_ = last_block_timestamp_;
   overflow_pc_->points.clear();
   overflow_pc_->points.reserve(max_pts_);
 }
@@ -243,10 +280,12 @@ void Vls128Decoder::unpack(const velodyne_msgs::msg::VelodynePacket & velodyne_p
               const float z_coord = distance * sin_vert_angle;       // velodyne z
               const uint8_t intensity = current_block.data[k + 2];
               auto block_timestamp = rclcpp::Time(velodyne_packet.stamp).seconds();
+              last_block_timestamp_ = block_timestamp;
               if (scan_timestamp_ < 0) {
                 scan_timestamp_ = block_timestamp;
               }
-              double point_time_offset = timing_offsets_[block / 4][firing_order + laser_number / 64];
+              double point_time_offset =
+                timing_offsets_[block / 4][firing_order + laser_number / 64];
 
               // Determine return type.
               uint8_t return_type;
@@ -297,9 +336,8 @@ void Vls128Decoder::unpack(const velodyne_msgs::msg::VelodynePacket & velodyne_p
               current_point.elevation = sin_vert_angle;
               current_point.distance = distance;
               auto point_ts = block_timestamp - scan_timestamp_ + point_time_offset;
-              if (point_ts < 0)
-                point_ts = 0;
-              current_point.time_stamp = static_cast<uint32_t>(point_ts*1e9);
+              if (point_ts < 0) point_ts = 0;
+              current_point.time_stamp = static_cast<uint32_t>(point_ts * 1e9);
               current_point.intensity = intensity;
               scan_pc_->points.emplace_back(current_point);
             }  // 2nd scan area condition

--- a/nebula_decoders/src/nebula_decoders_velodyne/decoders/vls128_decoder.cpp
+++ b/nebula_decoders/src/nebula_decoders_velodyne/decoders/vls128_decoder.cpp
@@ -106,7 +106,7 @@ void Vls128Decoder::reset_overflow(double time_stamp)
   const double last_overflow_time_stamp =
     scan_timestamp_ + 1e-9 * overflow_pc_->points.back().time_stamp;
 
-  // Detect cases where there in an inacceptable time differente between the last overflow point and
+  // Detect cases where there in an unacceptable time difference between the last overflow point and
   // the first point of the next packet. In that case, there was probably a packet drop so it is
   // better to ignore the overflow pointcloud
   if (time_stamp - last_overflow_time_stamp > 0.05) {

--- a/nebula_decoders/src/nebula_decoders_velodyne/decoders/vls128_decoder.cpp
+++ b/nebula_decoders/src/nebula_decoders_velodyne/decoders/vls128_decoder.cpp
@@ -121,9 +121,9 @@ void Vls128Decoder::reset_overflow(double time_stamp)
 
     // The overflow points had the stamps from the previous pointcloud. These need to be changed to
     // be relative to the overflow's packet timestamp
-    double new_timestamp =
+    double new_timestamp_seconds =
       scan_timestamp_ + 1e-9 * overflow_point.time_stamp - last_block_timestamp_;
-    overflow_point.time_stamp = 1e-9 * new_timestamp;
+    overflow_point.time_stamp = 1e9 * new_timestamp_seconds;
 
     scan_pc_->points.emplace_back(overflow_point);
   }

--- a/nebula_decoders/src/nebula_decoders_velodyne/decoders/vls128_decoder.cpp
+++ b/nebula_decoders/src/nebula_decoders_velodyne/decoders/vls128_decoder.cpp
@@ -106,7 +106,7 @@ void Vls128Decoder::reset_overflow(double time_stamp)
   const double last_overflow_time_stamp =
     scan_timestamp_ + 1e-9 * overflow_pc_->points.back().time_stamp;
 
-  // Detect cases where there in an unacceptable time difference between the last overflow point and
+  // Detect cases where there is an unacceptable time difference between the last overflow point and
   // the first point of the next packet. In that case, there was probably a packet drop so it is
   // better to ignore the overflow pointcloud
   if (time_stamp - last_overflow_time_stamp > 0.05) {

--- a/nebula_decoders/src/nebula_decoders_velodyne/decoders/vls128_decoder.cpp
+++ b/nebula_decoders/src/nebula_decoders_velodyne/decoders/vls128_decoder.cpp
@@ -123,7 +123,7 @@ void Vls128Decoder::reset_overflow(double time_stamp)
     // be relative to the overflow's packet timestamp
     double new_timestamp_seconds =
       scan_timestamp_ + 1e-9 * overflow_point.time_stamp - last_block_timestamp_;
-    overflow_point.time_stamp = new_timestamp_seconds < 0.0 ? 0.0 : 1e9 * new_timestamp_seconds;
+    overflow_point.time_stamp = static_cast<uint32_t>(new_timestamp_seconds < 0.0 ? 0.0 : 1e9 * new_timestamp_seconds);
 
     scan_pc_->points.emplace_back(overflow_point);
     overflow_pc_->points.pop_back();

--- a/nebula_decoders/src/nebula_decoders_velodyne/velodyne_driver.cpp
+++ b/nebula_decoders/src/nebula_decoders_velodyne/velodyne_driver.cpp
@@ -53,7 +53,8 @@ std::tuple<drivers::NebulaPointCloudPtr, double> VelodyneDriver::ConvertScanToPo
 {
   std::tuple<drivers::NebulaPointCloudPtr, double> pointcloud;
   if (driver_status_ == nebula::Status::OK) {
-    scan_decoder_->reset_pointcloud(velodyne_scan->packets.size());
+    scan_decoder_->reset_pointcloud(
+      velodyne_scan->packets.size(), rclcpp::Time(velodyne_scan->packets.front().stamp).seconds());
     for (auto & packet : velodyne_scan->packets) {
       scan_decoder_->unpack(packet);
     }
@@ -63,7 +64,10 @@ std::tuple<drivers::NebulaPointCloudPtr, double> VelodyneDriver::ConvertScanToPo
   }
   return pointcloud;
 }
-Status VelodyneDriver::GetStatus() { return driver_status_; }
+Status VelodyneDriver::GetStatus()
+{
+  return driver_status_;
+}
 
 }  // namespace drivers
 }  // namespace nebula


### PR DESCRIPTION
The timestamps in the vls128 were still relative to the last pointcloud, which was producing some errors Additionally, when entire scans were dropped, the overflow was not being handled correctly (this bug was also present in the awf velodyne driver)

## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Bug Fix

## Related Links
[TIER IV INTERNAL LINK (discussion)](https://star4.slack.com/archives/C057JDFS5M2/p1703655034662449)
[TIER IV INTERNAL LINK (footage)](https://drive.google.com/drive/folders/1sB3iTCVo9Z4ysu-HwtBLWnPHRN3Vmk6_?usp=drive_link)

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description
2 bugs were discovered and addressed related to the handling of time stamps during pointcloud overflow between scans.
Context: 
 - The lidar scan has an azimuth value (the origin is defined by the sensor) and usually a pointcloud would start at 0 degrees and end in 360 degrees. 
 - However, to synchronize multiple lidars and cameras we can actually make pointclouds  starting from a different angle.
 - Since the communication with the sensor is via "small" packets instead of a single packet per physical scan (360 degrees) we can decide how to assemble the packets into a pointcloud (e.g, start making a pointcloud starting from sensor angle = 30 degrees).
 - However, since each packet contains several points with different azimuth values, we need to handle one packet in two poinclouds (we call this concept overflow). Example: a certain packet contains points both lower and higher than a desired azimuth threshold. Lower values are added to the current pointcloud, whereas the higher ones need to be handled by the next one.

Nebula-only problem:
 - When a scan message arrives at the decoder, the absolute time stamp gets taken from the first block of the first package in the scan message. In nebula (velodyne_points), each individual point has a relative time stamp, and they are relative to the previously stated absolute time stamp.
 - However, the points that were determined to be part of the next pointcloud (overflow) currently retain their relative timestamp. Since they are the last points of the scan, they actually have relative times close to 100ms (the highest value, since physical scans run at 10hz).
 - When the next scan message arrives, the process is repeated once again, but this time, the first points of the pointcloud will have a very high relative time, followed by points with relative time close to 0 and increasing to almost 100ms (there is a discontinuity).

Although only the non-overflow points are OK, if we use algorithms that integrate timestamps from all the points starting from the beginning (overflow points), it will cause big errors. This was particularly observed in the distortion correction algorithm (see the provided videos)

The solution simply consists of using as global timestamp the stamp of the overflow points (some conversions were required).

Nebula & old vls driver problem:
 - In the vehicle, due to how pointcloud containers work, "there are no dropped packages". All packets from the lidar end up being converted into pointclouds.
 - However, when recording and replaying rosbags, some entire scans (aggregation of sensor packets corresponding to one physical 360 degree scan) can be missing.
 - In this case, even using the previews fix, errors still occur, since the overflow packets are used to determine the global time stamp, but since the points following the overflow are missing, the points after the overflow corresponds to the ones of the next physical scan, which makes a total time difference between the first and last point of the pointcloud of about 200ms (two scans).

For this problem, the proposed solution is that we first detect dropped packages using a rough stamp criteria, and then just ignore the last pointcloud's overflow when necessary (since there are abut 600 packages per scan, we are only loosing 360 * 1 / 600 degrees of information)


<!-- Describe what this PR changes. -->

## Review Procedure
A good way to check that the timestamps are being computed correctly, is comparing the raw_pointcloud with the output of the distortion corrector of autoware.

For example, it would be convenient to compare the behavior of the output of the distortion correction before/after this PR
(additionally, the fix for the original vls implementation also serves as a good baseline https://github.com/knzo25/awf_velodyne/tree/fix/drop_packages_fix )




<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [x] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
