### PR TITLE
fix: non steady clock and watchdog

### DIFF
--- a/nebula_ros/include/nebula_ros/common/watchdog_timer.hpp
+++ b/nebula_ros/include/nebula_ros/common/watchdog_timer.hpp
@@ -36,7 +36,9 @@ private:
   {
     uint64_t now_ns = node_.get_clock()->now().nanoseconds();
 
-    bool is_late = (now_ns - last_update_ns_) > expected_update_interval_ns_;
+    bool is_late = (last_update_ns_ > now_ns)
+                     ? false
+                     : (now_ns - last_update_ns_) > expected_update_interval_ns_;
 
     callback_(!is_late);
   }

--- a/nebula_ros/include/nebula_ros/common/watchdog_timer.hpp
+++ b/nebula_ros/include/nebula_ros/common/watchdog_timer.hpp
@@ -36,6 +36,8 @@ private:
   {
     uint64_t now_ns = node_.get_clock()->now().nanoseconds();
 
+    // As the clock is not steady, the update timestamp can be newer than clock.now().
+    // Define that edge-case as not being late too.
     bool is_late = (last_update_ns_ > now_ns)
                      ? false
                      : (now_ns - last_update_ns_) > expected_update_interval_ns_;


### PR DESCRIPTION

## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Bug Fix

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description
The callback was being called even though there were frequent updates to the watchdog.
Printing the stamps, the latest stamp was newer than now. Ros time is not steady and it seems ptp affecting the watchdog's time


<!-- Describe what this PR changes. -->

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
