### PR TITLE
chore: exclude build and example folders from coverage

### DIFF
--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -48,9 +48,11 @@ jobs:
 
       - name: Upload coverage to CodeCov
         if: ${{ steps.test.outputs.coverage-report-files != '' }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: ${{ steps.test.outputs.coverage-report-files }}
+          exclude: build/*,nebula_examples/*
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
           verbose: true
           flags: differential

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -63,7 +63,6 @@ jobs:
           files: ${{ steps.test.outputs.coverage-report-files }}
           exclude: build/*,nebula_examples/*
           token: ${{ secrets.CODECOV_TOKEN }}
-          slug: tier4/nebula
           fail_ci_if_error: false
           verbose: true
           flags: total

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -58,9 +58,12 @@ jobs:
 
       - name: Upload coverage to CodeCov
         if: ${{ steps.test.outputs.coverage-report-files != '' }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: ${{ steps.test.outputs.coverage-report-files }}
+          exclude: build/*,nebula_examples/*
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: tier4/nebula
           fail_ci_if_error: false
           verbose: true
           flags: total


### PR DESCRIPTION
## PR Type

- Improvement

## Related Links

- [Codecov before](https://app.codecov.io/gh/tier4/nebula/commit/18af521fc3a3ab1ce9c17ec94c2a0a8633317de4)
- [Codecov after](https://app.codecov.io/github/tier4/nebula/commit/1b8105e8cd6c5d15ea1c61c7bf15ce98d5d4131f)

## Description

This PR removes the `build` and `nebula_examples` folders from code coverage statistics.
The `build` folder contains the code-generation results from `nebula_msgs` etc. and should not be included (also, it's 9000 lines :exploding_head:).
The `nebula_examples` folder is not part of the main functionality of the software and thus, coverage is not important.

With this PR, coverage goes from 10% to 28%:
![image](https://github.com/user-attachments/assets/0e814f08-af89-4ef6-8ba3-83a07280521a)

:warning: **Dummy changes in all modules were necessary to trigger the coverage report, these have since been reverted.**

## Review Procedure

Compare coverage results from before and after given the links above and confirm that
- the directories are removed
- all other relevant directories are present and correct

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
