### PR TITLE
docs: create API reference page, link class/namespace/... references in navigation

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,0 +1,8 @@
+Nebula is divided into several modules:
+
+- Common, for type definitions and utilities
+- Decoders, for converting raw packets into pointclouds and performing correction and filtering
+- HW Interfaces, for hardware protocols and socket implementations
+- ROS Wrappers, for ROS launch, parameter handling, data publishing and diagnostics
+
+For API details, see the navigation items on this page.

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,3 +1,5 @@
+# API Reference
+
 Nebula is divided into several modules:
 
 - **Common**, for type definitions and utilities

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,8 +1,8 @@
 Nebula is divided into several modules:
 
-- Common, for type definitions and utilities
-- Decoders, for converting raw packets into pointclouds and performing correction and filtering
-- HW Interfaces, for hardware protocols and socket implementations
-- ROS Wrappers, for ROS launch, parameter handling, data publishing and diagnostics
+- **Common**, for type definitions and utilities
+- **Decoders**, for converting raw packets into pointclouds and performing correction and filtering
+- **HW interfaces**, for hardware protocols and socket implementations
+- **ROS wrappers**, for ROS launch, parameter handling, data publishing and diagnostics
 
 For API details, see the navigation items on this page.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,10 +44,96 @@ nav:
   - Supported sensors: supported_sensors.md
   - Tutorials: tutorials.md
   - Contributing: contribute.md
-  - Nebula common: nebula_common/links.md
-  - Nebula decoders: nebula_decoders/links.md
-  - Nebula HW interfaces: nebula_hw_interfaces/links.md
-  - Nebula ROS: nebula_ros/links.md
+  - API reference:
+      - api_reference.md
+      - Nebula common:
+          - Links: nebula_common/links.md
+          - Classes:
+              - Class List: nebula_common/annotated.md
+              - Class Index: nebula_common/classes.md
+              - Class Hierarchy: nebula_common/hierarchy.md
+              - Class Members: nebula_common/class_members.md
+              - Class Member Functions: nebula_common/class_member_functions.md
+              - Class Member Variables: nebula_common/class_member_variables.md
+              - Class Member Typedefs: nebula_common/class_member_typedefs.md
+              - Class Member Enumerations: nebula_common/class_member_enums.md
+          - Namespaces:
+              - Namespace List: nebula_common/namespaces.md
+              - Namespace Members: nebula_common/namespace_members.md
+              - Namespace Member Functions: nebula_common/namespace_member_functions.md
+              - Namespace Member Variables: nebula_common/namespace_member_variables.md
+              - Namespace Member Typedefs: nebula_common/namespace_member_typedefs.md
+              - Namespace Member Enumerations: nebula_common/namespace_member_enums.md
+          - Functions: nebula_common/functions.md
+          - Variables: nebula_common/variables.md
+          - Macros: nebula_common/macros.md
+          - Files: nebula_common/files.md
+      - Nebula decoders:
+          - Links: nebula_decoders/links.md
+          - Classes:
+              - Class List: nebula_decoders/annotated.md
+              - Class Index: nebula_decoders/classes.md
+              - Class Hierarchy: nebula_decoders/hierarchy.md
+              - Class Members: nebula_decoders/class_members.md
+              - Class Member Functions: nebula_decoders/class_member_functions.md
+              - Class Member Variables: nebula_decoders/class_member_variables.md
+              - Class Member Typedefs: nebula_decoders/class_member_typedefs.md
+              - Class Member Enumerations: nebula_decoders/class_member_enums.md
+          - Namespaces:
+              - Namespace List: nebula_decoders/namespaces.md
+              - Namespace Members: nebula_decoders/namespace_members.md
+              - Namespace Member Functions: nebula_decoders/namespace_member_functions.md
+              - Namespace Member Variables: nebula_decoders/namespace_member_variables.md
+              - Namespace Member Typedefs: nebula_decoders/namespace_member_typedefs.md
+              - Namespace Member Enumerations: nebula_decoders/namespace_member_enums.md
+          - Functions: nebula_decoders/functions.md
+          - Variables: nebula_decoders/variables.md
+          - Macros: nebula_decoders/macros.md
+          - Files: nebula_decoders/files.md
+      - Nebula HW interfaces:
+          - Links: nebula_hw_interfaces/links.md
+          - Classes:
+              - Class List: nebula_hw_interfaces/annotated.md
+              - Class Index: nebula_hw_interfaces/classes.md
+              - Class Hierarchy: nebula_hw_interfaces/hierarchy.md
+              - Class Members: nebula_hw_interfaces/class_members.md
+              - Class Member Functions: nebula_hw_interfaces/class_member_functions.md
+              - Class Member Variables: nebula_hw_interfaces/class_member_variables.md
+              - Class Member Typedefs: nebula_hw_interfaces/class_member_typedefs.md
+              - Class Member Enumerations: nebula_hw_interfaces/class_member_enums.md
+          - Namespaces:
+              - Namespace List: nebula_hw_interfaces/namespaces.md
+              - Namespace Members: nebula_hw_interfaces/namespace_members.md
+              - Namespace Member Functions: nebula_hw_interfaces/namespace_member_functions.md
+              - Namespace Member Variables: nebula_hw_interfaces/namespace_member_variables.md
+              - Namespace Member Typedefs: nebula_hw_interfaces/namespace_member_typedefs.md
+              - Namespace Member Enumerations: nebula_hw_interfaces/namespace_member_enums.md
+          - Functions: nebula_hw_interfaces/functions.md
+          - Variables: nebula_hw_interfaces/variables.md
+          - Macros: nebula_hw_interfaces/macros.md
+          - Files: nebula_hw_interfaces/files.md
+      - Nebula ROS:
+          - Links: nebula_ros/links.md
+          - Classes:
+              - Class List: nebula_ros/annotated.md
+              - Class Index: nebula_ros/classes.md
+              - Class Hierarchy: nebula_ros/hierarchy.md
+              - Class Members: nebula_ros/class_members.md
+              - Class Member Functions: nebula_ros/class_member_functions.md
+              - Class Member Variables: nebula_ros/class_member_variables.md
+              - Class Member Typedefs: nebula_ros/class_member_typedefs.md
+              - Class Member Enumerations: nebula_ros/class_member_enums.md
+          - Namespaces:
+              - Namespace List: nebula_ros/namespaces.md
+              - Namespace Members: nebula_ros/namespace_members.md
+              - Namespace Member Functions: nebula_ros/namespace_member_functions.md
+              - Namespace Member Variables: nebula_ros/namespace_member_variables.md
+              - Namespace Member Typedefs: nebula_ros/namespace_member_typedefs.md
+              - Namespace Member Enumerations: nebula_ros/namespace_member_enums.md
+          - Functions: nebula_ros/functions.md
+          - Variables: nebula_ros/variables.md
+          - Macros: nebula_ros/macros.md
+          - Files: nebula_ros/files.md
 
 ### Extra Settings ###
 plugins:


### PR DESCRIPTION
## PR Type

- Improvement

## Description

This PR should make it much user-friendlier to navigate through the API reference.

![image](https://github.com/user-attachments/assets/2f187351-8a6c-4be5-a6a0-121a3b19706d)

## Review Procedure

Run
```shell
python3 -m pip install -U $(curl -fsSL https://raw.githubusercontent.com/autowarefoundation/autoware-github-actions/main/deploy-docs/mkdocs-requirements.txt)
cd src
mkdocs serve
```
and confirm the API reference tab is working as expected.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
