### PR TITLE
docs(readme): add boost version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Here you will find information about the background of the project, how to insta
 
 ## Quick start
 
-Nebula builds with ROS 2 Galactic and Humble. 
+Nebula builds with ROS 2 Galactic and Humble.
 
-> **Note** 
-> 
+> **Note**
+>
 > Boost version 1.74.0 or later is required. A manual install may be required in Ubuntu versions earlier than 22.04.
 
 > **Note**

--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ Here you will find information about the background of the project, how to insta
 
 ## Quick start
 
-Nebula builds with ROS 2 Galactic and Humble.
+Nebula builds with ROS 2 Galactic and Humble. 
+
+> **Note** 
+> 
+> Boost version 1.74.0 or later is required. A manual install may be required in Ubuntu versions earlier than 22.04.
 
 > **Note**
 >

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,8 +7,8 @@ Please see the [ROS 2 documentation](https://docs.ros.org/en/humble/index.html) 
 
 ## Getting the source and building
 
-> **Note** 
-> 
+> **Note**
+>
 > Boost version 1.74.0 or later is required. A manual install may be required in Ubuntu versions earlier than 22.04.
 
 > **Note**

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,6 +7,10 @@ Please see the [ROS 2 documentation](https://docs.ros.org/en/humble/index.html) 
 
 ## Getting the source and building
 
+> **Note** 
+> 
+> Boost version 1.74.0 or later is required. A manual install may be required in Ubuntu versions earlier than 22.04.
+
 > **Note**
 >
 > A [TCP enabled version of ROS' Transport Driver](https://github.com/mojomex/transport_drivers/tree/mutable-buffer-in-udp-callback) is required to use Nebula.


### PR DESCRIPTION
## PR Type

- Improvement

## Description

When trying to install Nebula on Ubuntu 20.04 with manually built Humble, a lot of Boost compile errors were emitted for
`big_float32_buf_t` and `load_little_u16` etc. which are only supported for Boost 1.74.0 and later. Add this requirement to the readme file to avoid trouble in the future.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
