### PR TITLE
feat(nebula_ros): force fp parameters for numerics

### DIFF
--- a/nebula_ros/include/nebula_ros/common/parameter_descriptors.hpp
+++ b/nebula_ros/include/nebula_ros/common/parameter_descriptors.hpp
@@ -21,6 +21,10 @@ rcl_interfaces::msg::ParameterDescriptor::_floating_point_range_type float_range
 rcl_interfaces::msg::ParameterDescriptor::_integer_range_type int_range(
   int start, int stop, int step);
 
+double declare_fp_parameter(
+  rclcpp::Node * node, const std::string & name,
+  rcl_interfaces::msg::ParameterDescriptor descriptor = rcl_interfaces::msg::ParameterDescriptor());
+
 /// @brief Get a parameter's value from a list of parameters, if that parameter is in the list.
 /// @tparam T The parameter's expected value type
 /// @param p A vector of parameters

--- a/nebula_ros/src/common/parameter_descriptors.cpp
+++ b/nebula_ros/src/common/parameter_descriptors.cpp
@@ -30,5 +30,29 @@ rcl_interfaces::msg::ParameterDescriptor::_integer_range_type int_range(
     rcl_interfaces::msg::IntegerRange().set__from_value(start).set__to_value(stop).set__step(step)};
 }
 
+double declare_fp_parameter(
+  rclcpp::Node * node, const std::string & name,
+  rcl_interfaces::msg::ParameterDescriptor descriptor)
+{
+  rclcpp::ParameterValue raw_parameter;
+  descriptor.dynamic_typing = true;
+
+  raw_parameter = node->declare_parameter(name, raw_parameter, descriptor);
+
+  switch (raw_parameter.get_type()) {
+    case rclcpp::ParameterType::PARAMETER_DOUBLE: {
+      return raw_parameter.get<double>();
+    }
+    case rclcpp::ParameterType::PARAMETER_INTEGER: {
+      auto parameter = static_cast<double>(raw_parameter.get<int64_t>());
+      node->undeclare_parameter(name);
+      node->declare_parameter(name, parameter, descriptor, true);
+      return parameter;
+    }
+    default:
+      throw std::runtime_error("Non numeric value");
+  }
+}
+
 }  // namespace ros
 }  // namespace nebula

--- a/nebula_ros/src/continental/continental_ars548_ros_wrapper.cpp
+++ b/nebula_ros/src/continental/continental_ars548_ros_wrapper.cpp
@@ -183,7 +183,7 @@ nebula::Status ContinentalARS548RosWrapper::DeclareAndGetSensorConfigParams()
     descriptor.read_only = true;
     descriptor.dynamic_typing = false;
     descriptor.additional_constraints = "";
-    this->declare_parameter<double>("configuration_vehicle_length", descriptor);
+    declare_fp_parameter(this, "configuration_vehicle_length", descriptor);
     config.configuration_vehicle_length =
       static_cast<float>(this->get_parameter("configuration_vehicle_length").as_double());
   }
@@ -193,7 +193,7 @@ nebula::Status ContinentalARS548RosWrapper::DeclareAndGetSensorConfigParams()
     descriptor.read_only = true;
     descriptor.dynamic_typing = false;
     descriptor.additional_constraints = "";
-    this->declare_parameter<double>("configuration_vehicle_width", descriptor);
+    declare_fp_parameter(this, "configuration_vehicle_width", descriptor);
     config.configuration_vehicle_width =
       static_cast<float>(this->get_parameter("configuration_vehicle_width").as_double());
   }
@@ -203,7 +203,7 @@ nebula::Status ContinentalARS548RosWrapper::DeclareAndGetSensorConfigParams()
     descriptor.read_only = true;
     descriptor.dynamic_typing = false;
     descriptor.additional_constraints = "";
-    this->declare_parameter<double>("configuration_vehicle_height", descriptor);
+    declare_fp_parameter(this, "configuration_vehicle_height", descriptor);
     config.configuration_vehicle_height =
       static_cast<float>(this->get_parameter("configuration_vehicle_height").as_double());
   }
@@ -213,7 +213,7 @@ nebula::Status ContinentalARS548RosWrapper::DeclareAndGetSensorConfigParams()
     descriptor.read_only = true;
     descriptor.dynamic_typing = false;
     descriptor.additional_constraints = "";
-    this->declare_parameter<double>("configuration_vehicle_wheelbase", descriptor);
+    declare_fp_parameter(this, "configuration_vehicle_wheelbase", descriptor);
     config.configuration_vehicle_wheelbase =
       static_cast<float>(this->get_parameter("configuration_vehicle_wheelbase").as_double());
   }

--- a/nebula_ros/src/hesai/hesai_ros_wrapper.cpp
+++ b/nebula_ros/src/hesai/hesai_ros_wrapper.cpp
@@ -82,11 +82,11 @@ nebula::Status HesaiRosWrapper::DeclareAndGetSensorConfigParams()
     rcl_interfaces::msg::ParameterDescriptor descriptor = param_read_write();
     descriptor.additional_constraints = "Angle where scans begin (degrees, [0.,360.])";
     descriptor.floating_point_range = float_range(0, 360, 0.01);
-    config.scan_phase = declare_parameter<double>("scan_phase", descriptor);
+    config.scan_phase = declare_fp_parameter(this, "scan_phase", descriptor);
   }
 
-  config.min_range = declare_parameter<double>("min_range", param_read_write());
-  config.max_range = declare_parameter<double>("max_range", param_read_write());
+  config.min_range = declare_fp_parameter(this, "min_range", param_read_write());
+  config.max_range = declare_fp_parameter(this, "max_range", param_read_write());
   config.packet_mtu_size = declare_parameter<uint16_t>("packet_mtu_size", param_read_only());
 
   {
@@ -117,7 +117,7 @@ nebula::Status HesaiRosWrapper::DeclareAndGetSensorConfigParams()
     descriptor.additional_constraints = "Dual return distance threshold [0.01, 0.5]";
     descriptor.floating_point_range = float_range(0.01, 0.5, 0.01);
     config.dual_return_distance_threshold =
-      declare_parameter<double>("dual_return_distance_threshold", descriptor);
+      declare_fp_parameter(this, "dual_return_distance_threshold", descriptor);
   }
 
   auto _ptp_profile = declare_parameter<std::string>("ptp_profile", param_read_only());

--- a/nebula_ros/src/robosense/robosense_ros_wrapper.cpp
+++ b/nebula_ros/src/robosense/robosense_ros_wrapper.cpp
@@ -82,14 +82,14 @@ nebula::Status RobosenseRosWrapper::DeclareAndGetSensorConfigParams()
     rcl_interfaces::msg::ParameterDescriptor descriptor = param_read_write();
     descriptor.additional_constraints = "Angle where scans begin (degrees, [0.,360.])";
     descriptor.floating_point_range = float_range(0, 360, 0.01);
-    config.scan_phase = declare_parameter<double>("scan_phase", descriptor);
+    config.scan_phase = declare_fp_parameter(this, "scan_phase", descriptor);
   }
   {
     rcl_interfaces::msg::ParameterDescriptor descriptor = param_read_write();
     descriptor.additional_constraints = "Dual return distance threshold [0.01, 0.5]";
     descriptor.floating_point_range = float_range(0.01, 0.5, 0.01);
     config.dual_return_distance_threshold =
-      declare_parameter<double>("dual_return_distance_threshold", descriptor);
+      declare_fp_parameter(this, "dual_return_distance_threshold", descriptor);
   }
 
   auto new_cfg_ptr = std::make_shared<const nebula::drivers::RobosenseSensorConfiguration>(config);

--- a/nebula_ros/src/velodyne/velodyne_ros_wrapper.cpp
+++ b/nebula_ros/src/velodyne/velodyne_ros_wrapper.cpp
@@ -82,11 +82,11 @@ nebula::Status VelodyneRosWrapper::DeclareAndGetSensorConfigParams()
     rcl_interfaces::msg::ParameterDescriptor descriptor = param_read_write();
     descriptor.additional_constraints = "Angle where scans begin (degrees, [0.,360.])";
     descriptor.floating_point_range = float_range(0, 360, 0.01);
-    config.scan_phase = declare_parameter<double>("scan_phase", descriptor);
+    config.scan_phase = declare_fp_parameter(this, "scan_phase", descriptor);
   }
 
-  config.min_range = declare_parameter<double>("min_range", param_read_write());
-  config.max_range = declare_parameter<double>("max_range", param_read_write());
+  config.min_range = declare_fp_parameter(this, "min_range", param_read_write());
+  config.max_range = declare_fp_parameter(this, "max_range", param_read_write());
   config.packet_mtu_size = declare_parameter<uint16_t>("packet_mtu_size", param_read_only());
 
   {


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Improvement

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description
JSON schema does not support floating point numbers  directly. Developers can define only integer or numeric type. Therefore, future unit test based on `check-jsonschema` library will pass integer parameter which were defined as numeric (floating point from ROS node perspective). In that case, dynamic parameter declaration for floating point parameters is required.

Idea:
```
if parameter<double> is double -> declare as usual
if parameter<double> is integer -> cast to double
```

<!-- Describe what this PR changes. -->

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
