### PR TITLE
docs: simplify installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,6 @@ Nebula builds with ROS 2 Galactic and Humble.
 > **Note**
 >
 > Boost version 1.74.0 or later is required. A manual install may be required in Ubuntu versions earlier than 22.04.
->
-> **Note**
->
-> A [TCP enabled version of ROS' Transport Driver](https://github.com/mojomex/transport_drivers/tree/mutable-buffer-in-udp-callback) is required to use Nebula.
-> It is installed automatically into your workspace using the below commands. However, if you already have ROS transport driver binaries installed, you will have to uninstall them to avoid conflicts (replace `humble` with your ROS distribution):
-> `sudo apt remove ros-humble-udp-driver ros-humble-io-context`
 
 To build Nebula run the following commands in your workspace:
 

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ To build Nebula run the following commands in your workspace:
 
 ```bash
 # In workspace
-mkdir src
-git clone https://github.com/tier4/nebula.git src
+git clone https://github.com/tier4/nebula.git
+cd nebula
 # Import dependencies
-vcs import src < src/build_depends.repos
-rosdep install --from-paths src --ignore-src -y -r
+vcs import < build_depends.repos
+rosdep install --from-paths . --ignore-src -y -r
 # Build Nebula
-colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
+colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=1
 ```
 
 To launch Nebula as a ROS 2 node with default parameters for your sensor model:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Nebula works with ROS 2 and is the recommended sensor driver for the [Autoware](
 We recommend you get started with the [Nebula Documention](https://tier4.github.io/nebula/).
 Here you will find information about the background of the project, how to install and use with ROS 2, and also how to add new sensors to the Nebula driver.
 
-- [About Nebula](https://tier4.github.io/nebula/about)
+- [About Nebula](https://tier4.github.io/nebula)
 - [Design](https://tier4.github.io/nebula/design)
 - [Supported Sensors](https://tier4.github.io/nebula/supported_sensors)
 - [Installation](https://tier4.github.io/nebula/installation)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,12 +10,6 @@ Please see the [ROS 2 documentation](https://docs.ros.org/en/humble/index.html) 
 > **Note**
 >
 > Boost version 1.74.0 or later is required. A manual install may be required in Ubuntu versions earlier than 22.04.
->
-> **Note**
->
-> A [TCP enabled version of ROS' Transport Driver](https://github.com/mojomex/transport_drivers/tree/mutable-buffer-in-udp-callback) is required to use Nebula.
-> It is installed automatically into your workspace using the below commands. However, if you already have ROS transport driver binaries installed, you will have to uninstall them to avoid conflicts (replace `humble` with your ROS distribution):
-> `sudo apt remove ros-humble-udp-driver ros-humble-io-context`
 
 To build Nebula run the following commands in your workspace:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,13 +15,13 @@ To build Nebula run the following commands in your workspace:
 
 ```bash
 # In workspace
-mkdir src
-git clone https://github.com/tier4/nebula.git src
+git clone https://github.com/tier4/nebula.git
+cd nebula
 # Import dependencies
-vcs import src < src/build_depends.repos
-rosdep install --from-paths src --ignore-src -y -r
+vcs import < build_depends.repos
+rosdep install --from-paths . --ignore-src -y -r
 # Build Nebula
-colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
+colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=1
 ```
 
 ## Testing your build

--- a/nebula_sensor_driver/CMakeLists.txt
+++ b/nebula_sensor_driver/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 project(nebula_sensor_driver)
+set(ignoreMe "${CMAKE_EXPORT_COMPILE_COMMANDS}")
 
 find_package(ament_cmake REQUIRED)
 ament_package()


### PR DESCRIPTION
## PR Type

- Improvement

## Related Links

- #197 -- installation failed for a user due to unclear instructions in the readme

## Description

Simplify the readme/installation pages:

- remove the comment about the TCP-enabled transport drivers as they are installed automatically and are now prefixed by `boost_` and thus not conflicting with ROS' transport_drivers anymore
- remove the recommendation to create a `src` directory and instead recommend direct cloning
  - creating a `src` directory is one extra step which is not necessary
  - some IDEs/tools expect config files, e.g. .clang-tidy to be in the project root, not `src`
- update the link to our about page

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
