### PR TITLE
feat(nebula_ros): support `launch_hw` parameter in console again to make replaying rosbags easier

### DIFF
--- a/nebula_ros/launch/continental_launch_all_hw.xml
+++ b/nebula_ros/launch/continental_launch_all_hw.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0"?>
 <launch>
     <arg name="sensor_model" default="ARS548"/>
+    <arg name="launch_hw" default="true" description="Whether to connect to a real sensor (true) or to accept packet messages (false).">
+        <choice value="true" />
+        <choice value="false" />
+    </arg>
     <arg name="config_file" default="$(find-pkg-share nebula_ros)/config/radar/continental/$(var sensor_model).param.yaml"/>
 
     <arg name="odometry_topic" default="odometry_input"/>
@@ -11,6 +15,7 @@
 
         <node pkg="nebula_ros" exec="continental_ars548_ros_wrapper_node" name="nebula_continental_ars548" output="screen">
             <param from="$(var config_file)" allow_substs="true"/>
+            <param name="launch_hw" value="$(var launch_hw)"></param>
             <remap from="/diagnostics" to="diagnostics"/>
             <remap from="odometry_input" to="$(var odometry_topic)"/>
             <remap from="acceleration_input" to="$(var acceleration_topic)"/>
@@ -21,7 +26,8 @@
     <group if="$(eval &quot;'$(var sensor_model)' == 'SRR520' &quot;)" >
 
         <node pkg="nebula_ros" exec="continental_srr520_ros_wrapper_node" name="nebula_continental_srr520" output="screen">
-	    <param from="$(var config_file)" allow_substs="true"/>
+	        <param from="$(var config_file)" allow_substs="true"/>
+            <param name="launch_hw" value="$(var launch_hw)"></param>
             <remap from="/diagnostics" to="diagnostics"/>
             <remap from="odometry_input" to="$(var odometry_topic)"/>
             <remap from="acceleration_input" to="$(var acceleration_topic)"/>

--- a/nebula_ros/launch/continental_launch_all_hw.xml
+++ b/nebula_ros/launch/continental_launch_all_hw.xml
@@ -15,7 +15,7 @@
 
         <node pkg="nebula_ros" exec="continental_ars548_ros_wrapper_node" name="nebula_continental_ars548" output="screen">
             <param from="$(var config_file)" allow_substs="true"/>
-            <param name="launch_hw" value="$(var launch_hw)"></param>
+            <param name="launch_hw" value="$(var launch_hw)"/>
             <remap from="/diagnostics" to="diagnostics"/>
             <remap from="odometry_input" to="$(var odometry_topic)"/>
             <remap from="acceleration_input" to="$(var acceleration_topic)"/>
@@ -27,7 +27,7 @@
 
         <node pkg="nebula_ros" exec="continental_srr520_ros_wrapper_node" name="nebula_continental_srr520" output="screen">
 	        <param from="$(var config_file)" allow_substs="true"/>
-            <param name="launch_hw" value="$(var launch_hw)"></param>
+            <param name="launch_hw" value="$(var launch_hw)"/>
             <remap from="/diagnostics" to="diagnostics"/>
             <remap from="odometry_input" to="$(var odometry_topic)"/>
             <remap from="acceleration_input" to="$(var acceleration_topic)"/>

--- a/nebula_ros/launch/hesai_launch_all_hw.xml
+++ b/nebula_ros/launch/hesai_launch_all_hw.xml
@@ -9,7 +9,7 @@
 
   <node pkg="nebula_ros" exec="hesai_ros_wrapper_node" name="hesai_ros_wrapper_node" output="screen">
     <param from="$(var config_file)" allow_substs="true"/>
-    <param name="launch_hw" value="$(var launch_hw)"></param>
+    <param name="launch_hw" value="$(var launch_hw)"/>
   </node>
 
 </launch>

--- a/nebula_ros/launch/hesai_launch_all_hw.xml
+++ b/nebula_ros/launch/hesai_launch_all_hw.xml
@@ -1,10 +1,15 @@
 <?xml version="1.0"?>
 <launch>
   <arg name="sensor_model" description="Pandar64|Pandar40P|PandarXT32|PandarXT32M|PandarAT128|PandarQT64|PandarQT128|Pandar128E4X"/>
+  <arg name="launch_hw" default="true" description="Whether to connect to a real sensor (true) or to accept packet messages (false).">
+    <choice value="true" />
+    <choice value="false" />
+  </arg>
   <arg name="config_file" default="$(find-pkg-share nebula_ros)/config/lidar/hesai/$(var sensor_model).param.yaml"/>
 
   <node pkg="nebula_ros" exec="hesai_ros_wrapper_node" name="hesai_ros_wrapper_node" output="screen">
     <param from="$(var config_file)" allow_substs="true"/>
+    <param name="launch_hw" value="$(var launch_hw)"></param>
   </node>
 
 </launch>

--- a/nebula_ros/launch/robosense_launch_all_hw.xml
+++ b/nebula_ros/launch/robosense_launch_all_hw.xml
@@ -1,10 +1,15 @@
 <?xml version="1.0"?>
 <launch>
   <arg name="sensor_model" description="Helios|Bpearl"/>
+  <arg name="launch_hw" default="true" description="Whether to connect to a real sensor (true) or to accept packet messages (false).">
+    <choice value="true" />
+    <choice value="false" />
+  </arg>
   <arg name="config_file" default="$(find-pkg-share nebula_ros)/config/lidar/robosense/$(var sensor_model).param.yaml"/>
 
   <node pkg="nebula_ros" exec="robosense_ros_wrapper_node" name="robosense_ros_wrapper_node" output="screen">
     <param from="$(var config_file)" allow_substs="true"/>
+    <param name="launch_hw" value="$(var launch_hw)"></param>
   </node>
 
 </launch>

--- a/nebula_ros/launch/robosense_launch_all_hw.xml
+++ b/nebula_ros/launch/robosense_launch_all_hw.xml
@@ -9,7 +9,7 @@
 
   <node pkg="nebula_ros" exec="robosense_ros_wrapper_node" name="robosense_ros_wrapper_node" output="screen">
     <param from="$(var config_file)" allow_substs="true"/>
-    <param name="launch_hw" value="$(var launch_hw)"></param>
+    <param name="launch_hw" value="$(var launch_hw)"/>
   </node>
 
 </launch>

--- a/nebula_ros/launch/velodyne_launch_all_hw.xml
+++ b/nebula_ros/launch/velodyne_launch_all_hw.xml
@@ -9,7 +9,7 @@
 
   <node pkg="nebula_ros" exec="velodyne_ros_wrapper_node" name="velodyne_ros_wrapper_node" output="screen">
     <param from="$(var config_file)" allow_substs="true"/>
-    <param name="launch_hw" value="$(var launch_hw)"></param>
+    <param name="launch_hw" value="$(var launch_hw)"/>
   </node>
 
 </launch>

--- a/nebula_ros/launch/velodyne_launch_all_hw.xml
+++ b/nebula_ros/launch/velodyne_launch_all_hw.xml
@@ -1,10 +1,15 @@
 <?xml version="1.0"?>
 <launch>
   <arg name="sensor_model" description="VLP16|VLP32|VLS128"/>
+  <arg name="launch_hw" default="true" description="Whether to connect to a real sensor (true) or to accept packet messages (false).">
+    <choice value="true" />
+    <choice value="false" />
+  </arg>
   <arg name="config_file" default="$(find-pkg-share nebula_ros)/config/lidar/velodyne/$(var sensor_model).param.yaml"/>
 
   <node pkg="nebula_ros" exec="velodyne_ros_wrapper_node" name="velodyne_ros_wrapper_node" output="screen">
     <param from="$(var config_file)" allow_substs="true"/>
+    <param name="launch_hw" value="$(var launch_hw)"></param>
   </node>
 
 </launch>


### PR DESCRIPTION
## PR Type

- Improvement

## Description

Add the `launch_hw` argument to all vendors' launch files explicitly (instead of having ROS 2 Launch read it from the `config_file`) to enable the following workflow:

With the same config:
1. Connect to a real sensor and record data to a rosbag
2. Later, replay that rosbag with Nebula in offline mode (`launch_hw:=false`)

## Review Procedure

Try and launch each vendor, once with `launch_hw` being set to `true`, and once to `false`.
Nebula should try to connect to the sensor in one case, and print a message saying it's listening to recorded packets in the other.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
