### PR TITLE
fix(hesai_hw_monitor): reduce log spam for unsupported hardware commands on AT128 and 40P

### DIFF
--- a/nebula_hw_interfaces/src/nebula_hesai_hw_interfaces/hesai_hw_interface.cpp
+++ b/nebula_hw_interfaces/src/nebula_hesai_hw_interfaces/hesai_hw_interface.cpp
@@ -1,4 +1,5 @@
 #include "nebula_hw_interfaces/nebula_hw_interfaces_hesai/hesai_hw_interface.hpp"
+#include <sstream>
 
 // #define WITH_DEBUG_STDOUT_HESAI_HW_INTERFACE
 
@@ -335,7 +336,9 @@ boost::property_tree::ptree HesaiHwInterface::ParseJson(const std::string & str)
 {
   boost::property_tree::ptree tree;
   try {
-    boost::property_tree::read_json(str, tree);
+    std::stringstream ss;
+    ss << str;
+    boost::property_tree::read_json(ss, tree);
   } catch (boost::property_tree::json_parser_error & e) {
     std::cerr << e.what() << std::endl;
   }
@@ -811,10 +814,13 @@ Status HesaiHwInterface::SetLidarRange(int start, int end)
 
 HesaiLidarRangeAll HesaiHwInterface::GetLidarRange()
 {
+  HesaiLidarRangeAll hesai_range_all{};
   auto response_ptr = SendReceive(PTC_COMMAND_GET_LIDAR_RANGE);
-  auto & response = *response_ptr;
+  if (!response_ptr) return hesai_range_all;
 
-  HesaiLidarRangeAll hesai_range_all;
+  auto & response = *response_ptr;
+  if (response.empty()) return hesai_range_all;
+
   int payload_pos = 0;
   int method = static_cast<int>(response[payload_pos++]);
   switch (method) {
@@ -920,10 +926,13 @@ Status HesaiHwInterface::SetRotDir(int mode)
 
 HesaiLidarMonitor HesaiHwInterface::GetLidarMonitor()
 {
+  HesaiLidarMonitor hesai_lidar_monitor{};
   auto response_ptr = SendReceive(PTC_COMMAND_LIDAR_MONITOR);
-  auto & response = *response_ptr;
+  if (!response_ptr) return hesai_lidar_monitor;
 
-  HesaiLidarMonitor hesai_lidar_monitor;
+  auto & response = *response_ptr;
+  if (response.empty()) return hesai_lidar_monitor;
+
   int payload_pos = 0;
   hesai_lidar_monitor.input_voltage = response[payload_pos++] << 24;
   hesai_lidar_monitor.input_voltage = hesai_lidar_monitor.input_voltage | response[payload_pos++]


### PR DESCRIPTION
## PR Type

- Hotfix

## Related Links

- [TIER IV INTERNAL LINK](https://star4.slack.com/archives/C076E8EBJTG/p1723108703362159) -- request for this fix

## Description

This is a hotfix for until develop is merged, to suppress error messages for unsupported hardware monitor commands on 40P and AT128.

Instead of printing these messages
```
{"Head":{"ErrorCode":"3","Message":"Error: not support yet"}}: cannot open file
```
Nebula will now suppress the error and fill the affected diagnostic fields with "not supported":
![Screenshot from 2024-08-19 15-13-24](https://github.com/user-attachments/assets/2b534871-0db4-4955-8a65-3c6cd235995e)

Code changed to achieve this:
* in `ParseJson()`, convert the JSON string to a stream (passing a string to the `load_json` function will treat the string as a file, not as JSON
* return a 0-initialized struct instead of segfaulting during parsing for cases where the sensor responds with an error
* introduce a special case for AT128 to output the not supported message to diagnostics

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
