### PR TITLE
fix(at128): allow negative values in points' `elevation` fields

### DIFF
--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/angle_corrector_correction_based.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/angle_corrector_correction_based.hpp
@@ -181,19 +181,23 @@ public:
   {
     int field = findField(block_azimuth);
 
-    int32_t elevation =
-      correction_->elevation[channel_id] +
-      correction_->getElevationAdjustV3(channel_id, block_azimuth) * (AngleUnit / 100);
+    int32_t elevation = correction_->elevation[channel_id] +
+                        correction_->getElevationAdjustV3(channel_id, block_azimuth) *
+                          static_cast<int32_t>(AngleUnit / 100);
+
+    // Allow negative angles in the radian value. This makes visualization of this field nicer and
+    // should have no other mathematical implications in downstream modules.
+    float elevation_rad = 2.f * elevation * M_PI / MAX_AZIMUTH;
+    // Then, normalize the integer value to the positive [0, MAX_AZIMUTH] range for array indexing
     elevation = (MAX_AZIMUTH + elevation) % MAX_AZIMUTH;
 
-    int32_t azimuth =
-      (block_azimuth + MAX_AZIMUTH - correction_->startFrame[field]) * 2 -
-      correction_->azimuth[channel_id] +
-      correction_->getAzimuthAdjustV3(channel_id, block_azimuth) * (AngleUnit / 100);
+    int32_t azimuth = (block_azimuth + MAX_AZIMUTH - correction_->startFrame[field]) * 2 -
+                      correction_->azimuth[channel_id] +
+                      correction_->getAzimuthAdjustV3(channel_id, block_azimuth) *
+                        static_cast<int32_t>(AngleUnit / 100);
     azimuth = (MAX_AZIMUTH + azimuth) % MAX_AZIMUTH;
 
-    float azimuth_rad = 2.f * azimuth * M_PIf / MAX_AZIMUTH;
-    float elevation_rad = 2.f * elevation * M_PIf / MAX_AZIMUTH;
+    float azimuth_rad = 2.f * azimuth * M_PI / MAX_AZIMUTH;
 
     return {azimuth_rad,   elevation_rad,   sin_[azimuth],
             cos_[azimuth], sin_[elevation], cos_[elevation]};


### PR DESCRIPTION
## PR Type

- Improvement

## Related Links

- #173 -- the base for this PR, needed because AT128 is broken before this PR

## Description

:warning: This has to be rebased onto develop after #173 is merged, and then be merged.

Only AT128 normalized its points' `elevation` field to [0, 2pi) while other sensors allowed negative `elevation` values. While the normalization is done on azimuth as well and thus, for consistency sake, would be nice on the elevation field, too, this causes visualizations to look ugly when coloring by `elevation`. 
Anyway, trigonometry functions won't care about this change as they are periodic, and given that all other sensors are not normalizing elevation, it is safe to assume this doesn't impact downstream modules.

| Old (normalized) | New (unnormalized) |
|-|-|
| ![image](https://github.com/user-attachments/assets/5b0cbfb8-12f7-4036-b541-d435205742d1) | ![image](https://github.com/user-attachments/assets/303f5662-638a-4b5d-8cbd-45dd0951b552) |


## Review Procedure

Confirm the `elevation` field looks correct. Code review.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
