### PR TITLE
feat: allow to launch hardware in listen mode

### DIFF
--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -60,21 +60,22 @@ Parameters shared by all supported models:
 
 ### Hardware interface parameters
 
-| Parameter                      | Type   | Default         | Accepted values   | Description                    |
-| ------------------------------ | ------ | --------------- | ----------------- | ------------------------------ |
-| frame_id                       | string | hesai           |                   | ROS frame ID                   |
-| sensor_ip                      | string | 192.168.1.201   |                   | Sensor IP                      |
-| host_ip                        | string | 255.255.255.255 |                   | Host IP                        |
-| data_port                      | uint16 | 2368            |                   | Sensor port                    |
-| gnss_port                      | uint16 | 2369            |                   | GNSS port                      |
-| frequency_ms                   | uint16 | 100             | milliseconds, > 0 | Time per scan                  |
-| packet_mtu_size                | uint16 | 1500            |                   | Packet MTU size                |
-| rotation_speed                 | uint16 | 600             |                   | Rotation speed                 |
-| cloud_min_angle                | uint16 | 0               | degrees [0, 360]  | FoV start angle                |
-| cloud_max_angle                | uint16 | 359             | degrees [0, 360]  | FoV end angle                  |
-| dual_return_distance_threshold | double | 0.1             |                   | Dual return distance threshold |
-| diag_span                      | uint16 | 1000            | milliseconds, > 0 | Diagnostic span                |
-| setup_sensor                   | bool   | True            | True, False       | Configure sensor settings      |
+| Parameter                      | Type   | Default         | Accepted values   | Description                                                  |
+| ------------------------------ | ------ | --------------- | ----------------- | ------------------------------------------------------------ |
+| frame_id                       | string | hesai           |                   | ROS frame ID                                                 |
+| sensor_ip                      | string | 192.168.1.201   |                   | Sensor IP                                                    |
+| host_ip                        | string | 255.255.255.255 |                   | Host IP                                                      |
+| data_port                      | uint16 | 2368            |                   | Sensor port                                                  |
+| gnss_port                      | uint16 | 2369            |                   | GNSS port                                                    |
+| frequency_ms                   | uint16 | 100             | milliseconds, > 0 | Time per scan                                                |
+| packet_mtu_size                | uint16 | 1500            |                   | Packet MTU size                                              |
+| rotation_speed                 | uint16 | 600             |                   | Rotation speed                                               |
+| cloud_min_angle                | uint16 | 0               | degrees [0, 360]  | FoV start angle                                              |
+| cloud_max_angle                | uint16 | 359             | degrees [0, 360]  | FoV end angle                                                |
+| dual_return_distance_threshold | double | 0.1             |                   | Dual return distance threshold                               |
+| diag_span                      | uint16 | 1000            | milliseconds, > 0 | Diagnostic span                                              |
+| setup_sensor                   | bool   | True            | True, False       | Configure sensor settings                                    |
+| communicate_with_sensor        | bool   | True            | True, False       | Enable communication with sensor (listen mode only if false) |
 
 ### Driver parameters
 

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -98,17 +98,18 @@ Parameters shared by all supported models:
 
 ### Hardware interface parameters
 
-| Parameter       | Type   | Default         | Accepted values   | Description     |
-| --------------- | ------ | --------------- | ----------------- | --------------- |
-| frame_id        | string | velodyne        |                   | ROS frame ID    |
-| sensor_ip       | string | 192.168.1.201   |                   | Sensor IP       |
-| host_ip         | string | 255.255.255.255 |                   | Host IP         |
-| data_port       | uint16 | 2368            |                   | Sensor port     |
-| gnss_port       | uint16 | 2369            |                   | GNSS port       |
-| frequency_ms    | uint16 | 100             | milliseconds, > 0 | Time per scan   |
-| packet_mtu_size | uint16 | 1500            |                   | Packet MTU size |
-| cloud_min_angle | uint16 | 0               | degrees [0, 360]  | FoV start angle |
-| cloud_max_angle | uint16 | 359             | degrees [0, 360]  | FoV end angle   |
+| Parameter               | Type   | Default         | Accepted values   | Description                                                  |
+| ----------------------- | ------ | --------------- | ----------------- | ------------------------------------------------------------ |
+| frame_id                | string | velodyne        |                   | ROS frame ID                                                 |
+| sensor_ip               | string | 192.168.1.201   |                   | Sensor IP                                                    |
+| host_ip                 | string | 255.255.255.255 |                   | Host IP                                                      |
+| data_port               | uint16 | 2368            |                   | Sensor port                                                  |
+| gnss_port               | uint16 | 2369            |                   | GNSS port                                                    |
+| frequency_ms            | uint16 | 100             | milliseconds, > 0 | Time per scan                                                |
+| packet_mtu_size         | uint16 | 1500            |                   | Packet MTU size                                              |
+| cloud_min_angle         | uint16 | 0               | degrees [0, 360]  | FoV start angle                                              |
+| cloud_max_angle         | uint16 | 359             | degrees [0, 360]  | FoV end angle                                                |
+| communicate_with_sensor | bool   | True            | True, False       | Enable communication with sensor (listen mode only if false) |
 
 ### Driver parameters
 

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -60,22 +60,22 @@ Parameters shared by all supported models:
 
 ### Hardware interface parameters
 
-| Parameter                      | Type   | Default         | Accepted values   | Description                                                                            |
-| ------------------------------ | ------ | --------------- | ----------------- | -------------------------------------------------------------------------------------- |
-| frame_id                       | string | hesai           |                   | ROS frame ID                                                                           |
-| sensor_ip                      | string | 192.168.1.201   |                   | Sensor IP                                                                              |
-| host_ip                        | string | 255.255.255.255 |                   | Host IP                                                                                |
-| data_port                      | uint16 | 2368            |                   | Sensor port                                                                            |
-| gnss_port                      | uint16 | 2369            |                   | GNSS port                                                                              |
-| frequency_ms                   | uint16 | 100             | milliseconds, > 0 | Time per scan                                                                          |
-| packet_mtu_size                | uint16 | 1500            |                   | Packet MTU size                                                                        |
-| rotation_speed                 | uint16 | 600             |                   | Rotation speed                                                                         |
-| cloud_min_angle                | uint16 | 0               | degrees [0, 360]  | FoV start angle                                                                        |
-| cloud_max_angle                | uint16 | 359             | degrees [0, 360]  | FoV end angle                                                                          |
-| dual_return_distance_threshold | double | 0.1             |                   | Dual return distance threshold                                                         |
-| diag_span                      | uint16 | 1000            | milliseconds, > 0 | Diagnostic span                                                                        |
-| setup_sensor                   | bool   | True            | True, False       | Configure sensor settings                                                              |
-| udp_only                       | bool   | False           | True, False       | Use UDP protocol only (synchronizing settings and diagnostics publishing are disabled) |
+| Parameter                      | Type   | Default         | Accepted values   | Description                                                                              |
+| ------------------------------ | ------ | --------------- | ----------------- | ---------------------------------------------------------------------------------------- |
+| frame_id                       | string | hesai           |                   | ROS frame ID                                                                             |
+| sensor_ip                      | string | 192.168.1.201   |                   | Sensor IP                                                                                |
+| host_ip                        | string | 255.255.255.255 |                   | Host IP                                                                                  |
+| data_port                      | uint16 | 2368            |                   | Sensor port                                                                              |
+| gnss_port                      | uint16 | 2369            |                   | GNSS port                                                                                |
+| frequency_ms                   | uint16 | 100             | milliseconds, > 0 | Time per scan                                                                            |
+| packet_mtu_size                | uint16 | 1500            |                   | Packet MTU size                                                                          |
+| rotation_speed                 | uint16 | 600             |                   | Rotation speed                                                                           |
+| cloud_min_angle                | uint16 | 0               | degrees [0, 360]  | FoV start angle                                                                          |
+| cloud_max_angle                | uint16 | 359             | degrees [0, 360]  | FoV end angle                                                                            |
+| dual_return_distance_threshold | double | 0.1             |                   | Dual return distance threshold                                                           |
+| diag_span                      | uint16 | 1000            | milliseconds, > 0 | Diagnostic span                                                                          |
+| setup_sensor                   | bool   | True            | True, False       | Configure sensor settings                                                                |
+| udp_only                       | bool   | False           | True, False       | Use UDP protocol only (settings synchronization and diagnostics publishing are disabled) |
 
 ### Driver parameters
 
@@ -98,18 +98,18 @@ Parameters shared by all supported models:
 
 ### Hardware interface parameters
 
-| Parameter       | Type   | Default         | Accepted values   | Description                                                                            |
-| --------------- | ------ | --------------- | ----------------- | -------------------------------------------------------------------------------------- |
-| frame_id        | string | velodyne        |                   | ROS frame ID                                                                           |
-| sensor_ip       | string | 192.168.1.201   |                   | Sensor IP                                                                              |
-| host_ip         | string | 255.255.255.255 |                   | Host IP                                                                                |
-| data_port       | uint16 | 2368            |                   | Sensor port                                                                            |
-| gnss_port       | uint16 | 2369            |                   | GNSS port                                                                              |
-| frequency_ms    | uint16 | 100             | milliseconds, > 0 | Time per scan                                                                          |
-| packet_mtu_size | uint16 | 1500            |                   | Packet MTU size                                                                        |
-| cloud_min_angle | uint16 | 0               | degrees [0, 360]  | FoV start angle                                                                        |
-| cloud_max_angle | uint16 | 359             | degrees [0, 360]  | FoV end angle                                                                          |
-| udp_only        | bool   | False           | True, False       | Use UDP protocol only (synchronizing settings and diagnostics publishing are disabled) |
+| Parameter       | Type   | Default         | Accepted values   | Description                                                                              |
+| --------------- | ------ | --------------- | ----------------- | ---------------------------------------------------------------------------------------- |
+| frame_id        | string | velodyne        |                   | ROS frame ID                                                                             |
+| sensor_ip       | string | 192.168.1.201   |                   | Sensor IP                                                                                |
+| host_ip         | string | 255.255.255.255 |                   | Host IP                                                                                  |
+| data_port       | uint16 | 2368            |                   | Sensor port                                                                              |
+| gnss_port       | uint16 | 2369            |                   | GNSS port                                                                                |
+| frequency_ms    | uint16 | 100             | milliseconds, > 0 | Time per scan                                                                            |
+| packet_mtu_size | uint16 | 1500            |                   | Packet MTU size                                                                          |
+| cloud_min_angle | uint16 | 0               | degrees [0, 360]  | FoV start angle                                                                          |
+| cloud_max_angle | uint16 | 359             | degrees [0, 360]  | FoV end angle                                                                            |
+| udp_only        | bool   | False           | True, False       | Use UDP protocol only (settings synchronization and diagnostics publishing are disabled) |
 
 ### Driver parameters
 

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -60,22 +60,22 @@ Parameters shared by all supported models:
 
 ### Hardware interface parameters
 
-| Parameter                      | Type   | Default         | Accepted values   | Description                                                  |
-| ------------------------------ | ------ | --------------- | ----------------- | ------------------------------------------------------------ |
-| frame_id                       | string | hesai           |                   | ROS frame ID                                                 |
-| sensor_ip                      | string | 192.168.1.201   |                   | Sensor IP                                                    |
-| host_ip                        | string | 255.255.255.255 |                   | Host IP                                                      |
-| data_port                      | uint16 | 2368            |                   | Sensor port                                                  |
-| gnss_port                      | uint16 | 2369            |                   | GNSS port                                                    |
-| frequency_ms                   | uint16 | 100             | milliseconds, > 0 | Time per scan                                                |
-| packet_mtu_size                | uint16 | 1500            |                   | Packet MTU size                                              |
-| rotation_speed                 | uint16 | 600             |                   | Rotation speed                                               |
-| cloud_min_angle                | uint16 | 0               | degrees [0, 360]  | FoV start angle                                              |
-| cloud_max_angle                | uint16 | 359             | degrees [0, 360]  | FoV end angle                                                |
-| dual_return_distance_threshold | double | 0.1             |                   | Dual return distance threshold                               |
-| diag_span                      | uint16 | 1000            | milliseconds, > 0 | Diagnostic span                                              |
-| setup_sensor                   | bool   | True            | True, False       | Configure sensor settings                                    |
-| communicate_with_sensor        | bool   | True            | True, False       | Enable communication with sensor (listen mode only if false) |
+| Parameter                      | Type   | Default         | Accepted values   | Description                                                                            |
+| ------------------------------ | ------ | --------------- | ----------------- | -------------------------------------------------------------------------------------- |
+| frame_id                       | string | hesai           |                   | ROS frame ID                                                                           |
+| sensor_ip                      | string | 192.168.1.201   |                   | Sensor IP                                                                              |
+| host_ip                        | string | 255.255.255.255 |                   | Host IP                                                                                |
+| data_port                      | uint16 | 2368            |                   | Sensor port                                                                            |
+| gnss_port                      | uint16 | 2369            |                   | GNSS port                                                                              |
+| frequency_ms                   | uint16 | 100             | milliseconds, > 0 | Time per scan                                                                          |
+| packet_mtu_size                | uint16 | 1500            |                   | Packet MTU size                                                                        |
+| rotation_speed                 | uint16 | 600             |                   | Rotation speed                                                                         |
+| cloud_min_angle                | uint16 | 0               | degrees [0, 360]  | FoV start angle                                                                        |
+| cloud_max_angle                | uint16 | 359             | degrees [0, 360]  | FoV end angle                                                                          |
+| dual_return_distance_threshold | double | 0.1             |                   | Dual return distance threshold                                                         |
+| diag_span                      | uint16 | 1000            | milliseconds, > 0 | Diagnostic span                                                                        |
+| setup_sensor                   | bool   | True            | True, False       | Configure sensor settings                                                              |
+| udp_only                       | bool   | False           | True, False       | Use UDP protocol only (synchronizing settings and diagnostics publishing are disabled) |
 
 ### Driver parameters
 
@@ -98,18 +98,18 @@ Parameters shared by all supported models:
 
 ### Hardware interface parameters
 
-| Parameter               | Type   | Default         | Accepted values   | Description                                                  |
-| ----------------------- | ------ | --------------- | ----------------- | ------------------------------------------------------------ |
-| frame_id                | string | velodyne        |                   | ROS frame ID                                                 |
-| sensor_ip               | string | 192.168.1.201   |                   | Sensor IP                                                    |
-| host_ip                 | string | 255.255.255.255 |                   | Host IP                                                      |
-| data_port               | uint16 | 2368            |                   | Sensor port                                                  |
-| gnss_port               | uint16 | 2369            |                   | GNSS port                                                    |
-| frequency_ms            | uint16 | 100             | milliseconds, > 0 | Time per scan                                                |
-| packet_mtu_size         | uint16 | 1500            |                   | Packet MTU size                                              |
-| cloud_min_angle         | uint16 | 0               | degrees [0, 360]  | FoV start angle                                              |
-| cloud_max_angle         | uint16 | 359             | degrees [0, 360]  | FoV end angle                                                |
-| communicate_with_sensor | bool   | True            | True, False       | Enable communication with sensor (listen mode only if false) |
+| Parameter       | Type   | Default         | Accepted values   | Description                                                                            |
+| --------------- | ------ | --------------- | ----------------- | -------------------------------------------------------------------------------------- |
+| frame_id        | string | velodyne        |                   | ROS frame ID                                                                           |
+| sensor_ip       | string | 192.168.1.201   |                   | Sensor IP                                                                              |
+| host_ip         | string | 255.255.255.255 |                   | Host IP                                                                                |
+| data_port       | uint16 | 2368            |                   | Sensor port                                                                            |
+| gnss_port       | uint16 | 2369            |                   | GNSS port                                                                              |
+| frequency_ms    | uint16 | 100             | milliseconds, > 0 | Time per scan                                                                          |
+| packet_mtu_size | uint16 | 1500            |                   | Packet MTU size                                                                        |
+| cloud_min_angle | uint16 | 0               | degrees [0, 360]  | FoV start angle                                                                        |
+| cloud_max_angle | uint16 | 359             | degrees [0, 360]  | FoV end angle                                                                          |
+| udp_only        | bool   | False           | True, False       | Use UDP protocol only (synchronizing settings and diagnostics publishing are disabled) |
 
 ### Driver parameters
 

--- a/nebula_ros/config/lidar/hesai/Pandar128E4X.param.yaml
+++ b/nebula_ros/config/lidar/hesai/Pandar128E4X.param.yaml
@@ -8,7 +8,7 @@
     packet_mtu_size: 1500
     launch_hw: true
     setup_sensor: true
-    communicate_with_sensor: true
+    udp_only: false
     frame_id: hesai
     diag_span: 1000
     min_range: 0.3

--- a/nebula_ros/config/lidar/hesai/Pandar128E4X.param.yaml
+++ b/nebula_ros/config/lidar/hesai/Pandar128E4X.param.yaml
@@ -8,6 +8,7 @@
     packet_mtu_size: 1500
     launch_hw: true
     setup_sensor: true
+    communicate_with_sensor: true
     frame_id: hesai
     diag_span: 1000
     min_range: 0.3

--- a/nebula_ros/config/lidar/hesai/Pandar40P.param.yaml
+++ b/nebula_ros/config/lidar/hesai/Pandar40P.param.yaml
@@ -8,7 +8,7 @@
     packet_mtu_size: 1500
     launch_hw: true
     setup_sensor: true
-    communicate_with_sensor: true
+    udp_only: false
     frame_id: hesai
     diag_span: 1000
     min_range: 0.3

--- a/nebula_ros/config/lidar/hesai/Pandar40P.param.yaml
+++ b/nebula_ros/config/lidar/hesai/Pandar40P.param.yaml
@@ -8,6 +8,7 @@
     packet_mtu_size: 1500
     launch_hw: true
     setup_sensor: true
+    communicate_with_sensor: true
     frame_id: hesai
     diag_span: 1000
     min_range: 0.3

--- a/nebula_ros/config/lidar/hesai/Pandar64.param.yaml
+++ b/nebula_ros/config/lidar/hesai/Pandar64.param.yaml
@@ -8,7 +8,7 @@
     packet_mtu_size: 1500
     launch_hw: true
     setup_sensor: true
-    communicate_with_sensor: true
+    udp_only: false
     frame_id: hesai
     diag_span: 1000
     min_range: 0.3

--- a/nebula_ros/config/lidar/hesai/Pandar64.param.yaml
+++ b/nebula_ros/config/lidar/hesai/Pandar64.param.yaml
@@ -8,6 +8,7 @@
     packet_mtu_size: 1500
     launch_hw: true
     setup_sensor: true
+    communicate_with_sensor: true
     frame_id: hesai
     diag_span: 1000
     min_range: 0.3

--- a/nebula_ros/config/lidar/hesai/PandarAT128.param.yaml
+++ b/nebula_ros/config/lidar/hesai/PandarAT128.param.yaml
@@ -8,6 +8,7 @@
     packet_mtu_size: 1500
     launch_hw: true
     setup_sensor: true
+    communicate_with_sensor: true
     frame_id: hesai
     diag_span: 1000
     correction_file: $(find-pkg-share nebula_decoders)/calibration/hesai/$(var sensor_model).dat

--- a/nebula_ros/config/lidar/hesai/PandarAT128.param.yaml
+++ b/nebula_ros/config/lidar/hesai/PandarAT128.param.yaml
@@ -8,7 +8,7 @@
     packet_mtu_size: 1500
     launch_hw: true
     setup_sensor: true
-    communicate_with_sensor: true
+    udp_only: false
     frame_id: hesai
     diag_span: 1000
     correction_file: $(find-pkg-share nebula_decoders)/calibration/hesai/$(var sensor_model).dat

--- a/nebula_ros/config/lidar/hesai/PandarQT128.param.yaml
+++ b/nebula_ros/config/lidar/hesai/PandarQT128.param.yaml
@@ -8,7 +8,7 @@
     packet_mtu_size: 1500
     launch_hw: true
     setup_sensor: true
-    communicate_with_sensor: true
+    udp_only: false
     frame_id: hesai
     diag_span: 1000
     min_range: 0.3

--- a/nebula_ros/config/lidar/hesai/PandarQT128.param.yaml
+++ b/nebula_ros/config/lidar/hesai/PandarQT128.param.yaml
@@ -8,6 +8,7 @@
     packet_mtu_size: 1500
     launch_hw: true
     setup_sensor: true
+    communicate_with_sensor: true
     frame_id: hesai
     diag_span: 1000
     min_range: 0.3

--- a/nebula_ros/config/lidar/hesai/PandarQT64.param.yaml
+++ b/nebula_ros/config/lidar/hesai/PandarQT64.param.yaml
@@ -8,7 +8,7 @@
     packet_mtu_size: 1500
     launch_hw: true
     setup_sensor: true
-    communicate_with_sensor: true
+    udp_only: false
     frame_id: hesai
     diag_span: 1000
     min_range: 0.3

--- a/nebula_ros/config/lidar/hesai/PandarQT64.param.yaml
+++ b/nebula_ros/config/lidar/hesai/PandarQT64.param.yaml
@@ -8,6 +8,7 @@
     packet_mtu_size: 1500
     launch_hw: true
     setup_sensor: true
+    communicate_with_sensor: true
     frame_id: hesai
     diag_span: 1000
     min_range: 0.3

--- a/nebula_ros/config/lidar/hesai/PandarXT32.param.yaml
+++ b/nebula_ros/config/lidar/hesai/PandarXT32.param.yaml
@@ -8,7 +8,7 @@
     packet_mtu_size: 1500
     launch_hw: true
     setup_sensor: true
-    communicate_with_sensor: true
+    udp_only: false
     frame_id: hesai
     diag_span: 1000
     min_range: 0.3

--- a/nebula_ros/config/lidar/hesai/PandarXT32.param.yaml
+++ b/nebula_ros/config/lidar/hesai/PandarXT32.param.yaml
@@ -8,6 +8,7 @@
     packet_mtu_size: 1500
     launch_hw: true
     setup_sensor: true
+    communicate_with_sensor: true
     frame_id: hesai
     diag_span: 1000
     min_range: 0.3

--- a/nebula_ros/config/lidar/hesai/PandarXT32M.param.yaml
+++ b/nebula_ros/config/lidar/hesai/PandarXT32M.param.yaml
@@ -8,7 +8,7 @@
     packet_mtu_size: 1500
     launch_hw: true
     setup_sensor: true
-    communicate_with_sensor: true
+    udp_only: false
     frame_id: hesai
     diag_span: 1000
     min_range: 0.3

--- a/nebula_ros/config/lidar/hesai/PandarXT32M.param.yaml
+++ b/nebula_ros/config/lidar/hesai/PandarXT32M.param.yaml
@@ -8,6 +8,7 @@
     packet_mtu_size: 1500
     launch_hw: true
     setup_sensor: true
+    communicate_with_sensor: true
     frame_id: hesai
     diag_span: 1000
     min_range: 0.3

--- a/nebula_ros/config/lidar/velodyne/VLP16.param.yaml
+++ b/nebula_ros/config/lidar/velodyne/VLP16.param.yaml
@@ -7,7 +7,7 @@
     packet_mtu_size: 1500
     launch_hw: true
     setup_sensor: true
-    communicate_with_sensor: true
+    udp_only: false
     frame_id: velodyne
     advanced_diagnostics: false
     diag_span: 1000

--- a/nebula_ros/config/lidar/velodyne/VLP16.param.yaml
+++ b/nebula_ros/config/lidar/velodyne/VLP16.param.yaml
@@ -7,6 +7,7 @@
     packet_mtu_size: 1500
     launch_hw: true
     setup_sensor: true
+    communicate_with_sensor: true
     frame_id: velodyne
     advanced_diagnostics: false
     diag_span: 1000

--- a/nebula_ros/config/lidar/velodyne/VLP32.param.yaml
+++ b/nebula_ros/config/lidar/velodyne/VLP32.param.yaml
@@ -7,7 +7,7 @@
     packet_mtu_size: 1500
     launch_hw: true
     setup_sensor: true
-    communicate_with_sensor: true
+    udp_only: false
     frame_id: velodyne
     advanced_diagnostics: false
     diag_span: 1000

--- a/nebula_ros/config/lidar/velodyne/VLP32.param.yaml
+++ b/nebula_ros/config/lidar/velodyne/VLP32.param.yaml
@@ -7,6 +7,7 @@
     packet_mtu_size: 1500
     launch_hw: true
     setup_sensor: true
+    communicate_with_sensor: true
     frame_id: velodyne
     advanced_diagnostics: false
     diag_span: 1000

--- a/nebula_ros/config/lidar/velodyne/VLS128.param.yaml
+++ b/nebula_ros/config/lidar/velodyne/VLS128.param.yaml
@@ -7,7 +7,7 @@
     packet_mtu_size: 1500
     launch_hw: true
     setup_sensor: true
-    communicate_with_sensor: true
+    udp_only: false
     frame_id: velodyne
     advanced_diagnostics: false
     diag_span: 1000

--- a/nebula_ros/config/lidar/velodyne/VLS128.param.yaml
+++ b/nebula_ros/config/lidar/velodyne/VLS128.param.yaml
@@ -7,6 +7,7 @@
     packet_mtu_size: 1500
     launch_hw: true
     setup_sensor: true
+    communicate_with_sensor: true
     frame_id: velodyne
     advanced_diagnostics: false
     diag_span: 1000

--- a/nebula_ros/include/nebula_ros/hesai/hw_interface_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/hesai/hw_interface_wrapper.hpp
@@ -27,7 +27,7 @@ class HesaiHwInterfaceWrapper
 public:
   HesaiHwInterfaceWrapper(
     rclcpp::Node * const parent_node,
-    std::shared_ptr<const nebula::drivers::HesaiSensorConfiguration> & config);
+    std::shared_ptr<const nebula::drivers::HesaiSensorConfiguration> & config, bool communicate_with_sensor = true);
 
   void on_config_change(
     const std::shared_ptr<const nebula::drivers::HesaiSensorConfiguration> & new_config);
@@ -41,5 +41,6 @@ private:
   rclcpp::Logger logger_;
   nebula::Status status_;
   bool setup_sensor_;
+  bool communicate_with_sensor_;
 };
 }  // namespace nebula::ros

--- a/nebula_ros/include/nebula_ros/hesai/hw_interface_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/hesai/hw_interface_wrapper.hpp
@@ -28,7 +28,7 @@ public:
   HesaiHwInterfaceWrapper(
     rclcpp::Node * const parent_node,
     std::shared_ptr<const nebula::drivers::HesaiSensorConfiguration> & config,
-    bool communicate_with_sensor = true);
+    bool use_udp_only = false);
 
   void on_config_change(
     const std::shared_ptr<const nebula::drivers::HesaiSensorConfiguration> & new_config);
@@ -42,6 +42,6 @@ private:
   rclcpp::Logger logger_;
   nebula::Status status_;
   bool setup_sensor_;
-  bool communicate_with_sensor_;
+  bool use_udp_only_;
 };
 }  // namespace nebula::ros

--- a/nebula_ros/include/nebula_ros/hesai/hw_interface_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/hesai/hw_interface_wrapper.hpp
@@ -27,7 +27,8 @@ class HesaiHwInterfaceWrapper
 public:
   HesaiHwInterfaceWrapper(
     rclcpp::Node * const parent_node,
-    std::shared_ptr<const nebula::drivers::HesaiSensorConfiguration> & config, bool communicate_with_sensor = true);
+    std::shared_ptr<const nebula::drivers::HesaiSensorConfiguration> & config,
+    bool communicate_with_sensor = true);
 
   void on_config_change(
     const std::shared_ptr<const nebula::drivers::HesaiSensorConfiguration> & new_config);

--- a/nebula_ros/include/nebula_ros/velodyne/hw_interface_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/velodyne/hw_interface_wrapper.hpp
@@ -29,7 +29,8 @@ class VelodyneHwInterfaceWrapper
 public:
   VelodyneHwInterfaceWrapper(
     rclcpp::Node * const parent_node,
-    std::shared_ptr<const nebula::drivers::VelodyneSensorConfiguration> & config);
+    std::shared_ptr<const nebula::drivers::VelodyneSensorConfiguration> & config,
+    bool communicate_with_sensor = true);
 
   void on_config_change(
     const std::shared_ptr<const nebula::drivers::VelodyneSensorConfiguration> & new_config);
@@ -43,5 +44,6 @@ private:
   rclcpp::Logger logger_;
   nebula::Status status_;
   bool setup_sensor_;
+  bool communicate_with_sensor_;
 };
 }  // namespace nebula::ros

--- a/nebula_ros/include/nebula_ros/velodyne/hw_interface_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/velodyne/hw_interface_wrapper.hpp
@@ -30,7 +30,7 @@ public:
   VelodyneHwInterfaceWrapper(
     rclcpp::Node * const parent_node,
     std::shared_ptr<const nebula::drivers::VelodyneSensorConfiguration> & config,
-    bool communicate_with_sensor = true);
+    bool use_udp_only = false);
 
   void on_config_change(
     const std::shared_ptr<const nebula::drivers::VelodyneSensorConfiguration> & new_config);
@@ -44,6 +44,6 @@ private:
   rclcpp::Logger logger_;
   nebula::Status status_;
   bool setup_sensor_;
-  bool communicate_with_sensor_;
+  bool use_udp_only_;
 };
 }  // namespace nebula::ros

--- a/nebula_ros/schema/Pandar128E4X.schema.json
+++ b/nebula_ros/schema/Pandar128E4X.schema.json
@@ -30,6 +30,9 @@
         "setup_sensor": {
           "$ref": "sub/hardware.json#/definitions/setup_sensor"
         },
+        "udp_only": {
+          "$ref": "sub/hardware.json#/definitions/udp_only"
+        },
         "frame_id": {
           "$ref": "sub/topic.json#/definitions/frame_id"
         },
@@ -109,6 +112,7 @@
         "packet_mtu_size",
         "launch_hw",
         "setup_sensor",
+        "udp_only",
         "frame_id",
         "diag_span",
         "cloud_min_angle",

--- a/nebula_ros/schema/Pandar40P.schema.json
+++ b/nebula_ros/schema/Pandar40P.schema.json
@@ -30,6 +30,9 @@
         "setup_sensor": {
           "$ref": "sub/hardware.json#/definitions/setup_sensor"
         },
+        "udp_only": {
+          "$ref": "sub/hardware.json#/definitions/udp_only"
+        },
         "frame_id": {
           "$ref": "sub/topic.json#/definitions/frame_id"
         },
@@ -100,6 +103,7 @@
         "packet_mtu_size",
         "launch_hw",
         "setup_sensor",
+        "udp_only",
         "frame_id",
         "diag_span",
         "cloud_min_angle",

--- a/nebula_ros/schema/Pandar64.schema.json
+++ b/nebula_ros/schema/Pandar64.schema.json
@@ -30,6 +30,9 @@
         "setup_sensor": {
           "$ref": "sub/hardware.json#/definitions/setup_sensor"
         },
+        "udp_only": {
+          "$ref": "sub/hardware.json#/definitions/udp_only"
+        },
         "frame_id": {
           "$ref": "sub/topic.json#/definitions/frame_id"
         },
@@ -97,6 +100,7 @@
         "packet_mtu_size",
         "launch_hw",
         "setup_sensor",
+        "udp_only",
         "frame_id",
         "diag_span",
         "cloud_min_angle",

--- a/nebula_ros/schema/PandarAT128.schema.json
+++ b/nebula_ros/schema/PandarAT128.schema.json
@@ -30,6 +30,9 @@
         "setup_sensor": {
           "$ref": "sub/hardware.json#/definitions/setup_sensor"
         },
+        "udp_only": {
+          "$ref": "sub/hardware.json#/definitions/udp_only"
+        },
         "frame_id": {
           "$ref": "sub/topic.json#/definitions/frame_id"
         },
@@ -120,6 +123,7 @@
         "packet_mtu_size",
         "launch_hw",
         "setup_sensor",
+        "udp_only",
         "frame_id",
         "diag_span",
         "correction_file",

--- a/nebula_ros/schema/PandarQT128.schema.json
+++ b/nebula_ros/schema/PandarQT128.schema.json
@@ -30,6 +30,9 @@
         "setup_sensor": {
           "$ref": "sub/hardware.json#/definitions/setup_sensor"
         },
+        "udp_only": {
+          "$ref": "sub/hardware.json#/definitions/udp_only"
+        },
         "frame_id": {
           "$ref": "sub/topic.json#/definitions/frame_id"
         },
@@ -103,6 +106,7 @@
         "packet_mtu_size",
         "launch_hw",
         "setup_sensor",
+        "udp_only",
         "frame_id",
         "diag_span",
         "cloud_min_angle",

--- a/nebula_ros/schema/PandarQT64.schema.json
+++ b/nebula_ros/schema/PandarQT64.schema.json
@@ -30,6 +30,9 @@
         "setup_sensor": {
           "$ref": "sub/hardware.json#/definitions/setup_sensor"
         },
+        "udp_only": {
+          "$ref": "sub/hardware.json#/definitions/udp_only"
+        },
         "frame_id": {
           "$ref": "sub/topic.json#/definitions/frame_id"
         },
@@ -100,6 +103,7 @@
         "packet_mtu_size",
         "launch_hw",
         "setup_sensor",
+        "udp_only",
         "frame_id",
         "diag_span",
         "cloud_min_angle",

--- a/nebula_ros/schema/PandarXT32.schema.json
+++ b/nebula_ros/schema/PandarXT32.schema.json
@@ -30,6 +30,9 @@
         "setup_sensor": {
           "$ref": "sub/hardware.json#/definitions/setup_sensor"
         },
+        "udp_only": {
+          "$ref": "sub/hardware.json#/definitions/udp_only"
+        },
         "frame_id": {
           "$ref": "sub/topic.json#/definitions/frame_id"
         },
@@ -103,6 +106,7 @@
         "packet_mtu_size",
         "launch_hw",
         "setup_sensor",
+        "udp_only",
         "frame_id",
         "diag_span",
         "cloud_min_angle",

--- a/nebula_ros/schema/PandarXT32M.schema.json
+++ b/nebula_ros/schema/PandarXT32M.schema.json
@@ -30,6 +30,9 @@
         "setup_sensor": {
           "$ref": "sub/hardware.json#/definitions/setup_sensor"
         },
+        "udp_only": {
+          "$ref": "sub/hardware.json#/definitions/udp_only"
+        },
         "frame_id": {
           "$ref": "sub/topic.json#/definitions/frame_id"
         },
@@ -103,6 +106,7 @@
         "packet_mtu_size",
         "launch_hw",
         "setup_sensor",
+        "udp_only",
         "frame_id",
         "diag_span",
         "cloud_min_angle",

--- a/nebula_ros/schema/VLP16.schema.json
+++ b/nebula_ros/schema/VLP16.schema.json
@@ -27,6 +27,9 @@
         "setup_sensor": {
           "$ref": "sub/hardware.json#/definitions/setup_sensor"
         },
+        "udp_only": {
+          "$ref": "sub/hardware.json#/definitions/udp_only"
+        },
         "frame_id": {
           "$ref": "sub/topic.json#/definitions/frame_id"
         },
@@ -72,6 +75,7 @@
         "packet_mtu_size",
         "launch_hw",
         "setup_sensor",
+        "udp_only",
         "frame_id",
         "advanced_diagnostics",
         "diag_span",

--- a/nebula_ros/schema/VLP32.schema.json
+++ b/nebula_ros/schema/VLP32.schema.json
@@ -27,6 +27,9 @@
         "setup_sensor": {
           "$ref": "sub/hardware.json#/definitions/setup_sensor"
         },
+        "udp_only": {
+          "$ref": "sub/hardware.json#/definitions/udp_only"
+        },
         "frame_id": {
           "$ref": "sub/topic.json#/definitions/frame_id"
         },
@@ -72,6 +75,7 @@
         "packet_mtu_size",
         "launch_hw",
         "setup_sensor",
+        "udp_only",
         "frame_id",
         "advanced_diagnostics",
         "diag_span",

--- a/nebula_ros/schema/VLS128.schema.json
+++ b/nebula_ros/schema/VLS128.schema.json
@@ -27,6 +27,9 @@
         "setup_sensor": {
           "$ref": "sub/hardware.json#/definitions/setup_sensor"
         },
+        "udp_only": {
+          "$ref": "sub/hardware.json#/definitions/udp_only"
+        },
         "frame_id": {
           "$ref": "sub/topic.json#/definitions/frame_id"
         },
@@ -72,6 +75,7 @@
         "packet_mtu_size",
         "launch_hw",
         "setup_sensor",
+        "udp_only",
         "frame_id",
         "advanced_diagnostics",
         "diag_span",

--- a/nebula_ros/schema/sub/hardware.json
+++ b/nebula_ros/schema/sub/hardware.json
@@ -28,6 +28,12 @@
       "type": "boolean",
       "default": "true",
       "description": "Whether TCP connections are retried on failure or the driver should instead exit."
+    },
+    "udp_only": {
+      "type": "boolean",
+      "default": "false",
+      "readOnly": true,
+      "description": "Use UDP protocol only (settings synchronization and diagnostics publishing are disabled)."
     }
   }
 }

--- a/nebula_ros/src/hesai/hesai_ros_wrapper.cpp
+++ b/nebula_ros/src/hesai/hesai_ros_wrapper.cpp
@@ -40,17 +40,16 @@ HesaiRosWrapper::HesaiRosWrapper(const rclcpp::NodeOptions & options)
   RCLCPP_INFO_STREAM(get_logger(), "Sensor Configuration: " << *sensor_cfg_ptr_);
 
   launch_hw_ = declare_parameter<bool>("launch_hw", param_read_only());
-  bool communicate_with_sensor =
-    declare_parameter<bool>("communicate_with_sensor", param_read_only());
+  bool use_udp_only = declare_parameter<bool>("udp_only", param_read_only());
 
   if (launch_hw_) {
-    hw_interface_wrapper_.emplace(this, sensor_cfg_ptr_, communicate_with_sensor);
-    if (communicate_with_sensor) {  // hardware monitor requires communication with sensor
+    hw_interface_wrapper_.emplace(this, sensor_cfg_ptr_, use_udp_only);
+    if (!use_udp_only) {  // hardware monitor requires TCP connection
       hw_monitor_wrapper_.emplace(this, hw_interface_wrapper_->hw_interface(), sensor_cfg_ptr_);
     }
   }
 
-  bool force_load_caibration_from_file = !communicate_with_sensor;
+  bool force_load_caibration_from_file = use_udp_only;  // Downloading from device requires TCP connection
   auto calibration_result =
     get_calibration_data(sensor_cfg_ptr_->calibration_path, force_load_caibration_from_file);
   if (!calibration_result.has_value()) {
@@ -59,7 +58,7 @@ HesaiRosWrapper::HesaiRosWrapper(const rclcpp::NodeOptions & options)
   }
 
   if (
-    hw_interface_wrapper_ && communicate_with_sensor &&
+    hw_interface_wrapper_ && !use_udp_only &&
     sensor_cfg_ptr_->sensor_model != drivers::SensorModel::HESAI_PANDARAT128) {
     auto status =
       hw_interface_wrapper_->hw_interface()->checkAndSetLidarRange(*calibration_result.value());

--- a/nebula_ros/src/hesai/hesai_ros_wrapper.cpp
+++ b/nebula_ros/src/hesai/hesai_ros_wrapper.cpp
@@ -42,6 +42,12 @@ HesaiRosWrapper::HesaiRosWrapper(const rclcpp::NodeOptions & options)
   launch_hw_ = declare_parameter<bool>("launch_hw", param_read_only());
   bool use_udp_only = declare_parameter<bool>("udp_only", param_read_only());
 
+  if (use_udp_only) {
+    RCLCPP_INFO_STREAM(
+      get_logger(),
+      "UDP-only mode is enabled. Settings checks, synchronization, and diagnostics publishing are disabled.");
+  }
+
   if (launch_hw_) {
     hw_interface_wrapper_.emplace(this, sensor_cfg_ptr_, use_udp_only);
     if (!use_udp_only) {  // hardware monitor requires TCP connection

--- a/nebula_ros/src/hesai/hesai_ros_wrapper.cpp
+++ b/nebula_ros/src/hesai/hesai_ros_wrapper.cpp
@@ -40,17 +40,19 @@ HesaiRosWrapper::HesaiRosWrapper(const rclcpp::NodeOptions & options)
   RCLCPP_INFO_STREAM(get_logger(), "Sensor Configuration: " << *sensor_cfg_ptr_);
 
   launch_hw_ = declare_parameter<bool>("launch_hw", param_read_only());
-  bool communicate_with_sensor = declare_parameter<bool>("communicate_with_sensor", param_read_only());
+  bool communicate_with_sensor =
+    declare_parameter<bool>("communicate_with_sensor", param_read_only());
 
   if (launch_hw_) {
     hw_interface_wrapper_.emplace(this, sensor_cfg_ptr_, communicate_with_sensor);
-    if (communicate_with_sensor) { // hardware monitor requires communication with sensor
+    if (communicate_with_sensor) {  // hardware monitor requires communication with sensor
       hw_monitor_wrapper_.emplace(this, hw_interface_wrapper_->hw_interface(), sensor_cfg_ptr_);
     }
   }
 
   bool force_load_caibration_from_file = !communicate_with_sensor;
-  auto calibration_result = get_calibration_data(sensor_cfg_ptr_->calibration_path, force_load_caibration_from_file);
+  auto calibration_result =
+    get_calibration_data(sensor_cfg_ptr_->calibration_path, force_load_caibration_from_file);
   if (!calibration_result.has_value()) {
     throw std::runtime_error(
       (std::stringstream() << "No valid calibration found: " << calibration_result.error()).str());

--- a/nebula_ros/src/hesai/hesai_ros_wrapper.cpp
+++ b/nebula_ros/src/hesai/hesai_ros_wrapper.cpp
@@ -45,7 +45,8 @@ HesaiRosWrapper::HesaiRosWrapper(const rclcpp::NodeOptions & options)
   if (use_udp_only) {
     RCLCPP_INFO_STREAM(
       get_logger(),
-      "UDP-only mode is enabled. Settings checks, synchronization, and diagnostics publishing are disabled.");
+      "UDP-only mode is enabled. Settings checks, synchronization, and diagnostics publishing are "
+      "disabled.");
   }
 
   if (launch_hw_) {
@@ -55,7 +56,8 @@ HesaiRosWrapper::HesaiRosWrapper(const rclcpp::NodeOptions & options)
     }
   }
 
-  bool force_load_caibration_from_file = use_udp_only;  // Downloading from device requires TCP connection
+  bool force_load_caibration_from_file =
+    use_udp_only;  // Downloading from device requires TCP connection
   auto calibration_result =
     get_calibration_data(sensor_cfg_ptr_->calibration_path, force_load_caibration_from_file);
   if (!calibration_result.has_value()) {

--- a/nebula_ros/src/hesai/hw_interface_wrapper.cpp
+++ b/nebula_ros/src/hesai/hw_interface_wrapper.cpp
@@ -9,12 +9,11 @@ namespace nebula::ros
 
 HesaiHwInterfaceWrapper::HesaiHwInterfaceWrapper(
   rclcpp::Node * const parent_node,
-  std::shared_ptr<const nebula::drivers::HesaiSensorConfiguration> & config,
-  bool communicate_with_sensor)
+  std::shared_ptr<const nebula::drivers::HesaiSensorConfiguration> & config, bool use_udp_only)
 : hw_interface_(new nebula::drivers::HesaiHwInterface()),
   logger_(parent_node->get_logger().get_child("HwInterface")),
   status_(Status::NOT_INITIALIZED),
-  communicate_with_sensor_(communicate_with_sensor)
+  use_udp_only_(use_udp_only)
 {
   setup_sensor_ = parent_node->declare_parameter<bool>("setup_sensor", param_read_only());
   bool retry_connect = parent_node->declare_parameter<bool>("retry_hw", param_read_only());
@@ -30,8 +29,8 @@ HesaiHwInterfaceWrapper::HesaiHwInterfaceWrapper(
   hw_interface_->SetLogger(std::make_shared<rclcpp::Logger>(parent_node->get_logger()));
   hw_interface_->SetTargetModel(config->sensor_model);
 
-  if (!communicate_with_sensor_) {
-    // Do not initialize Tcp if communication is disabled
+  if (use_udp_only) {
+    // Do not initialize TCP
     return;
   }
 
@@ -72,7 +71,7 @@ void HesaiHwInterfaceWrapper::on_config_change(
 {
   hw_interface_->SetSensorConfiguration(
     std::static_pointer_cast<const nebula::drivers::SensorConfigurationBase>(new_config));
-  if (communicate_with_sensor_ && setup_sensor_) {
+  if (!use_udp_only_ && setup_sensor_) {
     hw_interface_->CheckAndSetConfig();
   }
 }

--- a/nebula_ros/src/hesai/hw_interface_wrapper.cpp
+++ b/nebula_ros/src/hesai/hw_interface_wrapper.cpp
@@ -9,7 +9,8 @@ namespace nebula::ros
 
 HesaiHwInterfaceWrapper::HesaiHwInterfaceWrapper(
   rclcpp::Node * const parent_node,
-  std::shared_ptr<const nebula::drivers::HesaiSensorConfiguration> & config, bool communicate_with_sensor)
+  std::shared_ptr<const nebula::drivers::HesaiSensorConfiguration> & config,
+  bool communicate_with_sensor)
 : hw_interface_(new nebula::drivers::HesaiHwInterface()),
   logger_(parent_node->get_logger().get_child("HwInterface")),
   status_(Status::NOT_INITIALIZED),

--- a/nebula_ros/src/hesai/hw_interface_wrapper.cpp
+++ b/nebula_ros/src/hesai/hw_interface_wrapper.cpp
@@ -30,7 +30,7 @@ HesaiHwInterfaceWrapper::HesaiHwInterfaceWrapper(
   hw_interface_->SetTargetModel(config->sensor_model);
 
   if (!communicate_with_sensor_) {
-    // No need to initialize Tcp if communication is disabled
+    // Do not initialize Tcp if communication is disabled
     return;
   }
 
@@ -69,13 +69,9 @@ HesaiHwInterfaceWrapper::HesaiHwInterfaceWrapper(
 void HesaiHwInterfaceWrapper::on_config_change(
   const std::shared_ptr<const nebula::drivers::HesaiSensorConfiguration> & new_config)
 {
-  if (!communicate_with_sensor_) {
-    RCLCPP_ERROR_STREAM(logger_, "Cannot change sensor configuration: communication with sensor is disabled");
-    return;
-  }
   hw_interface_->SetSensorConfiguration(
     std::static_pointer_cast<const nebula::drivers::SensorConfigurationBase>(new_config));
-  if (setup_sensor_) {
+  if (communicate_with_sensor_ && setup_sensor_) {
     hw_interface_->CheckAndSetConfig();
   }
 }

--- a/nebula_ros/src/velodyne/hw_interface_wrapper.cpp
+++ b/nebula_ros/src/velodyne/hw_interface_wrapper.cpp
@@ -26,7 +26,7 @@ VelodyneHwInterfaceWrapper::VelodyneHwInterfaceWrapper(
   }
 
   if (!communicate_with_sensor_) {
-    // No need to initialize http client if communication is disabled
+    // Do not initialize http client if communication is disabled
     return;
   }
 
@@ -53,14 +53,12 @@ VelodyneHwInterfaceWrapper::VelodyneHwInterfaceWrapper(
 void VelodyneHwInterfaceWrapper::on_config_change(
   const std::shared_ptr<const nebula::drivers::VelodyneSensorConfiguration> & new_config)
 {
-  if (!communicate_with_sensor_) {
-    RCLCPP_ERROR_STREAM(logger_, "Cannot change sensor configuration: communication with sensor is disabled");
-    return;
-  }
   hw_interface_->initialize_sensor_configuration(new_config);
-  hw_interface_->init_http_client();
-  if (setup_sensor_) {
-    hw_interface_->set_sensor_configuration(new_config);
+  if (communicate_with_sensor_) {
+    hw_interface_->init_http_client();
+    if (setup_sensor_) {
+      hw_interface_->set_sensor_configuration(new_config);
+    }
   }
 }
 

--- a/nebula_ros/src/velodyne/hw_interface_wrapper.cpp
+++ b/nebula_ros/src/velodyne/hw_interface_wrapper.cpp
@@ -7,8 +7,7 @@ namespace nebula::ros
 
 VelodyneHwInterfaceWrapper::VelodyneHwInterfaceWrapper(
   rclcpp::Node * const parent_node,
-  std::shared_ptr<const nebula::drivers::VelodyneSensorConfiguration> & config,
-  bool use_udp_only)
+  std::shared_ptr<const nebula::drivers::VelodyneSensorConfiguration> & config, bool use_udp_only)
 : hw_interface_(new nebula::drivers::VelodyneHwInterface()),
   logger_(parent_node->get_logger().get_child("HwInterfaceWrapper")),
   status_(Status::NOT_INITIALIZED),

--- a/nebula_ros/src/velodyne/velodyne_ros_wrapper.cpp
+++ b/nebula_ros/src/velodyne/velodyne_ros_wrapper.cpp
@@ -32,7 +32,8 @@ VelodyneRosWrapper::VelodyneRosWrapper(const rclcpp::NodeOptions & options)
   if (use_udp_only) {
     RCLCPP_INFO_STREAM(
       get_logger(),
-      "UDP-only mode is enabled. Settings checks, synchronization, and diagnostics publishing are disabled.");
+      "UDP-only mode is enabled. Settings checks, synchronization, and diagnostics publishing are "
+      "disabled.");
   }
 
   if (launch_hw_) {

--- a/nebula_ros/src/velodyne/velodyne_ros_wrapper.cpp
+++ b/nebula_ros/src/velodyne/velodyne_ros_wrapper.cpp
@@ -27,10 +27,13 @@ VelodyneRosWrapper::VelodyneRosWrapper(const rclcpp::NodeOptions & options)
   RCLCPP_INFO_STREAM(get_logger(), "Sensor Configuration: " << *sensor_cfg_ptr_);
 
   launch_hw_ = declare_parameter<bool>("launch_hw", param_read_only());
+  bool communicate_with_sensor = declare_parameter<bool>("communicate_with_sensor", param_read_only());
 
   if (launch_hw_) {
-    hw_interface_wrapper_.emplace(this, sensor_cfg_ptr_);
-    hw_monitor_wrapper_.emplace(this, hw_interface_wrapper_->hw_interface(), sensor_cfg_ptr_);
+    hw_interface_wrapper_.emplace(this, sensor_cfg_ptr_, communicate_with_sensor);
+    if (communicate_with_sensor) { // hardware monitor requires communication with sensor
+      hw_monitor_wrapper_.emplace(this, hw_interface_wrapper_->hw_interface(), sensor_cfg_ptr_);
+    }
   }
 
   decoder_wrapper_.emplace(

--- a/nebula_ros/src/velodyne/velodyne_ros_wrapper.cpp
+++ b/nebula_ros/src/velodyne/velodyne_ros_wrapper.cpp
@@ -27,12 +27,11 @@ VelodyneRosWrapper::VelodyneRosWrapper(const rclcpp::NodeOptions & options)
   RCLCPP_INFO_STREAM(get_logger(), "Sensor Configuration: " << *sensor_cfg_ptr_);
 
   launch_hw_ = declare_parameter<bool>("launch_hw", param_read_only());
-  bool communicate_with_sensor =
-    declare_parameter<bool>("communicate_with_sensor", param_read_only());
+  bool use_udp_only = declare_parameter<bool>("udp_only", param_read_only());
 
   if (launch_hw_) {
-    hw_interface_wrapper_.emplace(this, sensor_cfg_ptr_, communicate_with_sensor);
-    if (communicate_with_sensor) {  // hardware monitor requires communication with sensor
+    hw_interface_wrapper_.emplace(this, sensor_cfg_ptr_, use_udp_only);
+    if (!use_udp_only) {  // hardware monitor requires HTTP connection
       hw_monitor_wrapper_.emplace(this, hw_interface_wrapper_->hw_interface(), sensor_cfg_ptr_);
     }
   }

--- a/nebula_ros/src/velodyne/velodyne_ros_wrapper.cpp
+++ b/nebula_ros/src/velodyne/velodyne_ros_wrapper.cpp
@@ -29,6 +29,12 @@ VelodyneRosWrapper::VelodyneRosWrapper(const rclcpp::NodeOptions & options)
   launch_hw_ = declare_parameter<bool>("launch_hw", param_read_only());
   bool use_udp_only = declare_parameter<bool>("udp_only", param_read_only());
 
+  if (use_udp_only) {
+    RCLCPP_INFO_STREAM(
+      get_logger(),
+      "UDP-only mode is enabled. Settings checks, synchronization, and diagnostics publishing are disabled.");
+  }
+
   if (launch_hw_) {
     hw_interface_wrapper_.emplace(this, sensor_cfg_ptr_, use_udp_only);
     if (!use_udp_only) {  // hardware monitor requires HTTP connection

--- a/nebula_ros/src/velodyne/velodyne_ros_wrapper.cpp
+++ b/nebula_ros/src/velodyne/velodyne_ros_wrapper.cpp
@@ -27,11 +27,12 @@ VelodyneRosWrapper::VelodyneRosWrapper(const rclcpp::NodeOptions & options)
   RCLCPP_INFO_STREAM(get_logger(), "Sensor Configuration: " << *sensor_cfg_ptr_);
 
   launch_hw_ = declare_parameter<bool>("launch_hw", param_read_only());
-  bool communicate_with_sensor = declare_parameter<bool>("communicate_with_sensor", param_read_only());
+  bool communicate_with_sensor =
+    declare_parameter<bool>("communicate_with_sensor", param_read_only());
 
   if (launch_hw_) {
     hw_interface_wrapper_.emplace(this, sensor_cfg_ptr_, communicate_with_sensor);
-    if (communicate_with_sensor) { // hardware monitor requires communication with sensor
+    if (communicate_with_sensor) {  // hardware monitor requires communication with sensor
       hw_monitor_wrapper_.emplace(this, hw_interface_wrapper_->hw_interface(), sensor_cfg_ptr_);
     }
   }


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Improvement

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

https://github.com/tier4/nebula/issues/136

## Description

<!-- Describe what this PR changes. -->

This PR introduces a new parameter to the `hesai_ros_wrapper` and `velodyne_ros_wrapper` nodes, allowing hardware to launch with communication to the sensor disabled. In this configuration, the driver operates in a "listen-only" mode, receiving packet data without sending commands.

This functionality is required for the [AWSIM](https://github.com/tier4/AWSIM) simulator, where the LiDAR simulation plugin supports publishing raw packets via UDP but doesn't handle communication from the driver.

Prior to nebula version `0.2.0`, there was a workaround for this behaviour (as outlined in the related issue). However, recent architectural changes have removed the ability to use that workaround (segmentation fault appears).

## Review Procedure

Code review + test to ensure that the new parameter does not interfere with the normal operation of real-world sensors.

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [x] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
