### PR TITLE
feat(hesai): add node name to diag name of hesai hw_monitor

### DIFF
--- a/nebula_ros/src/hesai/hw_monitor_wrapper.cpp
+++ b/nebula_ros/src/hesai/hw_monitor_wrapper.cpp
@@ -4,6 +4,7 @@
 
 #include "nebula_ros/common/parameter_descriptors.hpp"
 
+#include <diagnostic_updater/diagnostic_updater.hpp>
 #include <nebula_common/nebula_common.hpp>
 
 namespace nebula::ros
@@ -13,7 +14,8 @@ HesaiHwMonitorWrapper::HesaiHwMonitorWrapper(
   const std::shared_ptr<nebula::drivers::HesaiHwInterface> & hw_interface,
   std::shared_ptr<const nebula::drivers::HesaiSensorConfiguration> & config)
 : logger_(parent_node->get_logger().get_child("HwMonitor")),
-  diagnostics_updater_(parent_node),
+  diagnostics_updater_(
+    (parent_node->declare_parameter<bool>("diagnostic_updater.use_fqn", true), parent_node)),
   status_(Status::OK),
   hw_interface_(hw_interface),
   parent_node_(parent_node)


### PR DESCRIPTION
## PR Type
- Improvement

## Related Links
https://tier4.atlassian.net/browse/RT0-34026

## Description
Added namespace so that hessai_hw_monitor can diag each LiDAR
You can verify with a bench test that a diag is published containing the namespace of each LiDAR

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
