### PR TITLE
fix: make Nebula Clang-compatible

### DIFF
--- a/nebula_common/include/nebula_common/continental/continental_ars548.hpp
+++ b/nebula_common/include/nebula_common/continental/continental_ars548.hpp
@@ -579,7 +579,7 @@ struct FilterStatusPacket
 
 #pragma pack(pop)
 
-struct PointARS548Detection
+struct EIGEN_ALIGN16 PointARS548Detection
 {
   PCL_ADD_POINT4D;
   float azimuth;
@@ -598,11 +598,11 @@ struct PointARS548Detection
   uint16_t object_id;
   uint8_t ambiguity_flag;
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-} EIGEN_ALIGN16;
+};
 
 // Note we only use a subset of the data since POINT_CLOUD_REGISTER_POINT_STRUCT has a limit in the
 // number of fields
-struct PointARS548Object
+struct EIGEN_ALIGN16 PointARS548Object
 {
   PCL_ADD_POINT4D;
   uint32_t id;
@@ -623,7 +623,7 @@ struct PointARS548Object
   float shape_width_edge_mean;
   float dynamics_orientation_rate_mean;
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-} EIGEN_ALIGN16;
+};
 
 }  // namespace continental_ars548
 }  // namespace drivers

--- a/nebula_common/include/nebula_common/point_types.hpp
+++ b/nebula_common/include/nebula_common/point_types.hpp
@@ -8,13 +8,13 @@ namespace nebula
 {
 namespace drivers
 {
-struct PointXYZIR
+struct EIGEN_ALIGN16 PointXYZIR
 {
   PCL_ADD_POINT4D;
   float intensity;
   uint16_t ring;
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-} EIGEN_ALIGN16;
+};
 
 struct PointXYZICATR
 {
@@ -43,7 +43,7 @@ struct PointXYZIRCAEDT
   std::uint32_t time_stamp;
 };
 
-struct PointXYZIRADT
+struct EIGEN_ALIGN16 PointXYZIRADT
 {
   PCL_ADD_POINT4D;
   float intensity;
@@ -53,7 +53,7 @@ struct PointXYZIRADT
   uint8_t return_type;
   double time_stamp;
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-} EIGEN_ALIGN16;
+};
 
 using NebulaPoint = PointXYZIRCAEDT;
 using NebulaPointPtr = std::shared_ptr<NebulaPoint>;


### PR DESCRIPTION
## PR Type

- Improvement
- Bug Fix

## Related Links

* Fixes #157 
* For reference: [the same fix in PCL](https://github.com/PointCloudLibrary/pcl/pull/3237)

## Description

This PR moves the `EIGEN_ALIGN16` from behind point structs to after the `struct` keyword, remaining compatible with GCC while enabling compilation with Clang (and enabling usage of all the great Clang tools :tada:)

:warning: Note: Nebula still does not compile on the newest Clang version (18) due to a tricky error in `transport_drivers`. The newest version I have tested with is Clang 15.

## Review Procedure

The code should still compile on GCC, but now compiles on Clang as well.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
