### PR TITLE
fix(clang): make build pass with Clang

### DIFF
--- a/nebula_common/include/nebula_common/continental/continental_ars548.hpp
+++ b/nebula_common/include/nebula_common/continental/continental_ars548.hpp
@@ -620,7 +620,7 @@ struct FilterStatusPacket
 
 #pragma pack(pop)
 
-struct PointARS548Detection
+struct EIGEN_ALIGN16 PointARS548Detection
 {
   PCL_ADD_POINT4D;
   float azimuth;
@@ -639,11 +639,11 @@ struct PointARS548Detection
   uint16_t object_id;
   uint8_t ambiguity_flag;
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-} EIGEN_ALIGN16;
+};
 
 // Note we only use a subset of the data since POINT_CLOUD_REGISTER_POINT_STRUCT has a limit in the
 // number of fields
-struct PointARS548Object
+struct EIGEN_ALIGN16 PointARS548Object
 {
   PCL_ADD_POINT4D;
   uint32_t id;
@@ -664,7 +664,7 @@ struct PointARS548Object
   float shape_width_edge_mean;
   float dynamics_orientation_rate_mean;
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-} EIGEN_ALIGN16;
+};
 
 }  // namespace continental_ars548
 }  // namespace drivers

--- a/nebula_common/include/nebula_common/point_types.hpp
+++ b/nebula_common/include/nebula_common/point_types.hpp
@@ -8,13 +8,13 @@ namespace nebula
 {
 namespace drivers
 {
-struct PointXYZIR
+struct EIGEN_ALIGN16 PointXYZIR
 {
   PCL_ADD_POINT4D;
   float intensity;
   uint16_t ring;
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-} EIGEN_ALIGN16;
+};
 
 struct PointXYZICATR
 {
@@ -43,7 +43,7 @@ struct PointXYZIRCAEDT
   std::uint32_t time_stamp;
 };
 
-struct PointXYZIRADT
+struct EIGEN_ALIGN16 PointXYZIRADT
 {
   PCL_ADD_POINT4D;
   float intensity;
@@ -53,7 +53,7 @@ struct PointXYZIRADT
   uint8_t return_type;
   double time_stamp;
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-} EIGEN_ALIGN16;
+};
 
 using NebulaPoint = PointXYZIRCAEDT;
 using NebulaPointPtr = std::shared_ptr<NebulaPoint>;

--- a/nebula_hw_interfaces/src/nebula_continental_hw_interfaces/continental_ars548_hw_interface.cpp
+++ b/nebula_hw_interfaces/src/nebula_continental_hw_interfaces/continental_ars548_hw_interface.cpp
@@ -578,6 +578,14 @@ Status ContinentalARS548HwInterface::SetYawRate(float yaw_rate)
   return Status::OK;
 }
 
+Status ContinentalARS548HwInterface::CheckAndSetConfig()
+{
+  RCLCPP_ERROR(
+    *parent_node_logger,
+    "This functionality is not yet implemented. Sensor is probably out of sync with config now.");
+  return Status::ERROR_1;
+}
+
 void ContinentalARS548HwInterface::SetLogger(std::shared_ptr<rclcpp::Logger> logger)
 {
   parent_node_logger = logger;

--- a/nebula_hw_interfaces/src/nebula_continental_hw_interfaces/multi_continental_ars548_hw_interface.cpp
+++ b/nebula_hw_interfaces/src/nebula_continental_hw_interfaces/multi_continental_ars548_hw_interface.cpp
@@ -406,6 +406,14 @@ Status MultiContinentalARS548HwInterface::SetYawRate(float yaw_rate)
   return Status::OK;
 }
 
+Status MultiContinentalARS548HwInterface::CheckAndSetConfig()
+{
+  RCLCPP_ERROR(
+    *parent_node_logger,
+    "This functionality is not yet implemented. Sensor is probably out of sync with config now.");
+  return Status::ERROR_1;
+}
+
 void MultiContinentalARS548HwInterface::SetLogger(std::shared_ptr<rclcpp::Logger> logger)
 {
   parent_node_logger = logger;


### PR DESCRIPTION
## PR Type

- Improvement
- Bug Fix

## Related Links

Similar PR currently merged in `develop`:
* #160 

## Description

@veqcc wants to analyze Autoware and Nebula using Clang-tooling, this PR is to make this possible before the (possibly long-winded) merge of `develop`.

There were two declared, but undefined member functions in the ARS548 HW interfaces that were addressed in
* #124 

which wouldn't link after compiling with Clang, so I implemented them as printing an error to the console for now (non-breaking change and better than failing silently). @knzo25 please check that this temporary warning is okay.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
