### PR TITLE
fix(nebula_hw_interfaces): add missing iomanip header

### DIFF
--- a/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_hesai/hesai_cmd_response.hpp
+++ b/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_hesai/hesai_cmd_response.hpp
@@ -5,6 +5,7 @@
 #include <boost/format.hpp>
 
 #include <ostream>
+#include <iomanip>
 
 namespace nebula
 {


### PR DESCRIPTION
## PR Type

- Bug Fix

## Bug

Run `colcon build --symlink-install --event-handlers=console_cohesion+ --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo --packages-up-to nebula_sensor_driver` in latest autoware workspace.

```
--- stderr: nebula_hw_interfaces
In file included from /home/mfc/projects/autoware/src/sensor_component/external/nebula/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_hesai/hesai_hw_interface.hpp:19,
                 from /home/mfc/projects/autoware/src/sensor_component/external/nebula/nebula_hw_interfaces/src/nebula_hesai_hw_interfaces/hesai_hw_interface.cpp:1:
/home/mfc/projects/autoware/src/sensor_component/external/nebula/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_hesai/hesai_cmd_response.hpp: In function ‘std::ostream& nebula::operator<<(std::ostream&, const nebula::HesaiInventory&)’:
/home/mfc/projects/autoware/src/sensor_component/external/nebula/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_hesai/hesai_cmd_response.hpp:200:30: error: ‘setfill’ is not a member of ‘std’; did you mean ‘fill’?
  200 |       ss << std::hex << std::setfill('0') << std::setw(2) << (static_cast<int>(arg.mac[i]) & 0xff)
      |                              ^~~~~~~
      |                              fill
/home/mfc/projects/autoware/src/sensor_component/external/nebula/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_hesai/hesai_cmd_response.hpp:200:51: error: ‘setw’ is not a member of ‘std’; did you mean ‘set’?
  200 |       ss << std::hex << std::setfill('0') << std::setw(2) << (static_cast<int>(arg.mac[i]) & 0xff)
      |                                                   ^~~~
      |                                                   set
/home/mfc/projects/autoware/src/sensor_component/external/nebula/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_hesai/hesai_cmd_response.hpp:203:28: error: ‘setfill’ is not a member of ‘std’; did you mean ‘fill’?
  203 |     ss << std::hex << std::setfill('0') << std::setw(2)
      |                            ^~~~~~~
      |                            fill
/home/mfc/projects/autoware/src/sensor_component/external/nebula/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_hesai/hesai_cmd_response.hpp:203:49: error: ‘setw’ is not a member of ‘std’; did you mean ‘set’?
  203 |     ss << std::hex << std::setfill('0') << std::setw(2)
      |                                                 ^~~~
      |                                                 set
gmake[2]: *** [CMakeFiles/nebula_hw_interfaces_hesai.dir/build.make:76: CMakeFiles/nebula_hw_interfaces_hesai.dir/src/nebula_hesai_hw_interfaces/hesai_hw_interface.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:143: CMakeFiles/nebula_hw_interfaces_hesai.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
---
Failed   <<< nebula_hw_interfaces [9.80s, exited with code 2]
```

## Description

See: https://en.cppreference.com/w/cpp/io/manip/setfill for why this missing header should be added.

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
