### PR TITLE
fix(robosense): include DIFOP packets in record/replay functionality

### DIFF
--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/robosense_driver.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_robosense/robosense_driver.hpp
@@ -34,7 +34,7 @@ class RobosenseDriver : NebulaDriverBase
 {
 private:
   /// @brief Current driver status
-  Status driver_status_;
+  Status driver_status_{Status::NOT_INITIALIZED};
 
   /// @brief Decoder according to the model
   std::shared_ptr<RobosenseScanDecoder> scan_decoder_;

--- a/nebula_ros/include/nebula_ros/robosense/robosense_ros_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/robosense/robosense_ros_wrapper.hpp
@@ -30,6 +30,7 @@
 #include <rclcpp_components/register_node_macro.hpp>
 
 #include <nebula_msgs/msg/nebula_packet.hpp>
+#include <robosense_msgs/msg/detail/robosense_info_packet__struct.hpp>
 #include <robosense_msgs/msg/robosense_info_packet.hpp>
 #include <robosense_msgs/msg/robosense_scan.hpp>
 
@@ -81,14 +82,17 @@ private:
 
   nebula::Status wrapper_status_;
 
-  std::shared_ptr<const nebula::drivers::RobosenseSensorConfiguration> sensor_cfg_ptr_{};
+  std::shared_ptr<const nebula::drivers::RobosenseSensorConfiguration> sensor_cfg_ptr_;
 
   /// @brief Stores received packets that have not been processed yet by the decoder thread
   MtQueue<std::unique_ptr<nebula_msgs::msg::NebulaPacket>> packet_queue_;
   /// @brief Thread to isolate decoding from receiving
   std::thread decoder_thread_;
 
-  rclcpp::Subscription<robosense_msgs::msg::RobosenseScan>::SharedPtr packets_sub_{};
+  rclcpp::Publisher<robosense_msgs::msg::RobosenseInfoPacket>::SharedPtr info_packets_pub_;
+
+  rclcpp::Subscription<robosense_msgs::msg::RobosenseScan>::SharedPtr packets_sub_;
+  rclcpp::Subscription<robosense_msgs::msg::RobosenseInfoPacket>::SharedPtr info_packets_sub_;
 
   bool launch_hw_;
 


### PR DESCRIPTION
## PR Type

- Bug Fix

## Related Links

- #147 -- bug introduced here

## Description

Since Nebula v0.2.0, or more specifically, since PR #147, DIFOP ("info") packets are not recorded/replayed anymore by Nebula.
This made diagnosing https://github.com/orgs/autowarefoundation/discussions/5378 impossible since the sensor configuration was not recorded.

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

Tested with the Helios PCAP from [here](https://github.com/tier4/nebula/pull/77#issuecomment-1831496822).

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
