### PR TITLE
Connection mode

### DIFF
--- a/nebula_common/include/nebula_common/nebula_common.hpp
+++ b/nebula_common/include/nebula_common/nebula_common.hpp
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <ostream>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -343,6 +344,41 @@ enum class SensorModel {
   CONTINENTAL_ARS548,
   CONTINENTAL_SRR520
 };
+
+enum class ConnectionMode {
+  /// No network connection, listen to replayed packets on a ROS 2 topic
+  OFFLINE,
+  /// Passive mode where Nebula does not inquire any settings or diagnostics, only listens via UDP
+  UDP_ONLY,
+  /// Nebula compares settings with the sensor and runs all other functionality, but does not modify
+  /// sensor settings
+  SKIP_SETUP,
+  /// All supported network functionality is enabled
+  FULL
+};
+
+inline std::ostream & operator<<(std::ostream & os, ConnectionMode const & arg)
+{
+  switch (arg) {
+    case ConnectionMode::OFFLINE:
+      return os << "offline";
+    case ConnectionMode::UDP_ONLY:
+      return os << "UDP only";
+    case ConnectionMode::SKIP_SETUP:
+      return os << "skip setup";
+    case ConnectionMode::FULL:
+      return os << "full";
+  }
+}
+
+inline ConnectionMode connection_mode_from_string(const std::string & str)
+{
+  if (str == "offline") return ConnectionMode::OFFLINE;
+  if (str == "udp_only") return ConnectionMode::UDP_ONLY;
+  if (str == "skip_setup") return ConnectionMode::SKIP_SETUP;
+  if (str == "full") return ConnectionMode::FULL;
+  throw std::runtime_error("Unknown connection mode " + str);
+}
 
 /// @brief not used?
 enum class datatype {

--- a/nebula_ros/config/lidar/hesai/Pandar128E4X.param.yaml
+++ b/nebula_ros/config/lidar/hesai/Pandar128E4X.param.yaml
@@ -6,9 +6,7 @@
     data_port: 2368
     gnss_port: 10110
     packet_mtu_size: 1500
-    launch_hw: true
-    setup_sensor: true
-    udp_only: false
+    connection_mode: full
     frame_id: hesai
     diag_span: 1000
     min_range: 0.3

--- a/nebula_ros/config/lidar/hesai/Pandar40P.param.yaml
+++ b/nebula_ros/config/lidar/hesai/Pandar40P.param.yaml
@@ -6,9 +6,7 @@
     data_port: 2368
     gnss_port: 10110
     packet_mtu_size: 1500
-    launch_hw: true
-    setup_sensor: true
-    udp_only: false
+    connection_mode: full
     frame_id: hesai
     diag_span: 1000
     min_range: 0.3

--- a/nebula_ros/config/lidar/hesai/Pandar64.param.yaml
+++ b/nebula_ros/config/lidar/hesai/Pandar64.param.yaml
@@ -6,9 +6,7 @@
     data_port: 2368
     gnss_port: 10110
     packet_mtu_size: 1500
-    launch_hw: true
-    setup_sensor: true
-    udp_only: false
+    connection_mode: full
     frame_id: hesai
     diag_span: 1000
     min_range: 0.3

--- a/nebula_ros/config/lidar/hesai/PandarAT128.param.yaml
+++ b/nebula_ros/config/lidar/hesai/PandarAT128.param.yaml
@@ -6,9 +6,7 @@
     data_port: 2368
     gnss_port: 10110
     packet_mtu_size: 1500
-    launch_hw: true
-    setup_sensor: true
-    udp_only: false
+    connection_mode: full
     frame_id: hesai
     diag_span: 1000
     correction_file: $(find-pkg-share nebula_decoders)/calibration/hesai/$(var sensor_model).dat

--- a/nebula_ros/config/lidar/hesai/PandarQT128.param.yaml
+++ b/nebula_ros/config/lidar/hesai/PandarQT128.param.yaml
@@ -6,9 +6,7 @@
     data_port: 2368
     gnss_port: 10110
     packet_mtu_size: 1500
-    launch_hw: true
-    setup_sensor: true
-    udp_only: false
+    connection_mode: full
     frame_id: hesai
     diag_span: 1000
     min_range: 0.3

--- a/nebula_ros/config/lidar/hesai/PandarQT64.param.yaml
+++ b/nebula_ros/config/lidar/hesai/PandarQT64.param.yaml
@@ -6,9 +6,7 @@
     data_port: 2368
     gnss_port: 10110
     packet_mtu_size: 1500
-    launch_hw: true
-    setup_sensor: true
-    udp_only: false
+    connection_mode: full
     frame_id: hesai
     diag_span: 1000
     min_range: 0.3

--- a/nebula_ros/config/lidar/hesai/PandarXT32.param.yaml
+++ b/nebula_ros/config/lidar/hesai/PandarXT32.param.yaml
@@ -6,9 +6,7 @@
     data_port: 2368
     gnss_port: 10110
     packet_mtu_size: 1500
-    launch_hw: true
-    setup_sensor: true
-    udp_only: false
+    connection_mode: full
     frame_id: hesai
     diag_span: 1000
     min_range: 0.3

--- a/nebula_ros/config/lidar/hesai/PandarXT32M.param.yaml
+++ b/nebula_ros/config/lidar/hesai/PandarXT32M.param.yaml
@@ -6,9 +6,7 @@
     data_port: 2368
     gnss_port: 10110
     packet_mtu_size: 1500
-    launch_hw: true
-    setup_sensor: true
-    udp_only: false
+    connection_mode: full
     frame_id: hesai
     diag_span: 1000
     min_range: 0.3

--- a/nebula_ros/config/lidar/robosense/Bpearl.param.yaml
+++ b/nebula_ros/config/lidar/robosense/Bpearl.param.yaml
@@ -5,7 +5,7 @@
     data_port: 2368
     gnss_port: 2369
     packet_mtu_size: 1500
-    launch_hw: true
+    connection_mode: full
     setup_sensor: true
     frame_id: robosense
     diag_span: 1000

--- a/nebula_ros/config/lidar/robosense/Helios.param.yaml
+++ b/nebula_ros/config/lidar/robosense/Helios.param.yaml
@@ -5,7 +5,7 @@
     data_port: 2368
     gnss_port: 2369
     packet_mtu_size: 1500
-    launch_hw: true
+    connection_mode: full
     setup_sensor: true
     frame_id: robosense
     diag_span: 1000

--- a/nebula_ros/config/lidar/velodyne/VLP16.param.yaml
+++ b/nebula_ros/config/lidar/velodyne/VLP16.param.yaml
@@ -5,9 +5,7 @@
     data_port: 2368
     gnss_port: 2369
     packet_mtu_size: 1500
-    launch_hw: true
-    setup_sensor: true
-    udp_only: false
+    connection_mode: full
     frame_id: velodyne
     advanced_diagnostics: false
     diag_span: 1000

--- a/nebula_ros/config/lidar/velodyne/VLP32.param.yaml
+++ b/nebula_ros/config/lidar/velodyne/VLP32.param.yaml
@@ -5,9 +5,7 @@
     data_port: 2368
     gnss_port: 2369
     packet_mtu_size: 1500
-    launch_hw: true
-    setup_sensor: true
-    udp_only: false
+    connection_mode: full
     frame_id: velodyne
     advanced_diagnostics: false
     diag_span: 1000

--- a/nebula_ros/config/lidar/velodyne/VLS128.param.yaml
+++ b/nebula_ros/config/lidar/velodyne/VLS128.param.yaml
@@ -5,9 +5,7 @@
     data_port: 2368
     gnss_port: 2369
     packet_mtu_size: 1500
-    launch_hw: true
-    setup_sensor: true
-    udp_only: false
+    connection_mode: full
     frame_id: velodyne
     advanced_diagnostics: false
     diag_span: 1000

--- a/nebula_ros/config/radar/continental/ARS548.param.yaml
+++ b/nebula_ros/config/radar/continental/ARS548.param.yaml
@@ -6,7 +6,7 @@
     frame_id: continental
     base_frame: base_link
     object_frame: base_link
-    launch_hw: true
+    connection_mode: full
     multicast_ip: 224.0.2.2
     sensor_model: ARS548
     configuration_host_port: 42401

--- a/nebula_ros/config/radar/continental/SRR520.param.yaml
+++ b/nebula_ros/config/radar/continental/SRR520.param.yaml
@@ -4,7 +4,7 @@
     frame_id: continental
     base_frame: base_link
     interface: can4
-    launch_hw: true
+    connection_mode: full
     receiver_timeout_sec: 0.03
     sender_timeout_sec: 0.01
     filters: 0:0 # candump-like filters

--- a/nebula_ros/include/nebula_ros/hesai/hesai_ros_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/hesai/hesai_ros_wrapper.hpp
@@ -105,7 +105,7 @@ private:
 
   rclcpp::Subscription<pandar_msgs::msg::PandarScan>::SharedPtr packets_sub_{};
 
-  bool launch_hw_;
+  drivers::ConnectionMode connection_mode_;
 
   std::optional<HesaiHwInterfaceWrapper> hw_interface_wrapper_;
   std::optional<HesaiHwMonitorWrapper> hw_monitor_wrapper_;

--- a/nebula_ros/include/nebula_ros/hesai/hw_interface_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/hesai/hw_interface_wrapper.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <nebula_common/hesai/hesai_common.hpp>
+#include <nebula_common/nebula_common.hpp>
 #include <nebula_hw_interfaces/nebula_hw_interfaces_hesai/hesai_hw_interface.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -28,7 +29,7 @@ public:
   HesaiHwInterfaceWrapper(
     rclcpp::Node * const parent_node,
     std::shared_ptr<const nebula::drivers::HesaiSensorConfiguration> & config,
-    bool use_udp_only = false);
+    drivers::ConnectionMode connection_mode);
 
   void on_config_change(
     const std::shared_ptr<const nebula::drivers::HesaiSensorConfiguration> & new_config);
@@ -41,7 +42,6 @@ private:
   std::shared_ptr<drivers::HesaiHwInterface> hw_interface_;
   rclcpp::Logger logger_;
   nebula::Status status_;
-  bool setup_sensor_;
-  bool use_udp_only_;
+  drivers::ConnectionMode connection_mode_;
 };
 }  // namespace nebula::ros

--- a/nebula_ros/include/nebula_ros/velodyne/hw_interface_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/velodyne/hw_interface_wrapper.hpp
@@ -16,6 +16,7 @@
 
 #include "nebula_ros/common/parameter_descriptors.hpp"
 
+#include <nebula_common/nebula_common.hpp>
 #include <nebula_common/velodyne/velodyne_common.hpp>
 #include <nebula_hw_interfaces/nebula_hw_interfaces_velodyne/velodyne_hw_interface.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -30,7 +31,7 @@ public:
   VelodyneHwInterfaceWrapper(
     rclcpp::Node * const parent_node,
     std::shared_ptr<const nebula::drivers::VelodyneSensorConfiguration> & config,
-    bool use_udp_only = false);
+    drivers::ConnectionMode connection_mode);
 
   void on_config_change(
     const std::shared_ptr<const nebula::drivers::VelodyneSensorConfiguration> & new_config);
@@ -43,7 +44,6 @@ private:
   std::shared_ptr<drivers::VelodyneHwInterface> hw_interface_;
   rclcpp::Logger logger_;
   nebula::Status status_;
-  bool setup_sensor_;
-  bool use_udp_only_;
+  drivers::ConnectionMode connection_mode_;
 };
 }  // namespace nebula::ros

--- a/nebula_ros/include/nebula_ros/velodyne/velodyne_ros_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/velodyne/velodyne_ros_wrapper.hpp
@@ -89,7 +89,7 @@ private:
 
   rclcpp::Subscription<velodyne_msgs::msg::VelodyneScan>::SharedPtr packets_sub_{};
 
-  bool launch_hw_;
+  drivers::ConnectionMode connection_mode_;
 
   std::optional<VelodyneHwInterfaceWrapper> hw_interface_wrapper_;
   std::optional<VelodyneHwMonitorWrapper> hw_monitor_wrapper_;

--- a/nebula_ros/schema/Pandar128E4X.schema.json
+++ b/nebula_ros/schema/Pandar128E4X.schema.json
@@ -24,14 +24,8 @@
         "packet_mtu_size": {
           "$ref": "sub/communication.json#/definitions/packet_mtu_size"
         },
-        "launch_hw": {
-          "$ref": "sub/hardware.json#/definitions/launch_hw"
-        },
-        "setup_sensor": {
-          "$ref": "sub/hardware.json#/definitions/setup_sensor"
-        },
-        "udp_only": {
-          "$ref": "sub/hardware.json#/definitions/udp_only"
+        "connection_mode": {
+          "$ref": "sub/hardware.json#/definitions/connection_mode"
         },
         "frame_id": {
           "$ref": "sub/topic.json#/definitions/frame_id"
@@ -110,9 +104,7 @@
         "data_port",
         "gnss_port",
         "packet_mtu_size",
-        "launch_hw",
-        "setup_sensor",
-        "udp_only",
+        "connection_mode",
         "frame_id",
         "diag_span",
         "cloud_min_angle",

--- a/nebula_ros/schema/Pandar40P.schema.json
+++ b/nebula_ros/schema/Pandar40P.schema.json
@@ -24,14 +24,8 @@
         "packet_mtu_size": {
           "$ref": "sub/communication.json#/definitions/packet_mtu_size"
         },
-        "launch_hw": {
-          "$ref": "sub/hardware.json#/definitions/launch_hw"
-        },
-        "setup_sensor": {
-          "$ref": "sub/hardware.json#/definitions/setup_sensor"
-        },
-        "udp_only": {
-          "$ref": "sub/hardware.json#/definitions/udp_only"
+        "connection_mode": {
+          "$ref": "sub/hardware.json#/definitions/connection_mode"
         },
         "frame_id": {
           "$ref": "sub/topic.json#/definitions/frame_id"
@@ -101,9 +95,7 @@
         "data_port",
         "gnss_port",
         "packet_mtu_size",
-        "launch_hw",
-        "setup_sensor",
-        "udp_only",
+        "connection_mode",
         "frame_id",
         "diag_span",
         "cloud_min_angle",

--- a/nebula_ros/schema/Pandar64.schema.json
+++ b/nebula_ros/schema/Pandar64.schema.json
@@ -24,14 +24,8 @@
         "packet_mtu_size": {
           "$ref": "sub/communication.json#/definitions/packet_mtu_size"
         },
-        "launch_hw": {
-          "$ref": "sub/hardware.json#/definitions/launch_hw"
-        },
-        "setup_sensor": {
-          "$ref": "sub/hardware.json#/definitions/setup_sensor"
-        },
-        "udp_only": {
-          "$ref": "sub/hardware.json#/definitions/udp_only"
+        "connection_mode": {
+          "$ref": "sub/hardware.json#/definitions/connection_mode"
         },
         "frame_id": {
           "$ref": "sub/topic.json#/definitions/frame_id"
@@ -98,9 +92,7 @@
         "data_port",
         "gnss_port",
         "packet_mtu_size",
-        "launch_hw",
-        "setup_sensor",
-        "udp_only",
+        "connection_mode",
         "frame_id",
         "diag_span",
         "cloud_min_angle",

--- a/nebula_ros/schema/PandarAT128.schema.json
+++ b/nebula_ros/schema/PandarAT128.schema.json
@@ -24,14 +24,8 @@
         "packet_mtu_size": {
           "$ref": "sub/communication.json#/definitions/packet_mtu_size"
         },
-        "launch_hw": {
-          "$ref": "sub/hardware.json#/definitions/launch_hw"
-        },
-        "setup_sensor": {
-          "$ref": "sub/hardware.json#/definitions/setup_sensor"
-        },
-        "udp_only": {
-          "$ref": "sub/hardware.json#/definitions/udp_only"
+        "connection_mode": {
+          "$ref": "sub/hardware.json#/definitions/connection_mode"
         },
         "frame_id": {
           "$ref": "sub/topic.json#/definitions/frame_id"
@@ -121,9 +115,7 @@
         "data_port",
         "gnss_port",
         "packet_mtu_size",
-        "launch_hw",
-        "setup_sensor",
-        "udp_only",
+        "connection_mode",
         "frame_id",
         "diag_span",
         "correction_file",

--- a/nebula_ros/schema/PandarQT128.schema.json
+++ b/nebula_ros/schema/PandarQT128.schema.json
@@ -24,14 +24,8 @@
         "packet_mtu_size": {
           "$ref": "sub/communication.json#/definitions/packet_mtu_size"
         },
-        "launch_hw": {
-          "$ref": "sub/hardware.json#/definitions/launch_hw"
-        },
-        "setup_sensor": {
-          "$ref": "sub/hardware.json#/definitions/setup_sensor"
-        },
-        "udp_only": {
-          "$ref": "sub/hardware.json#/definitions/udp_only"
+        "connection_mode": {
+          "$ref": "sub/hardware.json#/definitions/connection_mode"
         },
         "frame_id": {
           "$ref": "sub/topic.json#/definitions/frame_id"
@@ -104,9 +98,7 @@
         "data_port",
         "gnss_port",
         "packet_mtu_size",
-        "launch_hw",
-        "setup_sensor",
-        "udp_only",
+        "connection_mode",
         "frame_id",
         "diag_span",
         "cloud_min_angle",

--- a/nebula_ros/schema/PandarQT64.schema.json
+++ b/nebula_ros/schema/PandarQT64.schema.json
@@ -24,14 +24,8 @@
         "packet_mtu_size": {
           "$ref": "sub/communication.json#/definitions/packet_mtu_size"
         },
-        "launch_hw": {
-          "$ref": "sub/hardware.json#/definitions/launch_hw"
-        },
-        "setup_sensor": {
-          "$ref": "sub/hardware.json#/definitions/setup_sensor"
-        },
-        "udp_only": {
-          "$ref": "sub/hardware.json#/definitions/udp_only"
+        "connection_mode": {
+          "$ref": "sub/hardware.json#/definitions/connection_mode"
         },
         "frame_id": {
           "$ref": "sub/topic.json#/definitions/frame_id"
@@ -101,9 +95,7 @@
         "data_port",
         "gnss_port",
         "packet_mtu_size",
-        "launch_hw",
-        "setup_sensor",
-        "udp_only",
+        "connection_mode",
         "frame_id",
         "diag_span",
         "cloud_min_angle",

--- a/nebula_ros/schema/PandarXT32.schema.json
+++ b/nebula_ros/schema/PandarXT32.schema.json
@@ -24,14 +24,8 @@
         "packet_mtu_size": {
           "$ref": "sub/communication.json#/definitions/packet_mtu_size"
         },
-        "launch_hw": {
-          "$ref": "sub/hardware.json#/definitions/launch_hw"
-        },
-        "setup_sensor": {
-          "$ref": "sub/hardware.json#/definitions/setup_sensor"
-        },
-        "udp_only": {
-          "$ref": "sub/hardware.json#/definitions/udp_only"
+        "connection_mode": {
+          "$ref": "sub/hardware.json#/definitions/connection_mode"
         },
         "frame_id": {
           "$ref": "sub/topic.json#/definitions/frame_id"
@@ -104,9 +98,7 @@
         "data_port",
         "gnss_port",
         "packet_mtu_size",
-        "launch_hw",
-        "setup_sensor",
-        "udp_only",
+        "connection_mode",
         "frame_id",
         "diag_span",
         "cloud_min_angle",

--- a/nebula_ros/schema/PandarXT32M.schema.json
+++ b/nebula_ros/schema/PandarXT32M.schema.json
@@ -24,14 +24,8 @@
         "packet_mtu_size": {
           "$ref": "sub/communication.json#/definitions/packet_mtu_size"
         },
-        "launch_hw": {
-          "$ref": "sub/hardware.json#/definitions/launch_hw"
-        },
-        "setup_sensor": {
-          "$ref": "sub/hardware.json#/definitions/setup_sensor"
-        },
-        "udp_only": {
-          "$ref": "sub/hardware.json#/definitions/udp_only"
+        "connection_mode": {
+          "$ref": "sub/hardware.json#/definitions/connection_mode"
         },
         "frame_id": {
           "$ref": "sub/topic.json#/definitions/frame_id"
@@ -104,9 +98,7 @@
         "data_port",
         "gnss_port",
         "packet_mtu_size",
-        "launch_hw",
-        "setup_sensor",
-        "udp_only",
+        "connection_mode",
         "frame_id",
         "diag_span",
         "cloud_min_angle",

--- a/nebula_ros/schema/VLP16.schema.json
+++ b/nebula_ros/schema/VLP16.schema.json
@@ -21,14 +21,8 @@
         "packet_mtu_size": {
           "$ref": "sub/communication.json#/definitions/packet_mtu_size"
         },
-        "launch_hw": {
-          "$ref": "sub/hardware.json#/definitions/launch_hw"
-        },
-        "setup_sensor": {
-          "$ref": "sub/hardware.json#/definitions/setup_sensor"
-        },
-        "udp_only": {
-          "$ref": "sub/hardware.json#/definitions/udp_only"
+        "connection_mode": {
+          "$ref": "sub/hardware.json#/definitions/connection_mode"
         },
         "frame_id": {
           "$ref": "sub/topic.json#/definitions/frame_id"
@@ -73,9 +67,7 @@
         "data_port",
         "gnss_port",
         "packet_mtu_size",
-        "launch_hw",
-        "setup_sensor",
-        "udp_only",
+        "connection_mode",
         "frame_id",
         "advanced_diagnostics",
         "diag_span",

--- a/nebula_ros/schema/VLP32.schema.json
+++ b/nebula_ros/schema/VLP32.schema.json
@@ -21,14 +21,8 @@
         "packet_mtu_size": {
           "$ref": "sub/communication.json#/definitions/packet_mtu_size"
         },
-        "launch_hw": {
-          "$ref": "sub/hardware.json#/definitions/launch_hw"
-        },
-        "setup_sensor": {
-          "$ref": "sub/hardware.json#/definitions/setup_sensor"
-        },
-        "udp_only": {
-          "$ref": "sub/hardware.json#/definitions/udp_only"
+        "connection_mode": {
+          "$ref": "sub/hardware.json#/definitions/connection_mode"
         },
         "frame_id": {
           "$ref": "sub/topic.json#/definitions/frame_id"
@@ -73,9 +67,7 @@
         "data_port",
         "gnss_port",
         "packet_mtu_size",
-        "launch_hw",
-        "setup_sensor",
-        "udp_only",
+        "connection_mode",
         "frame_id",
         "advanced_diagnostics",
         "diag_span",

--- a/nebula_ros/schema/VLS128.schema.json
+++ b/nebula_ros/schema/VLS128.schema.json
@@ -21,14 +21,8 @@
         "packet_mtu_size": {
           "$ref": "sub/communication.json#/definitions/packet_mtu_size"
         },
-        "launch_hw": {
-          "$ref": "sub/hardware.json#/definitions/launch_hw"
-        },
-        "setup_sensor": {
-          "$ref": "sub/hardware.json#/definitions/setup_sensor"
-        },
-        "udp_only": {
-          "$ref": "sub/hardware.json#/definitions/udp_only"
+        "connection_mode": {
+          "$ref": "sub/hardware.json#/definitions/connection_mode"
         },
         "frame_id": {
           "$ref": "sub/topic.json#/definitions/frame_id"
@@ -73,9 +67,7 @@
         "data_port",
         "gnss_port",
         "packet_mtu_size",
-        "launch_hw",
-        "setup_sensor",
-        "udp_only",
+        "connection_mode",
         "frame_id",
         "advanced_diagnostics",
         "diag_span",

--- a/nebula_ros/schema/sub/communication.json
+++ b/nebula_ros/schema/sub/communication.json
@@ -115,6 +115,17 @@
       "default": "0.01",
       "minimum": 0.0,
       "description": "Timeout for sending data to the CAN bus."
+    },
+    "connection_mode": {
+      "type": "string",
+      "enum": [
+        "offline",
+        "udp_only",
+        "skip_setup",
+        "full"
+      ],
+      "default": "full",
+      "description": "Whether to connect to no sensor and listen to a packets topic (offline), listen to sensor outputs only with limited diagnostics and no settings sync (udp_only), connect fully but not changing sensor settings (skip_setup) or to connect fully with settings sync."
     }
   }
 }

--- a/nebula_ros/schema/sub/hardware.json
+++ b/nebula_ros/schema/sub/hardware.json
@@ -18,22 +18,10 @@
       "readOnly": true,
       "description": "Sensor model."
     },
-    "setup_sensor": {
-      "type": "boolean",
-      "default": "true",
-      "readOnly": true,
-      "description": "Enable sensor setup on hardware driver."
-    },
     "retry_hw": {
       "type": "boolean",
       "default": "true",
       "description": "Whether TCP connections are retried on failure or the driver should instead exit."
-    },
-    "udp_only": {
-      "type": "boolean",
-      "default": "false",
-      "readOnly": true,
-      "description": "Use UDP protocol only (settings synchronization and diagnostics publishing are disabled)."
     }
   }
 }


### PR DESCRIPTION
## PR Type

- Improvement

## Related Links

- #210 -- motivation for this PR

## Description

With #210, the connection-related parameters for Hesai and Velodyne sensors became a total of three each (`udp_only`, `launch_hw` and `setup_sensor`), resulting in 8 possible combinations, of which only four were valid:
* `launch_hw && setup_sensor && !udp_only` -- fullly connected
* `launch_hw && !setup_sensor && !udp_only` -- skip sensor setup but otherwise fully connected
* `launch_hw && !setup_sensor && udp_only` -- UDP-only mode
* `!launch_hw` -- offline mode

This PR combines the three parameters into one enum, `connection_mode`, which can be one of `offline`, `udp_only`, `skip_setup` and `full`.

Sensors that do not have TCP support and which do not support sensor setup are left untouched. They remain having one `launch_hw` parameter.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
