### PR TITLE
build: make #include <angles/angles.h> internal to cpp file

### DIFF
--- a/nebula_decoders/CMakeLists.txt
+++ b/nebula_decoders/CMakeLists.txt
@@ -14,6 +14,7 @@ if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_compile_options(-Wall -Wextra -Wpedantic -Wunused-function)
 endif ()
 
+find_package(angles REQUIRED)
 find_package(PCL REQUIRED)
 find_package(pcl_conversions REQUIRED)
 find_package(yaml-cpp REQUIRED)

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/decoders/velodyne_scan_decoder.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/decoders/velodyne_scan_decoder.hpp
@@ -12,12 +12,6 @@
 #include <string>
 #include <vector>
 
-#if defined(ROS_DISTRO_FOXY) || defined(ROS_DISTRO_GALACTIC)
-#include <angles/angles.h>  //Galactic
-#else
-#include <angles/angles/angles.h>  //Humble
-#endif
-
 #include "nebula_common/point_types.hpp"
 #include "nebula_common/velodyne/velodyne_calibration_decoder.hpp"
 #include "nebula_common/velodyne/velodyne_common.hpp"

--- a/nebula_decoders/src/nebula_decoders_velodyne/decoders/vlp16_decoder.cpp
+++ b/nebula_decoders/src/nebula_decoders_velodyne/decoders/vlp16_decoder.cpp
@@ -3,6 +3,8 @@
 #include <cmath>
 #include <utility>
 
+#include <angles/angles.h> 
+
 namespace nebula
 {
 namespace drivers

--- a/nebula_decoders/src/nebula_decoders_velodyne/decoders/vlp32_decoder.cpp
+++ b/nebula_decoders/src/nebula_decoders_velodyne/decoders/vlp32_decoder.cpp
@@ -3,6 +3,8 @@
 #include <cmath>
 #include <utility>
 
+#include <angles/angles.h> 
+
 namespace nebula
 {
 namespace drivers

--- a/nebula_decoders/src/nebula_decoders_velodyne/decoders/vls128_decoder.cpp
+++ b/nebula_decoders/src/nebula_decoders_velodyne/decoders/vls128_decoder.cpp
@@ -3,6 +3,8 @@
 #include <cmath>
 #include <utility>
 
+#include <angles/angles.h> 
+
 namespace nebula
 {
 namespace drivers


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Improvement

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description

<!-- Describe what this PR changes. -->

before this PR, `angles/angles.h` is included in a public header file of `velodyne_scan_decoder.hpp`, so that any project that uses this repo needs to include `angles` as well.

After this PR, `angles/angles.h` is moved to .cpp files, so it's internal to this repo. Other project that uses this repo does not need to find and include `angles`.

This can reduce compile time for both colcon/cmake and gcc.

Another minor change is the 
```
#if defined(ROS_DISTRO_FOXY) || defined(ROS_DISTRO_GALACTIC)
#include <angles/angles.h>  //Galactic
#else
#include <angles/angles/angles.h>  //Humble
#endif
```
which is not necessary if `angles` is installed according to https://github.com/ros/rosdistro/blob/master/humble/distribution.yaml#L403

Many other ros2 projects are not using `#if/#endif` for humble like https://github.com/ros-planning/navigation2/blob/humble/nav2_controller/plugins/pose_progress_checker.cpp#L20
## Review Procedure

build this project

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [x] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [x] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [x] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
