### PR TITLE
fix(velodyne): reset pointcloud correctly, including width and height fields

### DIFF
--- a/nebula_decoders/src/nebula_decoders_velodyne/decoders/vlp16_decoder.cpp
+++ b/nebula_decoders/src/nebula_decoders_velodyne/decoders/vlp16_decoder.cpp
@@ -85,7 +85,7 @@ int Vlp16Decoder::points_per_packet()
 
 void Vlp16Decoder::reset_pointcloud(double time_stamp)
 {
-  scan_pc_->points.clear();
+  scan_pc_->clear();
   reset_overflow(time_stamp);  // transfer existing overflow points to the cleared pointcloud
 }
 

--- a/nebula_decoders/src/nebula_decoders_velodyne/decoders/vlp32_decoder.cpp
+++ b/nebula_decoders/src/nebula_decoders_velodyne/decoders/vlp32_decoder.cpp
@@ -83,8 +83,7 @@ int Vlp32Decoder::points_per_packet()
 
 void Vlp32Decoder::reset_pointcloud(double time_stamp)
 {
-  //  scan_pc_.reset(new NebulaPointCloud);
-  scan_pc_->points.clear();
+  scan_pc_->clear();
   reset_overflow(time_stamp);  // transfer existing overflow points to the cleared pointcloud
 }
 

--- a/nebula_decoders/src/nebula_decoders_velodyne/decoders/vls128_decoder.cpp
+++ b/nebula_decoders/src/nebula_decoders_velodyne/decoders/vls128_decoder.cpp
@@ -86,8 +86,7 @@ int Vls128Decoder::points_per_packet()
 
 void Vls128Decoder::reset_pointcloud(double time_stamp)
 {
-  //  scan_pc_.reset(new NebulaPointCloud);
-  scan_pc_->points.clear();
+  scan_pc_->clear();
   reset_overflow(time_stamp);  // transfer existing overflow points to the cleared pointcloud
 }
 


### PR DESCRIPTION
## PR Type

- Bug Fix

## Related Links

- [TIER IV INTERNAL LINK](https://star4.slack.com/archives/C076ZGRC15X/p1730449377715739?thread_ts=1729751812.548579&cid=C076ZGRC15X) -- conversation
- [TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/RT0-33996?focusedCommentId=193350) -- JIRA comment

## Description

Velodyne decoders were resetting only the point buffer but not the width/height header fields, resulting in an invalid pointcloud output when no valid points have been received in a scan.

This PR uses the correct reset method to fix this problem.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
