### PR TITLE
fix: lower packet loss to near-zero levels

### DIFF
--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/hesai_packet.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/hesai_packet.hpp
@@ -17,6 +17,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <ctime>
+#include <stdexcept>
 
 namespace nebula
 {

--- a/nebula_decoders/src/nebula_decoders_hesai/hesai_driver.cpp
+++ b/nebula_decoders/src/nebula_decoders_hesai/hesai_driver.cpp
@@ -13,6 +13,8 @@
 #include "nebula_decoders/nebula_decoders_hesai/decoders/pandar_xt32.hpp"
 #include "nebula_decoders/nebula_decoders_hesai/decoders/pandar_xt32m.hpp"
 
+#include <rclcpp/logging.hpp>
+
 // #define WITH_DEBUG_STD_COUT_HESAI_CLIENT // Use std::cout messages for debugging
 
 namespace nebula

--- a/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_hesai/hesai_cmd_response.hpp
+++ b/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_hesai/hesai_cmd_response.hpp
@@ -21,6 +21,7 @@
 
 #include <array>
 #include <cstdint>
+#include <iomanip>
 #include <ostream>
 #include <string>
 

--- a/nebula_ros/include/nebula_ros/hesai/hesai_ros_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/hesai/hesai_ros_wrapper.hpp
@@ -18,8 +18,6 @@
 #include "nebula_common/hesai/hesai_common.hpp"
 #include "nebula_common/nebula_common.hpp"
 #include "nebula_common/nebula_status.hpp"
-#include "nebula_hw_interfaces/nebula_hw_interfaces_hesai/hesai_hw_interface.hpp"
-#include "nebula_ros/common/mt_queue.hpp"
 #include "nebula_ros/common/parameter_descriptors.hpp"
 #include "nebula_ros/hesai/decoder_wrapper.hpp"
 #include "nebula_ros/hesai/hw_interface_wrapper.hpp"
@@ -82,11 +80,6 @@ private:
   Status wrapper_status_;
 
   std::shared_ptr<const nebula::drivers::HesaiSensorConfiguration> sensor_cfg_ptr_{};
-
-  /// @brief Stores received packets that have not been processed yet by the decoder thread
-  mt_queue<std::unique_ptr<nebula_msgs::msg::NebulaPacket>> packet_queue_;
-  /// @brief Thread to isolate decoding from receiving
-  std::thread decoder_thread_;
 
   rclcpp::Subscription<pandar_msgs::msg::PandarScan>::SharedPtr packets_sub_{};
 

--- a/nebula_ros/include/nebula_ros/robosense/decoder_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/robosense/decoder_wrapper.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "nebula_ros/common/mt_queue.hpp"
 #include "nebula_ros/common/watchdog_timer.hpp"
 
 #include <nebula_common/nebula_common.hpp>
@@ -24,6 +25,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <nebula_msgs/msg/nebula_packet.hpp>
+#include <nebula_msgs/msg/nebula_packets.hpp>
 #include <robosense_msgs/msg/robosense_scan.hpp>
 
 #include <chrono>
@@ -51,6 +53,15 @@ public:
   nebula::Status Status();
 
 private:
+  struct PublishData
+  {
+    nebula_msgs::msg::NebulaPackets::UniquePtr packets;
+    drivers::NebulaPointCloudPtr cloud;
+    double cloud_timestamp_s;
+  };
+
+  void publish(PublishData && data);
+
   void PublishCloud(
     std::unique_ptr<sensor_msgs::msg::PointCloud2> pointcloud,
     const rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr & publisher);
@@ -69,17 +80,20 @@ private:
 
   std::shared_ptr<nebula::drivers::RobosenseHwInterface> hw_interface_;
   std::shared_ptr<const drivers::RobosenseSensorConfiguration> sensor_cfg_;
-  std::shared_ptr<const drivers::RobosenseCalibrationConfiguration> calibration_cfg_ptr_{};
+  std::shared_ptr<const drivers::RobosenseCalibrationConfiguration> calibration_cfg_ptr_;
 
   std::shared_ptr<drivers::RobosenseDriver> driver_ptr_;
   std::mutex mtx_driver_ptr_;
 
-  rclcpp::Publisher<robosense_msgs::msg::RobosenseScan>::SharedPtr packets_pub_{};
-  robosense_msgs::msg::RobosenseScan::UniquePtr current_scan_msg_{};
+  rclcpp::Publisher<robosense_msgs::msg::RobosenseScan>::SharedPtr packets_pub_;
+  nebula_msgs::msg::NebulaPackets::UniquePtr current_scan_msg_;
 
-  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr nebula_points_pub_{};
-  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr aw_points_ex_pub_{};
-  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr aw_points_base_pub_{};
+  mt_queue<PublishData> publish_queue_;
+  std::thread pub_thread_;
+
+  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr nebula_points_pub_;
+  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr aw_points_ex_pub_;
+  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr aw_points_base_pub_;
 
   std::shared_ptr<WatchdogTimer> cloud_watchdog_;
 };

--- a/nebula_ros/include/nebula_ros/robosense/robosense_ros_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/robosense/robosense_ros_wrapper.hpp
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include "nebula_ros/common/mt_queue.hpp"
 #include "nebula_ros/robosense/decoder_wrapper.hpp"
 #include "nebula_ros/robosense/hw_interface_wrapper.hpp"
 #include "nebula_ros/robosense/hw_monitor_wrapper.hpp"
@@ -83,14 +82,9 @@ private:
 
   nebula::Status wrapper_status_;
 
-  std::shared_ptr<const nebula::drivers::RobosenseSensorConfiguration> sensor_cfg_ptr_{};
+  std::shared_ptr<const nebula::drivers::RobosenseSensorConfiguration> sensor_cfg_ptr_;
 
-  /// @brief Stores received packets that have not been processed yet by the decoder thread
-  mt_queue<std::unique_ptr<nebula_msgs::msg::NebulaPacket>> packet_queue_;
-  /// @brief Thread to isolate decoding from receiving
-  std::thread decoder_thread_;
-
-  rclcpp::Subscription<robosense_msgs::msg::RobosenseScan>::SharedPtr packets_sub_{};
+  rclcpp::Subscription<robosense_msgs::msg::RobosenseScan>::SharedPtr packets_sub_;
 
   bool launch_hw_;
 

--- a/nebula_ros/include/nebula_ros/velodyne/velodyne_ros_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/velodyne/velodyne_ros_wrapper.hpp
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include "nebula_ros/common/mt_queue.hpp"
 #include "nebula_ros/common/parameter_descriptors.hpp"
 #include "nebula_ros/velodyne/decoder_wrapper.hpp"
 #include "nebula_ros/velodyne/hw_interface_wrapper.hpp"
@@ -83,11 +82,6 @@ private:
   Status wrapper_status_;
 
   std::shared_ptr<const nebula::drivers::VelodyneSensorConfiguration> sensor_cfg_ptr_{};
-
-  /// @brief Stores received packets that have not been processed yet by the decoder thread
-  mt_queue<std::unique_ptr<nebula_msgs::msg::NebulaPacket>> packet_queue_;
-  /// @brief Thread to isolate decoding from receiving
-  std::thread decoder_thread_;
 
   rclcpp::Subscription<velodyne_msgs::msg::VelodyneScan>::SharedPtr packets_sub_{};
 

--- a/nebula_ros/src/robosense/decoder_wrapper.cpp
+++ b/nebula_ros/src/robosense/decoder_wrapper.cpp
@@ -122,7 +122,7 @@ void RobosenseDecoderWrapper::publish(PublishData && data)
   cloud_watchdog_->update();
 
   // Publish scan message only if it has been written to
-  if (current_scan_msg_ && !current_scan_msg_->packets.empty()) {
+  if (!data.packets->packets.empty()) {
     auto robosense_scan = std::make_unique<robosense_msgs::msg::RobosenseScan>();
     robosense_scan->header = data.packets->header;
 

--- a/nebula_ros/src/velodyne/decoder_wrapper.cpp
+++ b/nebula_ros/src/velodyne/decoder_wrapper.cpp
@@ -207,7 +207,7 @@ void VelodyneDecoderWrapper::publish(PublishData && data)
   cloud_watchdog_->update();
 
   // Publish scan message only if it has been written to
-  if (current_scan_msg_ && !current_scan_msg_->packets.empty()) {
+  if (data.packets->packets.empty()) {
     auto velodyne_scan = std::make_unique<velodyne_msgs::msg::VelodyneScan>();
     velodyne_scan->header = data.packets->header;
 


### PR DESCRIPTION
## PR Type

- Bug Fix

## Related Links

- [TIER IV internal link] -- internal ticket

## Description

This PR lowers the chance of packet loss occurring for all supported LiDARs by minimizing the number of mutex locks in the UDP receiver thread.

The UDP receiver thread was losing packets before, mainly because of scheduling:
1. Decoder is currently reading from queue
2. UDP receiver cannot acquire lock, its thread gets suspended
3. N UDP packets arrive (and are lost) while thread is not scheduled
4. When thread gets finally scheduled, it has lost packets

This is mostly mitigated by moving the `mt_queue` buffer from between the hardware interface and decoder to between the decoder and pointcloud/packets publishers. In other words, the queue is moved from the high-frequency part of Nebula (up to 36kHz for OT128) to the low-frequency part (10Hz or whatever the sensor framerate is set to).

The below figure shows the number of points in an unfiltered pointcloud (as a proxy for the number of packets received) for the baseline and fixed ("queue_only") implementations. The sensor tested was OT128 in dual return & high resolution mode.
The benchmarking setup was as follows (every run was repeated 3 times):
- taskset Nebula to cores 0-7
- taskset `ros2 bag record -s mcap --max-cache-size 5000000000 /pandar_points` to cores 8-11
- run 8 instances of `ros2 topic echo  /pandar_points --field header` taskset to core `12 + 2i` for instance i
- stop all processes after 60s

The plot was generated from the concatenated rosbags.

![nebula_queue](https://github.com/user-attachments/assets/aa199328-c861-4ea3-b5c8-9dad1caf60da)

|  | messages | mean | std | min | 0.1% | 1% | 10% | 50% |
|-|-:|-:|-:|-:|-:|-:|-:|-:|
| baseline |1715 |920577 |2436.64 |865024 |895010 |911908 |919040 |**921600** |
| fix |1717|921585 |582.054 | 897536| 920503|**921600** |**921600** | **921600** |
| baseline (% lost) |  |920577 |0.11  |6.14 |2.89 |1.05 |0.28 |**0** |
| fix (% lost) | |0.00 | | 2.61| 0.12|**0** |**0** | **0** |

:information_source: This PR applies to all Hesai, Velodyne, and Robosense sensors.
:information_source: #169 (Aeva Aeries II) already uses a similar approach and should be immune to packet loss
:warning: I am not sure at the moment whether this change would benefit Continental sensors as well (HW monitor and other functions handled in decoder, packet rate unknown to me), so I skipped them for now. @knzo25 have you observed packet loss on Radars so far?

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
