### PR TITLE
fix(nebula_ros): remove calibration file argument from robosense launch

### DIFF
--- a/nebula_ros/launch/robosense_launch.all_hw.xml
+++ b/nebula_ros/launch/robosense_launch.all_hw.xml
@@ -5,8 +5,6 @@
     <arg name="frame_id" default="robosense"/>
     <arg name="scan_phase" default="0.0"/>
 
-    <arg name="calibration_file" default="$(find-pkg-share nebula_decoders)/calibration/robosense/Helios5515.csv"/>
-
     <arg name="sensor_ip" default="192.168.1.202" description="Lidar Sensor IP"/>
     <arg name="host_ip" default="192.168.1.201" description="Broadcast IP from Sensor"/>
     <arg name="data_port" default="6701" description="LiDAR Data Port"/>


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Bug Fix

## Related Links
Fixes: https://github.com/tier4/nebula/issues/115

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description

<!-- Describe what this PR changes. -->

Since Robosense lidars provides calibration data via DIFOP packets, we don't require a calibration file. Every time the driver is started, calibration data is parsed from incoming DIFOP packets.

The calibration file argument was added during development process and removed after further developments. Currently, Robosense driver doesn't use them.

## Review Procedure

<!-- Explain how to review this PR. -->

The Robosense launch file should make the driver launch without errors.

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
