### PR TITLE
fix(hesai_hw_monitor): fix 2s drops issue - again

### DIFF
--- a/nebula_ros/include/nebula_ros/hesai/hesai_hw_monitor_ros_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/hesai/hesai_hw_monitor_ros_wrapper.hpp
@@ -109,8 +109,7 @@ private:
 
   rclcpp::TimerBase::SharedPtr diagnostics_update_timer_;
   rclcpp::TimerBase::SharedPtr diagnostics_update_monitor_timer_;
-  rclcpp::TimerBase::SharedPtr diagnostics_status_timer_;
-  rclcpp::TimerBase::SharedPtr diagnostics_lidar_monitor_timer_;
+  rclcpp::TimerBase::SharedPtr fetch_diagnostics_timer_;
   std::unique_ptr<HesaiLidarStatus> current_status;
   std::unique_ptr<HesaiLidarMonitor> current_monitor;
   std::unique_ptr<HesaiConfig> current_config;

--- a/nebula_ros/launch/hesai_launch_all_hw.xml
+++ b/nebula_ros/launch/hesai_launch_all_hw.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <launch>
-    <arg name="launch_hw" default="True" />
+    <arg name="launch_hw" default="true" />
     <arg name="sensor_model" description="Pandar64|Pandar40P|PandarXT32|PandarXT32M|PandarAT128|PandarQT64|PandarQT128|Pandar128E4X"/>
     <arg name="return_mode" default="Dual" description="See readme for supported return modes"/>
     <arg name="frame_id"  default="hesai"/>

--- a/nebula_ros/launch/hesai_launch_component.launch.xml
+++ b/nebula_ros/launch/hesai_launch_component.launch.xml
@@ -85,6 +85,31 @@
                 <extra_arg name="use_intra_process_comms" value="true" />
             </composable_node>
         </load_composable_node>
+
+        <load_composable_node target="PandarContainer">
+            <composable_node pkg="nebula_ros" 
+                             plugin="HesaiHwMonitorRosWrapper"
+                             name="PandarMon" 
+                             namespace="/">
+                <param name="sensor_model" value="$(var sensor_model)"/>
+                <param name="return_mode" value="$(var return_mode)"/>
+                <param name="frame_id" value="$(var frame_id)"/>
+                <param name="scan_phase" value="$(var scan_phase)"/>
+                <param name="sensor_ip" value="$(var sensor_ip)"/>
+                <param name="frame_id" value="$(var frame_id)"/>
+                <param name="host_ip" value="$(var host_ip)"/>
+                <param name="data_port" value="$(var data_port)"/>
+                <param name="gnss_port" value="$(var gnss_port)"/>
+                <param name="packet_mtu_size" value="$(var packet_mtu_size)"/>
+                <param name="rotation_speed" value="$(var rotation_speed)"/>
+                <param name="cloud_min_angle" value="$(var cloud_min_angle)"/>
+                <param name="cloud_max_angle" value="$(var cloud_max_angle)"/>
+                <param name="diag_span" value="$(var diag_span)"/>
+                <param name="dual_return_distance_threshold" value="$(var dual_return_distance_threshold)"/>
+                <param name="delay_monitor_ms" value="$(var delay_monitor_ms)"/>
+                <extra_arg name="use_intra_process_comms" value="true" />
+            </composable_node>
+        </load_composable_node>
     </group>
 
 </launch>


### PR DESCRIPTION
## PR Type

- Bug Fix

## Related Links

* #126 -- last attempted fix
* [TIER IV INTERNAL LINK](https://tier4.atlassian.net/wiki/x/JwRxtQ) -- detailed troubleshooting

## Description

This PR fixes the OT128's 2s UDP packet drop issue (again, this time for node containers).
The culprit was a race condition between the HW monitor's `OnHesaiStatusTimer()` and `OnHesaiLidarMonitorTimer()` callbacks, which both access the non-thread-safe HW interface.
(Thread-safety will _probably_ be fixed by #131 as the `SendReceive()` function should be thread-safe there, as a side-effect of the other fixes made.)

Due to the race condition, the callbacks got into a deadlock, causing all TCP communication from HW monitor to stop. HW monitor is the only source of constant TCP traffic to the sensor (once per `diag_span`, default 1s) and is thought to refresh the sensor's ARP cache. When the monitor stops, after 1 minute the sensor sends 2 duplicate ARP requests (which are presumably a bug on the sensor side), causing the sensor to stop sending UDP packets for 2s.

The fix in this PR is to merge the two above-mentioned callbacks into a unified one:
```c++
[this](){
  OnHesaiStatusTimer();
  OnHesaiLidarMonitorTimer();
}
```
This gets rid of the sensor's duplicate ARP requests and 2s drops once per minute.

## Review Procedure

Run Nebula with OT128 once with, once without this PR (using `hesai_launch_component.launch.xml`) and confirm in `Wireshark -> Statistics -> I/O Graphs` that once per minute there is a 2s drop without this PR, and no such drop with this PR.

## Remarks

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
