### PR TITLE
chore: concatenate all namespaces c++17-style

### DIFF
--- a/nebula_common/include/nebula_common/nebula_common.hpp
+++ b/nebula_common/include/nebula_common/nebula_common.hpp
@@ -24,9 +24,7 @@
 #include <string>
 #include <vector>
 
-namespace nebula
-{
-namespace drivers
+namespace nebula::drivers
 {
 /// @brief Coordinate mode for Velodyne's setting (need to check)
 enum class CoordinateMode { UNKNOWN = 0, CARTESIAN, SPHERICAL, CYLINDRICAL };
@@ -785,7 +783,6 @@ static inline float rad2deg(double radians)
 {
   return radians * 180.0 / M_PI;
 }
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers
 
 #endif  // NEBULA_CONFIGURATION_BASE_H

--- a/nebula_common/include/nebula_common/point_types.hpp
+++ b/nebula_common/include/nebula_common/point_types.hpp
@@ -20,9 +20,7 @@
 
 #include <memory>
 
-namespace nebula
-{
-namespace drivers
+namespace nebula::drivers
 {
 struct EIGEN_ALIGN16 PointXYZIR
 {
@@ -76,8 +74,7 @@ using NebulaPointPtr = std::shared_ptr<NebulaPoint>;
 using NebulaPointCloud = pcl::PointCloud<NebulaPoint>;
 using NebulaPointCloudPtr = pcl::PointCloud<NebulaPoint>::Ptr;
 
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers
 
 POINT_CLOUD_REGISTER_POINT_STRUCT(
   nebula::drivers::PointXYZIR,

--- a/nebula_common/include/nebula_common/velodyne/velodyne_calibration_decoder.hpp
+++ b/nebula_common/include/nebula_common/velodyne/velodyne_calibration_decoder.hpp
@@ -19,9 +19,7 @@
 #include <string>
 #include <vector>
 
-namespace nebula
-{
-namespace drivers
+namespace nebula::drivers
 {
 struct VelodyneLaserCorrection
 {
@@ -68,7 +66,6 @@ public:
   void write(const std::string & calibration_file);
 };
 
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers
 
 #endif  // NEBULA_VELODYNE_CALIBRATION_DECODER_H

--- a/nebula_common/src/nebula_common.cpp
+++ b/nebula_common/src/nebula_common.cpp
@@ -2,9 +2,7 @@
 
 #include <nebula_common/nebula_common.hpp>
 
-namespace nebula
-{
-namespace drivers
+namespace nebula::drivers
 {
 [[maybe_unused]] pcl::PointCloud<PointXYZIR>::Ptr convert_point_xyziradt_to_point_xyzir(
   const pcl::PointCloud<PointXYZIRADT>::ConstPtr & input_pointcloud)
@@ -71,6 +69,4 @@ pcl::PointCloud<PointXYZIRADT>::Ptr convert_point_xyzircaedt_to_point_xyziradt(
   output_pointcloud->width = output_pointcloud->points.size();
   return output_pointcloud;
 }
-}  // namespace drivers
-
-}  // namespace nebula
+}  // namespace nebula::drivers

--- a/nebula_common/src/velodyne/velodyne_calibration_decoder.cpp
+++ b/nebula_common/src/velodyne/velodyne_calibration_decoder.cpp
@@ -24,9 +24,7 @@ void operator>>(const YAML::Node & node, T & i)
 }  // namespace YAML
 #endif  // HAVE_NEW_YAMLCPP
 
-namespace nebula
-{
-namespace drivers
+namespace nebula::drivers
 {
 const char g_num_lasers[] = "num_lasers";
 const char g_distance_resolution[] = "distance_resolution";
@@ -242,5 +240,4 @@ void VelodyneCalibration::write(const std::string & calibration_file)
   fout.close();
 }
 
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_common/nebula_driver_base.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_common/nebula_driver_base.hpp
@@ -23,9 +23,7 @@
 #include <string>
 #include <vector>
 
-namespace nebula
-{
-namespace drivers
+namespace nebula::drivers
 {
 /// @brief Base class for each sensor driver
 class NebulaDriverBase
@@ -45,6 +43,5 @@ public:
     const CalibrationConfigurationBase & calibration_configuration) = 0;
 };
 
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers
 #endif  // NEBULA_DRIVER_BASE_H

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_continental/decoders/continental_ars548_decoder.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_continental/decoders/continental_ars548_decoder.hpp
@@ -28,11 +28,7 @@
 #include <memory>
 #include <vector>
 
-namespace nebula
-{
-namespace drivers
-{
-namespace continental_ars548
+namespace nebula::drivers::continental_ars548
 {
 /// @brief Continental Radar decoder (ARS548)
 class ContinentalARS548Decoder : public ContinentalPacketsDecoder
@@ -108,6 +104,4 @@ private:
   std::shared_ptr<const continental_ars548::ContinentalARS548SensorConfiguration> config_ptr_{};
 };
 
-}  // namespace continental_ars548
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers::continental_ars548

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_continental/decoders/continental_packets_decoder.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_continental/decoders/continental_packets_decoder.hpp
@@ -23,9 +23,7 @@
 #include <memory>
 #include <tuple>
 
-namespace nebula
-{
-namespace drivers
+namespace nebula::drivers
 {
 /// @brief Base class for Continental Radar decoder
 class ContinentalPacketsDecoder
@@ -48,6 +46,5 @@ public:
   /// @return Resulting flag
   virtual bool process_packet(std::unique_ptr<nebula_msgs::msg::NebulaPacket> packet_msg) = 0;
 };
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers
 #endif  // NEBULA_WS_CONTINENTAL_PACKETS_DECODER_HPP

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_continental/decoders/continental_srr520_decoder.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_continental/decoders/continental_srr520_decoder.hpp
@@ -30,11 +30,7 @@
 #include <string>
 #include <vector>
 
-namespace nebula
-{
-namespace drivers
-{
-namespace continental_srr520
+namespace nebula::drivers::continental_srr520
 {
 /// @brief Continental Radar decoder (SRR520)
 class ContinentalSRR520Decoder : public ContinentalPacketsDecoder
@@ -206,6 +202,4 @@ private:
   std::shared_ptr<rclcpp::Logger> parent_node_logger_ptr_{};
 };
 
-}  // namespace continental_srr520
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers::continental_srr520

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/hesai_driver.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/hesai_driver.hpp
@@ -26,9 +26,7 @@
 #include <tuple>
 #include <vector>
 
-namespace nebula
-{
-namespace drivers
+namespace nebula::drivers
 {
 /// @brief Hesai driver
 class HesaiDriver
@@ -73,7 +71,6 @@ public:
     const std::vector<uint8_t> & packet);
 };
 
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers
 
 #endif  // NEBULA_HESAI_DRIVER_H

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/decoders/angle_corrector.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/decoders/angle_corrector.hpp
@@ -21,9 +21,7 @@
 #include <cstdint>
 #include <memory>
 
-namespace nebula
-{
-namespace drivers
+namespace nebula::drivers
 {
 
 struct CorrectedAngleData
@@ -68,5 +66,4 @@ public:
   virtual bool has_scanned(int current_azimuth, int last_azimuth) = 0;
 };
 
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/decoders/angle_corrector_calibration_based.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/decoders/angle_corrector_calibration_based.hpp
@@ -20,9 +20,7 @@
 #include <cstdint>
 #include <memory>
 
-namespace nebula
-{
-namespace drivers
+namespace nebula::drivers
 {
 
 template <size_t ChannelN, size_t AngleUnit>
@@ -96,5 +94,4 @@ public:
   }
 };
 
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/decoders/bpearl_v3.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/decoders/bpearl_v3.hpp
@@ -28,9 +28,7 @@
 
 using namespace boost::endian;  // NOLINT(build/namespaces)
 
-namespace nebula
-{
-namespace drivers
+namespace nebula::drivers
 {
 namespace robosense_packet
 {
@@ -473,5 +471,4 @@ public:
     return sensor_info;
   }
 };
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/decoders/bpearl_v4.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/decoders/bpearl_v4.hpp
@@ -28,9 +28,7 @@
 
 using namespace boost::endian;  // NOLINT(build/namespaces)
 
-namespace nebula
-{
-namespace drivers
+namespace nebula::drivers
 {
 namespace robosense_packet
 {
@@ -392,5 +390,4 @@ public:
     return sensor_info;
   }
 };
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/decoders/helios.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/decoders/helios.hpp
@@ -28,13 +28,9 @@
 
 using namespace boost::endian;  // NOLINT(build/namespaces)
 
-namespace nebula
+namespace nebula::drivers
 {
-namespace drivers
-{
-namespace robosense_packet
-{
-namespace helios
+namespace robosense_packet::helios
 {
 #pragma pack(push, 1)
 
@@ -161,8 +157,7 @@ struct InfoPacket
 };
 
 #pragma pack(pop)
-}  // namespace helios
-}  // namespace robosense_packet
+}  // namespace robosense_packet::helios
 
 class Helios
 : public RobosenseSensor<robosense_packet::helios::Packet, robosense_packet::helios::InfoPacket>
@@ -468,5 +463,4 @@ public:
   }
 };
 
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/decoders/robosense_decoder.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/decoders/robosense_decoder.hpp
@@ -25,9 +25,7 @@
 #include <utility>
 #include <vector>
 
-namespace nebula
-{
-namespace drivers
+namespace nebula::drivers
 {
 template <typename SensorT>
 class RobosenseDecoder : public RobosenseScanDecoder
@@ -281,5 +279,4 @@ public:
   }
 };
 
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/decoders/robosense_info_decoder.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/decoders/robosense_info_decoder.hpp
@@ -24,9 +24,7 @@
 #include <string>
 #include <vector>
 
-namespace nebula
-{
-namespace drivers
+namespace nebula::drivers
 {
 
 template <typename SensorT>
@@ -94,5 +92,4 @@ public:
   bool get_sync_status() override { return sensor_.get_sync_status(packet_); }
 };
 
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/decoders/robosense_info_decoder_base.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/decoders/robosense_info_decoder_base.hpp
@@ -20,9 +20,7 @@
 #include <map>
 #include <string>
 #include <vector>
-namespace nebula
-{
-namespace drivers
+namespace nebula::drivers
 {
 
 class RobosenseInfoDecoderBase
@@ -58,5 +56,4 @@ public:
   virtual bool get_sync_status() = 0;
 };
 
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/decoders/robosense_packet.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/decoders/robosense_packet.hpp
@@ -26,11 +26,7 @@
 
 using namespace boost::endian;  // NOLINT(build/namespaces)
 
-namespace nebula
-{
-namespace drivers
-{
-namespace robosense_packet
+namespace nebula::drivers::robosense_packet
 {
 
 #pragma pack(push, 1)
@@ -278,6 +274,4 @@ inline std::string get_float_value(const uint16_t & raw_angle)
   return std::to_string(static_cast<float>(raw_angle) / 100.0f);
 }
 
-}  // namespace robosense_packet
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers::robosense_packet

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/decoders/robosense_scan_decoder.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/decoders/robosense_scan_decoder.hpp
@@ -19,9 +19,7 @@
 #include <tuple>
 #include <vector>
 
-namespace nebula
-{
-namespace drivers
+namespace nebula::drivers
 {
 /// @brief Base class for Robosense LiDAR decoder
 class RobosenseScanDecoder
@@ -49,5 +47,4 @@ public:
   virtual std::tuple<drivers::NebulaPointCloudPtr, double> get_pointcloud() = 0;
 };
 
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/decoders/robosense_sensor.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/decoders/robosense_sensor.hpp
@@ -25,9 +25,7 @@
 #include <string>
 #include <vector>
 
-namespace nebula
-{
-namespace drivers
+namespace nebula::drivers
 {
 
 /// @brief Base class for all sensor definitions
@@ -145,5 +143,4 @@ public:
 
   virtual std::map<std::string, std::string> get_sensor_info(const info_t & info_packet) = 0;
 };
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/robosense_driver.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/robosense_driver.hpp
@@ -27,9 +27,7 @@
 #include <tuple>
 #include <vector>
 
-namespace nebula
-{
-namespace drivers
+namespace nebula::drivers
 {
 /// @brief Robosense driver
 class RobosenseDriver : NebulaDriverBase
@@ -69,5 +67,4 @@ public:
     const std::vector<uint8_t> & packet);
 };
 
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/robosense_info_driver.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/robosense_info_driver.hpp
@@ -28,9 +28,7 @@
 #include <string>
 #include <vector>
 
-namespace nebula
-{
-namespace drivers
+namespace nebula::drivers
 {
 /// @brief Robosense driver
 class RobosenseInfoDriver
@@ -67,5 +65,4 @@ public:
   bool get_sync_status();
 };
 
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/decoders/velodyne_scan_decoder.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/decoders/velodyne_scan_decoder.hpp
@@ -36,9 +36,7 @@
 #include <tuple>
 #include <vector>
 
-namespace nebula
-{
-namespace drivers
+namespace nebula::drivers
 {
 /**
  * Raw Velodyne packet constants and structures.
@@ -244,7 +242,6 @@ public:
   virtual void reset_overflow(double time_stamp) = 0;
 };
 
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers
 
 #endif  // NEBULA_WS_VELODYNE_SCAN_DECODER_HPP

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/decoders/vlp16_decoder.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/decoders/vlp16_decoder.hpp
@@ -24,11 +24,7 @@
 #include <tuple>
 #include <vector>
 
-namespace nebula
-{
-namespace drivers
-{
-namespace vlp16
+namespace nebula::drivers::vlp16
 {
 constexpr uint32_t max_points = 300000;
 /// @brief Velodyne LiDAR decoder (VLP16)
@@ -70,6 +66,4 @@ private:
   std::vector<std::vector<float>> timing_offsets_;
 };
 
-}  // namespace vlp16
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers::vlp16

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/decoders/vlp32_decoder.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/decoders/vlp32_decoder.hpp
@@ -24,11 +24,7 @@
 #include <tuple>
 #include <vector>
 
-namespace nebula
-{
-namespace drivers
-{
-namespace vlp32
+namespace nebula::drivers::vlp32
 {
 /// @brief Velodyne LiDAR decoder (VLP32)
 class Vlp32Decoder : public VelodyneScanDecoder
@@ -69,6 +65,4 @@ private:
   double last_block_timestamp_;
 };
 
-}  // namespace vlp32
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers::vlp32

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/decoders/vls128_decoder.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/decoders/vls128_decoder.hpp
@@ -24,11 +24,7 @@
 #include <tuple>
 #include <vector>
 
-namespace nebula
-{
-namespace drivers
-{
-namespace vls128
+namespace nebula::drivers::vls128
 {
 /// @brief Velodyne LiDAR decoder (VLS128)
 class Vls128Decoder : public VelodyneScanDecoder
@@ -70,6 +66,4 @@ private:
   std::vector<std::vector<float>> timing_offsets_;
 };
 
-}  // namespace vls128
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers::vls128

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/velodyne_driver.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_velodyne/velodyne_driver.hpp
@@ -34,9 +34,7 @@
 #include <tuple>
 #include <vector>
 
-namespace nebula
-{
-namespace drivers
+namespace nebula::drivers
 {
 /// @brief Velodyne driver
 class VelodyneDriver : NebulaDriverBase
@@ -74,7 +72,6 @@ public:
     const std::vector<uint8_t> & packet, double packet_seconds);
 };
 
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers
 
 #endif  // NEBULA_VELODYNE_DRIVER_H

--- a/nebula_decoders/src/nebula_decoders_continental/decoders/continental_ars548_decoder.cpp
+++ b/nebula_decoders/src/nebula_decoders_continental/decoders/continental_ars548_decoder.cpp
@@ -19,11 +19,7 @@
 #include <cmath>
 #include <utility>
 
-namespace nebula
-{
-namespace drivers
-{
-namespace continental_ars548
+namespace nebula::drivers::continental_ars548
 {
 ContinentalARS548Decoder::ContinentalARS548Decoder(
   const std::shared_ptr<const continental_ars548::ContinentalARS548SensorConfiguration> &
@@ -641,6 +637,4 @@ bool ContinentalARS548Decoder::parse_sensor_status_packet(
   return true;
 }
 
-}  // namespace continental_ars548
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers::continental_ars548

--- a/nebula_decoders/src/nebula_decoders_continental/decoders/continental_srr520_decoder.cpp
+++ b/nebula_decoders/src/nebula_decoders_continental/decoders/continental_srr520_decoder.cpp
@@ -22,11 +22,7 @@
 #include <cmath>
 #include <utility>
 
-namespace nebula
-{
-namespace drivers
-{
-namespace continental_srr520
+namespace nebula::drivers::continental_srr520
 {
 ContinentalSRR520Decoder::ContinentalSRR520Decoder(
   const std::shared_ptr<const continental_srr520::ContinentalSRR520SensorConfiguration> &
@@ -1205,6 +1201,4 @@ void ContinentalSRR520Decoder::print_debug(std::string debug)
   }
 }
 
-}  // namespace continental_srr520
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers::continental_srr520

--- a/nebula_decoders/src/nebula_decoders_hesai/hesai_driver.cpp
+++ b/nebula_decoders/src/nebula_decoders_hesai/hesai_driver.cpp
@@ -15,9 +15,7 @@
 
 // #define WITH_DEBUG_STD_COUT_HESAI_CLIENT // Use std::cout messages for debugging
 
-namespace nebula
-{
-namespace drivers
+namespace nebula::drivers
 {
 HesaiDriver::HesaiDriver(
   const std::shared_ptr<const HesaiSensorConfiguration> & sensor_configuration,
@@ -114,5 +112,4 @@ Status HesaiDriver::get_status()
   return driver_status_;
 }
 
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers

--- a/nebula_decoders/src/nebula_decoders_robosense/robosense_driver.cpp
+++ b/nebula_decoders/src/nebula_decoders_robosense/robosense_driver.cpp
@@ -7,9 +7,7 @@
 #include "nebula_decoders/nebula_decoders_robosense/decoders/helios.hpp"
 #include "nebula_decoders/nebula_decoders_robosense/decoders/robosense_decoder.hpp"
 
-namespace nebula
-{
-namespace drivers
+namespace nebula::drivers
 {
 
 RobosenseDriver::RobosenseDriver(
@@ -72,5 +70,4 @@ std::tuple<drivers::NebulaPointCloudPtr, double> RobosenseDriver::parse_cloud_pa
   return pointcloud;
 }
 
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers

--- a/nebula_decoders/src/nebula_decoders_robosense/robosense_info_driver.cpp
+++ b/nebula_decoders/src/nebula_decoders_robosense/robosense_info_driver.cpp
@@ -7,9 +7,7 @@
 #include "nebula_decoders/nebula_decoders_robosense/decoders/helios.hpp"
 #include "nebula_decoders/nebula_decoders_robosense/decoders/robosense_info_decoder.hpp"
 
-namespace nebula
-{
-namespace drivers
+namespace nebula::drivers
 {
 
 RobosenseInfoDriver::RobosenseInfoDriver(
@@ -70,5 +68,4 @@ bool RobosenseInfoDriver::get_sync_status()
   return info_decoder_->get_sync_status();
 }
 
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers

--- a/nebula_decoders/src/nebula_decoders_velodyne/decoders/vlp16_decoder.cpp
+++ b/nebula_decoders/src/nebula_decoders_velodyne/decoders/vlp16_decoder.cpp
@@ -9,9 +9,7 @@
 
 namespace nebula
 {
-namespace drivers
-{
-namespace vlp16
+namespace drivers::vlp16
 {
 Vlp16Decoder::Vlp16Decoder(
   const std::shared_ptr<const drivers::VelodyneSensorConfiguration> & sensor_configuration,
@@ -335,6 +333,5 @@ bool Vlp16Decoder::parse_packet(
   return 0;
 }
 
-}  // namespace vlp16
-}  // namespace drivers
+}  // namespace drivers::vlp16
 }  // namespace nebula

--- a/nebula_decoders/src/nebula_decoders_velodyne/decoders/vlp32_decoder.cpp
+++ b/nebula_decoders/src/nebula_decoders_velodyne/decoders/vlp32_decoder.cpp
@@ -9,9 +9,7 @@
 
 namespace nebula
 {
-namespace drivers
-{
-namespace vlp32
+namespace drivers::vlp32
 {
 Vlp32Decoder::Vlp32Decoder(
   const std::shared_ptr<const drivers::VelodyneSensorConfiguration> & sensor_configuration,
@@ -392,6 +390,5 @@ bool Vlp32Decoder::parse_packet(
   return 0;
 }
 
-}  // namespace vlp32
-}  // namespace drivers
+}  // namespace drivers::vlp32
 }  // namespace nebula

--- a/nebula_decoders/src/nebula_decoders_velodyne/decoders/vls128_decoder.cpp
+++ b/nebula_decoders/src/nebula_decoders_velodyne/decoders/vls128_decoder.cpp
@@ -9,9 +9,7 @@
 
 namespace nebula
 {
-namespace drivers
-{
-namespace vls128
+namespace drivers::vls128
 {
 Vls128Decoder::Vls128Decoder(
   const std::shared_ptr<const drivers::VelodyneSensorConfiguration> & sensor_configuration,
@@ -356,6 +354,5 @@ bool Vls128Decoder::parse_packet(
   return 0;
 }
 
-}  // namespace vls128
-}  // namespace drivers
+}  // namespace drivers::vls128
 }  // namespace nebula

--- a/nebula_decoders/src/nebula_decoders_velodyne/velodyne_driver.cpp
+++ b/nebula_decoders/src/nebula_decoders_velodyne/velodyne_driver.cpp
@@ -6,9 +6,7 @@
 #include "nebula_decoders/nebula_decoders_velodyne/decoders/vlp32_decoder.hpp"
 #include "nebula_decoders/nebula_decoders_velodyne/decoders/vls128_decoder.hpp"
 
-namespace nebula
-{
-namespace drivers
+namespace nebula::drivers
 {
 VelodyneDriver::VelodyneDriver(
   const std::shared_ptr<const drivers::VelodyneSensorConfiguration> & sensor_configuration,
@@ -72,5 +70,4 @@ Status VelodyneDriver::get_status()
   return driver_status_;
 }
 
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers

--- a/nebula_examples/include/hesai/hesai_ros_offline_extract_bag_pcd.hpp
+++ b/nebula_examples/include/hesai/hesai_ros_offline_extract_bag_pcd.hpp
@@ -31,9 +31,7 @@
 #include <memory>
 #include <string>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 class HesaiRosOfflineExtractBag final : public rclcpp::Node
 {
@@ -78,7 +76,6 @@ private:
   bool only_xyz_;
 };
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros
 
 #endif  // NEBULA_HesaiRosOfflineExtractBag_H

--- a/nebula_examples/include/hesai/hesai_ros_offline_extract_pcd.hpp
+++ b/nebula_examples/include/hesai/hesai_ros_offline_extract_pcd.hpp
@@ -29,9 +29,7 @@
 #include <memory>
 #include <string>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 /// @brief Offline hesai driver usage example (Output PCD data)
 class HesaiRosOfflineExtractSample final : public rclcpp::Node
@@ -90,7 +88,6 @@ private:
   std::string correction_file_path_;
 };
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros
 
 #endif  // NEBULA_HesaiRosOfflineExtractSample_H

--- a/nebula_examples/include/velodyne/velodyne_ros_offline_extract_bag_pcd.hpp
+++ b/nebula_examples/include/velodyne/velodyne_ros_offline_extract_bag_pcd.hpp
@@ -28,9 +28,7 @@
 #include <memory>
 #include <string>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 /// @brief Offline velodyne driver usage example (Output PCD data)
 class VelodyneRosOfflineExtractBag final : public rclcpp::Node
@@ -88,7 +86,6 @@ private:
   bool only_xyz_;
 };
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros
 
 #endif  // NEBULA_VelodyneRosOfflineExtractBag_H

--- a/nebula_examples/src/common/parameter_descriptors.cpp
+++ b/nebula_examples/src/common/parameter_descriptors.cpp
@@ -2,9 +2,7 @@
 
 #include "nebula_ros/common/parameter_descriptors.hpp"
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 
 rcl_interfaces::msg::ParameterDescriptor param_read_write()
@@ -32,5 +30,4 @@ rcl_interfaces::msg::ParameterDescriptor::_integer_range_type int_range(
     rcl_interfaces::msg::IntegerRange().set__from_value(start).set__to_value(stop).set__step(step)};
 }
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_examples/src/hesai/hesai_ros_offline_extract_bag_pcd.cpp
+++ b/nebula_examples/src/hesai/hesai_ros_offline_extract_bag_pcd.cpp
@@ -26,9 +26,7 @@
 
 #include <regex>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 HesaiRosOfflineExtractBag::HesaiRosOfflineExtractBag(
   const rclcpp::NodeOptions & options, const std::string & node_name)
@@ -268,5 +266,4 @@ Status HesaiRosOfflineExtractBag::read_bag()
   return Status::OK;
 }
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_examples/src/hesai/hesai_ros_offline_extract_pcd.cpp
+++ b/nebula_examples/src/hesai/hesai_ros_offline_extract_pcd.cpp
@@ -27,9 +27,7 @@
 
 #include <regex>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 HesaiRosOfflineExtractSample::HesaiRosOfflineExtractSample(
   const rclcpp::NodeOptions & options, const std::string & node_name)
@@ -226,5 +224,4 @@ Status HesaiRosOfflineExtractSample::read_bag()
   return Status::OK;
 }
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_examples/src/velodyne/velodyne_ros_offline_extract_bag_pcd.cpp
+++ b/nebula_examples/src/velodyne/velodyne_ros_offline_extract_bag_pcd.cpp
@@ -19,9 +19,7 @@
 
 #include <regex>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 VelodyneRosOfflineExtractBag::VelodyneRosOfflineExtractBag(
   const rclcpp::NodeOptions & options, const std::string & node_name)
@@ -392,5 +390,4 @@ Status VelodyneRosOfflineExtractBag::read_bag()
   return Status::OK;
 }
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_common/nebula_hw_interface_base.hpp
+++ b/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_common/nebula_hw_interface_base.hpp
@@ -21,9 +21,7 @@
 #include <memory>
 #include <vector>
 
-namespace nebula
-{
-namespace drivers
+namespace nebula::drivers
 {
 /// @brief Base class for hardware interface of each LiDAR
 class NebulaHwInterfaceBase
@@ -77,7 +75,6 @@ public:
   }
 };
 
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers
 
 #endif  // NEBULA_HW_INTERFACE_BASE_H

--- a/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_continental/continental_ars548_hw_interface.hpp
+++ b/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_continental/continental_ars548_hw_interface.hpp
@@ -27,11 +27,7 @@
 #include <string>
 #include <vector>
 
-namespace nebula
-{
-namespace drivers
-{
-namespace continental_ars548
+namespace nebula::drivers::continental_ars548
 {
 /// @brief Hardware interface of the Continental ARS548 radar
 class ContinentalARS548HwInterface
@@ -167,8 +163,6 @@ private:
 
   std::shared_ptr<rclcpp::Logger> parent_node_logger_ptr_;
 };
-}  // namespace continental_ars548
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers::continental_ars548
 
 #endif  // NEBULA_CONTINENTAL_ARS548_HW_INTERFACE_H

--- a/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_continental/continental_srr520_hw_interface.hpp
+++ b/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_continental/continental_srr520_hw_interface.hpp
@@ -30,11 +30,7 @@
 #include <string>
 #include <vector>
 
-namespace nebula
-{
-namespace drivers
-{
-namespace continental_srr520
+namespace nebula::drivers::continental_srr520
 {
 /// @brief Hardware interface of the Continental SRR520 radar
 class ContinentalSRR520HwInterface
@@ -141,8 +137,6 @@ private:
 
   std::shared_ptr<rclcpp::Logger> parent_node_logger_ptr_;
 };
-}  // namespace continental_srr520
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers::continental_srr520
 
 #endif  // NEBULA_CONTINENTAL_SRR520_HW_INTERFACE_H

--- a/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_hesai/hesai_hw_interface.hpp
+++ b/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_hesai/hesai_hw_interface.hpp
@@ -45,9 +45,7 @@
 #include <string>
 #include <vector>
 
-namespace nebula
-{
-namespace drivers
+namespace nebula::drivers
 {
 const int PandarTcpCommandPort = 9347;
 const uint8_t PTC_COMMAND_DUMMY_BYTE = 0x00;
@@ -461,7 +459,6 @@ public:
   /// @param node Logger
   void SetLogger(std::shared_ptr<rclcpp::Logger> node);
 };
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers
 
 #endif  // NEBULA_HESAI_HW_INTERFACE_H

--- a/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_robosense/robosense_hw_interface.hpp
+++ b/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_robosense/robosense_hw_interface.hpp
@@ -33,9 +33,7 @@
 #include <string>
 #include <vector>
 
-namespace nebula
-{
-namespace drivers
+namespace nebula::drivers
 {
 constexpr uint16_t mtu_size = 1248;
 constexpr uint16_t helios_packet_size = 1248;
@@ -107,5 +105,4 @@ public:
   void set_logger(std::shared_ptr<rclcpp::Logger> logger);
 };
 
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers

--- a/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_velodyne/velodyne_hw_interface.hpp
+++ b/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_velodyne/velodyne_hw_interface.hpp
@@ -41,9 +41,7 @@
 #include <string>
 #include <vector>
 
-namespace nebula
-{
-namespace drivers
+namespace nebula::drivers
 {
 /// @brief Hardware interface of velodyne driver
 class VelodyneHwInterface
@@ -227,7 +225,6 @@ public:
   void set_logger(std::shared_ptr<rclcpp::Logger> node);
 };
 
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers
 
 #endif  // NEBULA_VELODYNE_HW_INTERFACE_H

--- a/nebula_hw_interfaces/src/nebula_continental_hw_interfaces/continental_ars548_hw_interface.cpp
+++ b/nebula_hw_interfaces/src/nebula_continental_hw_interfaces/continental_ars548_hw_interface.cpp
@@ -17,11 +17,7 @@
 
 #include <nebula_common/continental/continental_ars548.hpp>
 
-namespace nebula
-{
-namespace drivers
-{
-namespace continental_ars548
+namespace nebula::drivers::continental_ars548
 {
 ContinentalARS548HwInterface::ContinentalARS548HwInterface()
 : sensor_io_context_ptr_{new ::drivers::common::IoContext(1)},
@@ -531,6 +527,4 @@ void ContinentalARS548HwInterface::print_debug(std::string debug)
   }
 }
 
-}  // namespace continental_ars548
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers::continental_ars548

--- a/nebula_hw_interfaces/src/nebula_continental_hw_interfaces/continental_srr520_hw_interface.cpp
+++ b/nebula_hw_interfaces/src/nebula_continental_hw_interfaces/continental_srr520_hw_interface.cpp
@@ -21,11 +21,7 @@
 #include <limits>
 #include <sstream>
 
-namespace nebula
-{
-namespace drivers
-{
-namespace continental_srr520
+namespace nebula::drivers::continental_srr520
 {
 ContinentalSRR520HwInterface::ContinentalSRR520HwInterface()
 {
@@ -400,6 +396,4 @@ void ContinentalSRR520HwInterface::print_debug(std::string debug)
   }
 }
 
-}  // namespace continental_srr520
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers::continental_srr520

--- a/nebula_hw_interfaces/src/nebula_robosense_hw_interfaces/robosense_hw_interface.cpp
+++ b/nebula_hw_interfaces/src/nebula_robosense_hw_interfaces/robosense_hw_interface.cpp
@@ -1,9 +1,7 @@
 // Copyright 2024 TIER IV, Inc.
 
 #include "nebula_hw_interfaces/nebula_hw_interfaces_robosense/robosense_hw_interface.hpp"
-namespace nebula
-{
-namespace drivers
+namespace nebula::drivers
 {
 RobosenseHwInterface::RobosenseHwInterface()
 : cloud_io_context_(new ::drivers::common::IoContext(1)),
@@ -126,5 +124,4 @@ void RobosenseHwInterface::set_logger(std::shared_ptr<rclcpp::Logger> logger)
   parent_node_logger_ = logger;
 }
 
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers

--- a/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
+++ b/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
@@ -2,9 +2,7 @@
 
 #include "nebula_hw_interfaces/nebula_hw_interfaces_velodyne/velodyne_hw_interface.hpp"
 
-namespace nebula
-{
-namespace drivers
+namespace nebula::drivers
 {
 VelodyneHwInterface::VelodyneHwInterface()
 : cloud_io_context_{new ::drivers::common::IoContext(1)},
@@ -430,5 +428,4 @@ void VelodyneHwInterface::print_debug(std::string debug)
   }
 }
 
-}  // namespace drivers
-}  // namespace nebula
+}  // namespace nebula::drivers

--- a/nebula_ros/include/nebula_ros/common/parameter_descriptors.hpp
+++ b/nebula_ros/include/nebula_ros/common/parameter_descriptors.hpp
@@ -20,9 +20,7 @@
 
 #include <string>
 #include <vector>
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 
 rcl_interfaces::msg::ParameterDescriptor param_read_write();
@@ -54,5 +52,4 @@ bool get_param(const std::vector<rclcpp::Parameter> & p, const std::string & nam
   return false;
 }
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/include/nebula_ros/common/watchdog_timer.hpp
+++ b/nebula_ros/include/nebula_ros/common/watchdog_timer.hpp
@@ -21,9 +21,7 @@
 #include <cstdint>
 #include <functional>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 
 class WatchdogTimer
@@ -67,5 +65,4 @@ private:
   const uint64_t expected_update_interval_ns_;
 };
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/include/nebula_ros/continental/continental_ars548_decoder_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/continental/continental_ars548_decoder_wrapper.hpp
@@ -40,9 +40,7 @@
 #include <unordered_set>
 #include <vector>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 class ContinentalARS548DecoderWrapper
 {
@@ -166,5 +164,4 @@ private:
 
   std::shared_ptr<WatchdogTimer> watchdog_;
 };
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/include/nebula_ros/continental/continental_ars548_hw_interface_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/continental/continental_ars548_hw_interface_wrapper.hpp
@@ -30,9 +30,7 @@
 
 #include <memory>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 class ContinentalARS548HwInterfaceWrapper
 {
@@ -127,5 +125,4 @@ private:
   rclcpp::Service<continental_srvs::srv::ContinentalArs548SetRadarParameters>::SharedPtr
     set_radar_parameters_service_server_{};
 };
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/include/nebula_ros/continental/continental_ars548_ros_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/continental/continental_ars548_ros_wrapper.hpp
@@ -36,9 +36,7 @@
 #include <thread>
 #include <vector>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 
 /// @brief Ros wrapper of continental ars548 driver
@@ -99,5 +97,4 @@ private:
   OnSetParametersCallbackHandle::SharedPtr parameter_event_cb_{};
 };
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/include/nebula_ros/continental/continental_srr520_decoder_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/continental/continental_srr520_decoder_wrapper.hpp
@@ -41,9 +41,7 @@
 #include <unordered_set>
 #include <vector>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 class ContinentalSRR520DecoderWrapper
 {
@@ -159,5 +157,4 @@ private:
 
   std::shared_ptr<WatchdogTimer> watchdog_;
 };
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/include/nebula_ros/continental/continental_srr520_hw_interface_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/continental/continental_srr520_hw_interface_wrapper.hpp
@@ -30,9 +30,7 @@
 
 #include <memory>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 class ContinentalSRR520HwInterfaceWrapper
 {
@@ -96,5 +94,4 @@ private:
   rclcpp::Service<continental_srvs::srv::ContinentalSrr520SetRadarParameters>::SharedPtr
     configure_sensor_service_server_{};
 };
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/include/nebula_ros/continental/continental_srr520_ros_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/continental/continental_srr520_ros_wrapper.hpp
@@ -34,9 +34,7 @@
 #include <thread>
 #include <vector>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 
 /// @brief Ros wrapper of continental srr520 driver
@@ -98,5 +96,4 @@ private:
   OnSetParametersCallbackHandle::SharedPtr parameter_event_cb_;
 };
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/include/nebula_ros/hesai/decoder_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/hesai/decoder_wrapper.hpp
@@ -28,9 +28,7 @@
 #include <memory>
 #include <mutex>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 class HesaiDecoderWrapper
 {
@@ -85,5 +83,4 @@ private:
 
   std::shared_ptr<WatchdogTimer> cloud_watchdog_;
 };
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/include/nebula_ros/hesai/hesai_ros_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/hesai/hesai_ros_wrapper.hpp
@@ -40,9 +40,7 @@
 #include <thread>
 #include <vector>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 
 /// @brief Ros wrapper of hesai driver
@@ -118,5 +116,4 @@ private:
   OnSetParametersCallbackHandle::SharedPtr parameter_event_cb_;
 };
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/include/nebula_ros/hesai/hw_interface_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/hesai/hw_interface_wrapper.hpp
@@ -20,9 +20,7 @@
 
 #include <memory>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 class HesaiHwInterfaceWrapper
 {
@@ -44,5 +42,4 @@ private:
   nebula::Status status_;
   bool setup_sensor_;
 };
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/include/nebula_ros/hesai/hw_monitor_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/hesai/hw_monitor_wrapper.hpp
@@ -28,9 +28,7 @@
 #include <string>
 #include <vector>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 class HesaiHwMonitorWrapper
 {
@@ -111,5 +109,4 @@ private:
   const std::string MSG_ERROR_ = "Error";
   const std::string MSG_SEP_ = ": ";
 };
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/include/nebula_ros/robosense/decoder_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/robosense/decoder_wrapper.hpp
@@ -29,9 +29,7 @@
 #include <chrono>
 #include <memory>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 /// @brief Ros wrapper of robosense driver
 class RobosenseDecoderWrapper
@@ -84,5 +82,4 @@ private:
   std::shared_ptr<WatchdogTimer> cloud_watchdog_;
 };
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/include/nebula_ros/robosense/hw_interface_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/robosense/hw_interface_wrapper.hpp
@@ -21,9 +21,7 @@
 
 #include <memory>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 class RobosenseHwInterfaceWrapper
 {
@@ -45,5 +43,4 @@ private:
   nebula::Status status_;
 };
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/include/nebula_ros/robosense/hw_monitor_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/robosense/hw_monitor_wrapper.hpp
@@ -30,9 +30,7 @@
 #include <mutex>
 #include <string>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 
 /// @brief Hardware monitor ros wrapper of robosense driver
@@ -77,5 +75,4 @@ private:
   uint16_t diag_span_{1000};
 };
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/include/nebula_ros/robosense/robosense_ros_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/robosense/robosense_ros_wrapper.hpp
@@ -43,9 +43,7 @@
 #include <thread>
 #include <vector>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 
 /// @brief Ros wrapper of robosense driver
@@ -105,5 +103,4 @@ private:
   OnSetParametersCallbackHandle::SharedPtr parameter_event_cb_;
 };
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/include/nebula_ros/velodyne/decoder_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/velodyne/decoder_wrapper.hpp
@@ -34,9 +34,7 @@
 #include <string>
 #include <vector>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 class VelodyneDecoderWrapper
 {
@@ -103,5 +101,4 @@ private:
 
   std::shared_ptr<WatchdogTimer> cloud_watchdog_;
 };
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/include/nebula_ros/velodyne/hw_interface_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/velodyne/hw_interface_wrapper.hpp
@@ -22,9 +22,7 @@
 
 #include <memory>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 class VelodyneHwInterfaceWrapper
 {
@@ -46,5 +44,4 @@ private:
   nebula::Status status_;
   bool setup_sensor_;
 };
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/include/nebula_ros/velodyne/hw_monitor_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/velodyne/hw_monitor_wrapper.hpp
@@ -31,9 +31,7 @@
 #include <string>
 #include <tuple>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 class VelodyneHwMonitorWrapper
 {
@@ -377,5 +375,4 @@ private:
   static constexpr auto ampere_low_message = "ampere low";
   static constexpr auto ampere_high_message = "ampere high";
 };
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/include/nebula_ros/velodyne/velodyne_ros_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/velodyne/velodyne_ros_wrapper.hpp
@@ -44,9 +44,7 @@
 #include <thread>
 #include <vector>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 
 /// @brief Ros wrapper of velodyne driver
@@ -102,5 +100,4 @@ private:
   OnSetParametersCallbackHandle::SharedPtr parameter_event_cb_;
 };
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/src/common/parameter_descriptors.cpp
+++ b/nebula_ros/src/common/parameter_descriptors.cpp
@@ -2,9 +2,7 @@
 
 #include "nebula_ros/common/parameter_descriptors.hpp"
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 
 rcl_interfaces::msg::ParameterDescriptor param_read_write()
@@ -32,5 +30,4 @@ rcl_interfaces::msg::ParameterDescriptor::_integer_range_type int_range(
     rcl_interfaces::msg::IntegerRange().set__from_value(start).set__to_value(stop).set__step(step)};
 }
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/src/continental/continental_ars548_decoder_wrapper.cpp
+++ b/nebula_ros/src/continental/continental_ars548_decoder_wrapper.cpp
@@ -16,9 +16,7 @@
 
 #include <pcl_conversions/pcl_conversions.h>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 ContinentalARS548DecoderWrapper::ContinentalARS548DecoderWrapper(
   rclcpp::Node * const parent_node,
@@ -707,5 +705,4 @@ nebula::Status ContinentalARS548DecoderWrapper::status()
 
   return driver_ptr_->get_status();
 }
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/src/continental/continental_ars548_hw_interface_wrapper.cpp
+++ b/nebula_ros/src/continental/continental_ars548_hw_interface_wrapper.cpp
@@ -17,9 +17,7 @@
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 
 ContinentalARS548HwInterfaceWrapper::ContinentalARS548HwInterfaceWrapper(
@@ -285,5 +283,4 @@ void ContinentalARS548HwInterfaceWrapper::set_radar_parameters_request_callback(
   response->message = (std::stringstream() << result).str();
 }
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/src/continental/continental_ars548_ros_wrapper.cpp
+++ b/nebula_ros/src/continental/continental_ars548_ros_wrapper.cpp
@@ -16,9 +16,7 @@
 
 #pragma clang diagnostic ignored "-Wbitwise-instead-of-logical"
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 ContinentalARS548RosWrapper::ContinentalARS548RosWrapper(const rclcpp::NodeOptions & options)
 : rclcpp::Node(
@@ -232,5 +230,4 @@ rcl_interfaces::msg::SetParametersResult ContinentalARS548RosWrapper::on_paramet
 }
 
 RCLCPP_COMPONENTS_REGISTER_NODE(ContinentalARS548RosWrapper)
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/src/continental/continental_srr520_decoder_wrapper.cpp
+++ b/nebula_ros/src/continental/continental_srr520_decoder_wrapper.cpp
@@ -16,9 +16,7 @@
 
 #include <pcl_conversions/pcl_conversions.h>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 ContinentalSRR520DecoderWrapper::ContinentalSRR520DecoderWrapper(
   rclcpp::Node * const parent_node,
@@ -599,5 +597,4 @@ nebula::Status ContinentalSRR520DecoderWrapper::status()
 
   return driver_ptr_->get_status();
 }
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/src/continental/continental_srr520_hw_interface_wrapper.cpp
+++ b/nebula_ros/src/continental/continental_srr520_hw_interface_wrapper.cpp
@@ -17,9 +17,7 @@
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 
 ContinentalSRR520HwInterfaceWrapper::ContinentalSRR520HwInterfaceWrapper(
@@ -180,5 +178,4 @@ void ContinentalSRR520HwInterfaceWrapper::sync_timer_callback()
   hw_interface_->sensor_sync();
 }
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/src/continental/continental_srr520_ros_wrapper.cpp
+++ b/nebula_ros/src/continental/continental_srr520_ros_wrapper.cpp
@@ -16,9 +16,7 @@
 
 #pragma clang diagnostic ignored "-Wbitwise-instead-of-logical"
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 ContinentalSRR520RosWrapper::ContinentalSRR520RosWrapper(const rclcpp::NodeOptions & options)
 : rclcpp::Node(
@@ -217,5 +215,4 @@ rcl_interfaces::msg::SetParametersResult ContinentalSRR520RosWrapper::on_paramet
 }
 
 RCLCPP_COMPONENTS_REGISTER_NODE(ContinentalSRR520RosWrapper)
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/src/hesai/decoder_wrapper.cpp
+++ b/nebula_ros/src/hesai/decoder_wrapper.cpp
@@ -9,9 +9,7 @@
 #include <memory>
 
 #pragma clang diagnostic ignored "-Wbitwise-instead-of-logical"
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 
 using namespace std::chrono_literals;  // NOLINT(build/namespaces)
@@ -191,5 +189,4 @@ nebula::Status HesaiDecoderWrapper::status()
 
   return driver_ptr_->get_status();
 }
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/src/hesai/hesai_ros_wrapper.cpp
+++ b/nebula_ros/src/hesai/hesai_ros_wrapper.cpp
@@ -17,9 +17,7 @@
 
 #pragma clang diagnostic ignored "-Wbitwise-instead-of-logical"
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 HesaiRosWrapper::HesaiRosWrapper(const rclcpp::NodeOptions & options)
 : rclcpp::Node("hesai_ros_wrapper", rclcpp::NodeOptions(options).use_intra_process_comms(true)),
@@ -507,5 +505,4 @@ HesaiRosWrapper::get_calibration_result_t HesaiRosWrapper::get_calibration_data(
 }
 
 RCLCPP_COMPONENTS_REGISTER_NODE(HesaiRosWrapper)
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/src/hesai/hw_interface_wrapper.cpp
+++ b/nebula_ros/src/hesai/hw_interface_wrapper.cpp
@@ -4,9 +4,7 @@
 
 #include "nebula_ros/common/parameter_descriptors.hpp"
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 
 HesaiHwInterfaceWrapper::HesaiHwInterfaceWrapper(
@@ -82,5 +80,4 @@ std::shared_ptr<drivers::HesaiHwInterface> HesaiHwInterfaceWrapper::hw_interface
   return hw_interface_;
 }
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/src/hesai/hw_monitor_wrapper.cpp
+++ b/nebula_ros/src/hesai/hw_monitor_wrapper.cpp
@@ -6,9 +6,7 @@
 
 #include <nebula_common/nebula_common.hpp>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 HesaiHwMonitorWrapper::HesaiHwMonitorWrapper(
   rclcpp::Node * const parent_node,
@@ -376,5 +374,4 @@ Status HesaiHwMonitorWrapper::status()
 {
   return Status::OK;
 }
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/src/robosense/decoder_wrapper.cpp
+++ b/nebula_ros/src/robosense/decoder_wrapper.cpp
@@ -2,9 +2,7 @@
 
 #include "nebula_ros/robosense/decoder_wrapper.hpp"
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 
 using namespace std::chrono_literals;  // NOLINT(build/namespaces)
@@ -157,5 +155,4 @@ void RobosenseDecoderWrapper::publish_cloud(
   publisher->publish(std::move(pointcloud));
 }
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/src/robosense/hw_interface_wrapper.cpp
+++ b/nebula_ros/src/robosense/hw_interface_wrapper.cpp
@@ -2,9 +2,7 @@
 
 #include "nebula_ros/robosense/hw_interface_wrapper.hpp"
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 RobosenseHwInterfaceWrapper::RobosenseHwInterfaceWrapper(
   rclcpp::Node * const parent_node,
@@ -39,5 +37,4 @@ std::shared_ptr<drivers::RobosenseHwInterface> RobosenseHwInterfaceWrapper::hw_i
   return hw_interface_;
 }
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/src/robosense/hw_monitor_wrapper.cpp
+++ b/nebula_ros/src/robosense/hw_monitor_wrapper.cpp
@@ -6,9 +6,7 @@
 
 #include <memory>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 RobosenseHwMonitorWrapper::RobosenseHwMonitorWrapper(
   rclcpp::Node * const parent_node,
@@ -109,5 +107,4 @@ void RobosenseHwMonitorWrapper::on_config_change(
   sensor_cfg_ptr_ = new_config;
 }
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/src/robosense/robosense_ros_wrapper.cpp
+++ b/nebula_ros/src/robosense/robosense_ros_wrapper.cpp
@@ -6,9 +6,7 @@
 
 #pragma clang diagnostic ignored "-Wbitwise-instead-of-logical"
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 RobosenseRosWrapper::RobosenseRosWrapper(const rclcpp::NodeOptions & options)
 : rclcpp::Node("robosense_ros_wrapper", rclcpp::NodeOptions(options).use_intra_process_comms(true)),
@@ -287,5 +285,4 @@ void RobosenseRosWrapper::receive_cloud_packet_callback(std::vector<uint8_t> & p
 }
 
 RCLCPP_COMPONENTS_REGISTER_NODE(RobosenseRosWrapper)
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/src/velodyne/decoder_wrapper.cpp
+++ b/nebula_ros/src/velodyne/decoder_wrapper.cpp
@@ -4,9 +4,7 @@
 
 #include <rclcpp/time.hpp>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 
 using namespace std::chrono_literals;  // NOLINT(build/namespaces)
@@ -249,5 +247,4 @@ nebula::Status VelodyneDecoderWrapper::status()
 
   return driver_ptr_->get_status();
 }
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/src/velodyne/hw_interface_wrapper.cpp
+++ b/nebula_ros/src/velodyne/hw_interface_wrapper.cpp
@@ -2,9 +2,7 @@
 
 #include "nebula_ros/velodyne/hw_interface_wrapper.hpp"
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 
 VelodyneHwInterfaceWrapper::VelodyneHwInterfaceWrapper(
@@ -65,5 +63,4 @@ std::shared_ptr<drivers::VelodyneHwInterface> VelodyneHwInterfaceWrapper::hw_int
   return hw_interface_;
 }
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/src/velodyne/hw_monitor_wrapper.cpp
+++ b/nebula_ros/src/velodyne/hw_monitor_wrapper.cpp
@@ -2,9 +2,7 @@
 
 #include "nebula_ros/velodyne/hw_monitor_wrapper.hpp"
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 VelodyneHwMonitorWrapper::VelodyneHwMonitorWrapper(
   rclcpp::Node * const parent_node,
@@ -1513,5 +1511,4 @@ Status VelodyneHwMonitorWrapper::status()
 {
   return Status::OK;
 }
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_ros/src/velodyne/velodyne_ros_wrapper.cpp
+++ b/nebula_ros/src/velodyne/velodyne_ros_wrapper.cpp
@@ -4,9 +4,7 @@
 
 #pragma clang diagnostic ignored "-Wbitwise-instead-of-logical"
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 VelodyneRosWrapper::VelodyneRosWrapper(const rclcpp::NodeOptions & options)
 : rclcpp::Node("velodyne_ros_wrapper", rclcpp::NodeOptions(options).use_intra_process_comms(true)),
@@ -253,5 +251,4 @@ void VelodyneRosWrapper::receive_cloud_packet_callback(std::vector<uint8_t> & pa
 }
 
 RCLCPP_COMPONENTS_REGISTER_NODE(VelodyneRosWrapper)
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_tests/continental/continental_ros_decoder_test_ars548.cpp
+++ b/nebula_tests/continental/continental_ros_decoder_test_ars548.cpp
@@ -34,9 +34,7 @@
 #include <string>
 #include <utility>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 ContinentalRosDecoderTest::ContinentalRosDecoderTest(
   const rclcpp::NodeOptions & options, const std::string & node_name)
@@ -229,5 +227,4 @@ void ContinentalRosDecoderTest::read_bag()
   }
 }
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_tests/continental/continental_ros_decoder_test_ars548.hpp
+++ b/nebula_tests/continental/continental_ros_decoder_test_ars548.hpp
@@ -31,9 +31,7 @@
 #include <memory>
 #include <string>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 class ContinentalRosDecoderTest final : public rclcpp::Node  //, testing::Test
 {
@@ -81,7 +79,6 @@ private:
   std::string target_topic_{};
 };
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros
 
 #endif  // NEBULA_ContinentalRosDecoderTestArs548_H

--- a/nebula_tests/continental/continental_ros_decoder_test_srr520.cpp
+++ b/nebula_tests/continental/continental_ros_decoder_test_srr520.cpp
@@ -34,9 +34,7 @@
 #include <string>
 #include <utility>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 ContinentalRosDecoderTest::ContinentalRosDecoderTest(
   const rclcpp::NodeOptions & options, const std::string & node_name)
@@ -255,5 +253,4 @@ void ContinentalRosDecoderTest::read_bag()
   EXPECT_EQ(1, object_list_count_);
 }
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_tests/continental/continental_ros_decoder_test_srr520.hpp
+++ b/nebula_tests/continental/continental_ros_decoder_test_srr520.hpp
@@ -31,9 +31,7 @@
 #include <memory>
 #include <string>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 class ContinentalRosDecoderTest final : public rclcpp::Node  //, testing::Test
 {
@@ -91,7 +89,6 @@ private:
   std::size_t object_list_count_{};
 };
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros
 
 #endif  // NEBULA_ContinentalRosDecoderTestsrr520_H

--- a/nebula_tests/continental/parameter_descriptors.cpp
+++ b/nebula_tests/continental/parameter_descriptors.cpp
@@ -2,9 +2,7 @@
 
 #include "parameter_descriptors.hpp"
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 
 rcl_interfaces::msg::ParameterDescriptor param_read_write()
@@ -32,5 +30,4 @@ rcl_interfaces::msg::ParameterDescriptor::_integer_range_type int_range(
     rcl_interfaces::msg::IntegerRange().set__from_value(start).set__to_value(stop).set__step(step)};
 }
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_tests/continental/parameter_descriptors.hpp
+++ b/nebula_tests/continental/parameter_descriptors.hpp
@@ -20,9 +20,7 @@
 
 #include <string>
 #include <vector>
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 
 rcl_interfaces::msg::ParameterDescriptor param_read_write();
@@ -54,5 +52,4 @@ bool get_param(const std::vector<rclcpp::Parameter> & p, const std::string & nam
   return false;
 }
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_tests/hesai/hesai_common.hpp
+++ b/nebula_tests/hesai/hesai_common.hpp
@@ -26,9 +26,7 @@
 
 #include <algorithm>
 
-namespace nebula
-{
-namespace test
+namespace nebula::test
 {
 
 inline void check_pcds(
@@ -79,5 +77,4 @@ inline void print_pcd(nebula::drivers::NebulaPointCloudPtr pp)
   }
 }
 
-}  // namespace test
-}  // namespace nebula
+}  // namespace nebula::test

--- a/nebula_tests/hesai/hesai_ros_decoder_test.cpp
+++ b/nebula_tests/hesai/hesai_ros_decoder_test.cpp
@@ -20,9 +20,7 @@
 #include <filesystem>
 #include <regex>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 HesaiRosDecoderTest::HesaiRosDecoderTest(
   const rclcpp::NodeOptions & options, const std::string & node_name,
@@ -202,5 +200,4 @@ void HesaiRosDecoderTest::read_bag(
   }
 }
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_tests/hesai/hesai_ros_decoder_test.hpp
+++ b/nebula_tests/hesai/hesai_ros_decoder_test.hpp
@@ -35,9 +35,7 @@
 #define _SRC_RESOURCES_DIR_PATH ""
 #endif
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 
 struct HesaiRosDecoderTestParams
@@ -137,5 +135,4 @@ public:
   HesaiRosDecoderTestParams params_;
 };
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_tests/hesai/hesai_ros_decoder_test_main.cpp
+++ b/nebula_tests/hesai/hesai_ros_decoder_test_main.cpp
@@ -21,9 +21,7 @@
 #include <string>
 #include <vector>
 
-namespace nebula
-{
-namespace test
+namespace nebula::test
 {
 
 const nebula::ros::HesaiRosDecoderTestParams TEST_CONFIGS[6] = {
@@ -160,8 +158,7 @@ INSTANTIATE_TEST_SUITE_P(
     return p.param.sensor_model;
   });
 
-}  // namespace test
-}  // namespace nebula
+}  // namespace nebula::test
 
 int main(int argc, char * argv[])
 {

--- a/nebula_tests/hesai/hesai_ros_decoder_test_main.hpp
+++ b/nebula_tests/hesai/hesai_ros_decoder_test_main.hpp
@@ -22,9 +22,7 @@
 
 #include <memory>
 
-namespace nebula
-{
-namespace test
+namespace nebula::test
 {
 class DecoderTest : public ::testing::TestWithParam<nebula::ros::HesaiRosDecoderTestParams>
 {
@@ -39,5 +37,4 @@ protected:
   std::shared_ptr<rclcpp::Logger> logger_;
 };
 
-}  // namespace test
-}  // namespace nebula
+}  // namespace nebula::test

--- a/nebula_tests/velodyne/velodyne_ros_decoder_test_vlp16.cpp
+++ b/nebula_tests/velodyne/velodyne_ros_decoder_test_vlp16.cpp
@@ -17,9 +17,7 @@
 #include <string>
 #include <vector>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 VelodyneRosDecoderTest::VelodyneRosDecoderTest(
   const rclcpp::NodeOptions & options, const std::string & node_name)
@@ -368,5 +366,4 @@ void VelodyneRosDecoderTest::read_bag()
   }
 }
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_tests/velodyne/velodyne_ros_decoder_test_vlp16.hpp
+++ b/nebula_tests/velodyne/velodyne_ros_decoder_test_vlp16.hpp
@@ -30,9 +30,7 @@
 #include <memory>
 #include <string>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 /// @brief Testing decoder of VLP16 (Keeps VelodyneDriverRosWrapper structure as much as possible)
 class VelodyneRosDecoderTest final : public rclcpp::Node
@@ -98,7 +96,6 @@ private:
   std::string correction_file_path_;
 };
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros
 
 #endif  // NEBULA_VelodyneRosDecoderTestVlp16_H

--- a/nebula_tests/velodyne/velodyne_ros_decoder_test_vlp32.cpp
+++ b/nebula_tests/velodyne/velodyne_ros_decoder_test_vlp32.cpp
@@ -15,9 +15,7 @@
 #include <regex>
 #include <vector>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 VelodyneRosDecoderTest::VelodyneRosDecoderTest(
   const rclcpp::NodeOptions & options, const std::string & node_name)
@@ -368,5 +366,4 @@ void VelodyneRosDecoderTest::read_bag()
   }
 }
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_tests/velodyne/velodyne_ros_decoder_test_vlp32.hpp
+++ b/nebula_tests/velodyne/velodyne_ros_decoder_test_vlp32.hpp
@@ -30,9 +30,7 @@
 #include <memory>
 #include <string>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 /// @brief Testing decoder of VLP16 (Keeps VelodyneDriverRosWrapper structure as much as possible)
 class VelodyneRosDecoderTest final : public rclcpp::Node
@@ -98,7 +96,6 @@ private:
   std::string correction_file_path_;
 };
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros
 
 #endif  // NEBULA_VelodyneRosDecoderTestVlp16_H

--- a/nebula_tests/velodyne/velodyne_ros_decoder_test_vls128.cpp
+++ b/nebula_tests/velodyne/velodyne_ros_decoder_test_vls128.cpp
@@ -20,9 +20,7 @@
 #include <string>
 #include <vector>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 VelodyneRosDecoderTest::VelodyneRosDecoderTest(
   const rclcpp::NodeOptions & options, const std::string & node_name)
@@ -370,5 +368,4 @@ void VelodyneRosDecoderTest::read_bag()
   }
 }
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros

--- a/nebula_tests/velodyne/velodyne_ros_decoder_test_vls128.hpp
+++ b/nebula_tests/velodyne/velodyne_ros_decoder_test_vls128.hpp
@@ -30,9 +30,7 @@
 #include <memory>
 #include <string>
 
-namespace nebula
-{
-namespace ros
+namespace nebula::ros
 {
 class VelodyneRosDecoderTest final : public rclcpp::Node
 {
@@ -72,7 +70,6 @@ private:
   std::string correction_file_path_;
 };
 
-}  // namespace ros
-}  // namespace nebula
+}  // namespace nebula::ros
 
 #endif  // NEBULA_VelodyneRosDecoderTestVls128_H


### PR DESCRIPTION
## PR Type

- Improvement

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description

These changes are auto-applied by Clang-Tidy.
I confirmed all diffs are of the shape (old -> new)

```cpp
namespace a {
namespace b {
} // b
} // a
```

->

```cpp
namespace a::b {
} // a::b


## Review Procedure

None necessary if CI passes.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
