### PR TITLE
fix(log-messages): reduce excessive log messages in velodyne decoder

### DIFF
--- a/nebula_common/include/nebula_common/velodyne/velodyne_calibration_decoder.hpp
+++ b/nebula_common/include/nebula_common/velodyne/velodyne_calibration_decoder.hpp
@@ -59,15 +59,14 @@ public:
   std::vector<VelodyneLaserCorrection> laser_corrections;
   int num_lasers{};
   bool initialized;
-  bool ros_info;
 
 public:
-  explicit VelodyneCalibration(bool info = true)
-  : distance_resolution_m(0.002f), initialized(false), ros_info(info)
+  explicit VelodyneCalibration()
+  : distance_resolution_m(0.002f), initialized(false)
   {
   }
-  explicit VelodyneCalibration(const std::string & calibration_file, bool info = true)
-  : distance_resolution_m(0.002f), ros_info(info)
+  explicit VelodyneCalibration(const std::string & calibration_file)
+  : distance_resolution_m(0.002f)
   {
     read(calibration_file);
   }

--- a/nebula_common/src/velodyne/velodyne_calibration_decoder.cpp
+++ b/nebula_common/src/velodyne/velodyne_calibration_decoder.cpp
@@ -162,10 +162,6 @@ void operator>>(const YAML::Node & node, VelodyneCalibration & calibration)
       // store this ring number with its corresponding laser number
       calibration.laser_corrections[next_index].laser_ring = ring;
       next_angle = min_seen;
-      if (calibration.ros_info) {
-        std::cout << "laser_ring[" << next_index << "] =" << ring << ", angle = " << next_angle
-                  << std::endl;
-      }
     }
   }
 }

--- a/nebula_decoders/src/nebula_decoders_velodyne/velodyne_driver.cpp
+++ b/nebula_decoders/src/nebula_decoders_velodyne/velodyne_driver.cpp
@@ -14,8 +14,6 @@ VelodyneDriver::VelodyneDriver(
 {
   // initialize proper parser from cloud config's model and echo mode
   driver_status_ = nebula::Status::OK;
-  std::cout << "sensor_configuration->sensor_model=" << sensor_configuration->sensor_model
-            << std::endl;
   switch (sensor_configuration->sensor_model) {
     case SensorModel::UNKNOWN:
       driver_status_ = nebula::Status::INVALID_SENSOR_MODEL;

--- a/nebula_ros/src/velodyne/velodyne_decoder_ros_wrapper.cpp
+++ b/nebula_ros/src/velodyne/velodyne_decoder_ros_wrapper.cpp
@@ -15,19 +15,19 @@ VelodyneDriverRosWrapper::VelodyneDriverRosWrapper(const rclcpp::NodeOptions & o
     RCLCPP_ERROR_STREAM(this->get_logger(), this->get_name() << " Error:" << wrapper_status_);
     return;
   }
-  RCLCPP_INFO_STREAM(this->get_logger(), this->get_name() << ". Starting...");
+  RCLCPP_DEBUG_STREAM(this->get_logger(), this->get_name() << ". Starting...");
 
   calibration_cfg_ptr_ =
     std::make_shared<drivers::VelodyneCalibrationConfiguration>(calibration_configuration);
 
   sensor_cfg_ptr_ = std::make_shared<drivers::VelodyneSensorConfiguration>(sensor_configuration);
 
-  RCLCPP_INFO_STREAM(this->get_logger(), this->get_name() << ". Driver ");
+  RCLCPP_DEBUG_STREAM(this->get_logger(), this->get_name() << ". Driver ");
   wrapper_status_ = InitializeDriver(
     std::const_pointer_cast<drivers::SensorConfigurationBase>(sensor_cfg_ptr_),
     std::static_pointer_cast<drivers::CalibrationConfigurationBase>(calibration_cfg_ptr_));
 
-  RCLCPP_INFO_STREAM(this->get_logger(), this->get_name() << "Wrapper=" << wrapper_status_);
+  RCLCPP_DEBUG_STREAM(this->get_logger(), this->get_name() << "Wrapper=" << wrapper_status_);
 
   velodyne_scan_sub_ = create_subscription<velodyne_msgs::msg::VelodyneScan>(
     "velodyne_packets", rclcpp::SensorDataQoS(),


### PR DESCRIPTION
## PR Type
- Improvement

## Related Links
More details in this [autoware issue](https://github.com/autowarefoundation/autoware.universe/issues/5539) and this [nebula issue](https://github.com/tier4/nebula/issues/122).

## Description
This PR is one of a group of PRs that aim to fix the Autoware logging system to reduce excessive error and warning logs on Autoware launch only on the Velodyne decoder.

Part of:
- https://github.com/autowarefoundation/autoware.universe/issues/5539
## Review Procedure
- Planning Simulation
  - Run [Autoware planning simulator](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/planning-simulation/), and you can see no more excessive and recurring errors, warnings, and info messages when the system running as expected
- Rosbag Replay Simulation
  - Run [Autoware rosbag repay simulation](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/) and you can see no more excessive and recurring error, warning, and info message when the system running as expected
- AWSIM
  - To be addressed in another PR - extended goal)

## Remarks
Take into consideration relevant PRs.
<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to a reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
