### PR TITLE
fix(nebula_tests): fix bugprone-incorrect-roundings

### DIFF
--- a/nebula_tests/velodyne/velodyne_ros_decoder_test_vlp16.cpp
+++ b/nebula_tests/velodyne/velodyne_ros_decoder_test_vlp16.cpp
@@ -11,6 +11,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cmath>
 #include <filesystem>
 #include <memory>
 #include <regex>
@@ -180,8 +181,10 @@ Status VelodyneRosDecoderTest::get_parameters(
   } else {
     double min_angle = fmod(fmod(view_direction + view_width / 2, 2 * M_PI) + 2 * M_PI, 2 * M_PI);
     double max_angle = fmod(fmod(view_direction - view_width / 2, 2 * M_PI) + 2 * M_PI, 2 * M_PI);
-    sensor_configuration.cloud_min_angle = 100 * (2 * M_PI - min_angle) * 180 / M_PI + 0.5;
-    sensor_configuration.cloud_max_angle = 100 * (2 * M_PI - max_angle) * 180 / M_PI + 0.5;
+    sensor_configuration.cloud_min_angle =
+      static_cast<int>(std::lround(100 * (2 * M_PI - min_angle) * 180 / M_PI));
+    sensor_configuration.cloud_max_angle =
+      static_cast<int>(std::lround(100 * (2 * M_PI - max_angle) * 180 / M_PI));
     if (sensor_configuration.cloud_min_angle == sensor_configuration.cloud_max_angle) {
       // avoid returning empty cloud if min_angle = max_angle
       sensor_configuration.cloud_min_angle = 0;

--- a/nebula_tests/velodyne/velodyne_ros_decoder_test_vlp32.cpp
+++ b/nebula_tests/velodyne/velodyne_ros_decoder_test_vlp32.cpp
@@ -11,6 +11,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cmath>
 #include <filesystem>
 #include <regex>
 #include <vector>
@@ -178,8 +179,10 @@ Status VelodyneRosDecoderTest::get_parameters(
   } else {
     double min_angle = fmod(fmod(view_direction + view_width / 2, 2 * M_PI) + 2 * M_PI, 2 * M_PI);
     double max_angle = fmod(fmod(view_direction - view_width / 2, 2 * M_PI) + 2 * M_PI, 2 * M_PI);
-    sensor_configuration.cloud_min_angle = 100 * (2 * M_PI - min_angle) * 180 / M_PI + 0.5;
-    sensor_configuration.cloud_max_angle = 100 * (2 * M_PI - max_angle) * 180 / M_PI + 0.5;
+    sensor_configuration.cloud_min_angle =
+      static_cast<int>(std::lround(100 * (2 * M_PI - min_angle) * 180 / M_PI));
+    sensor_configuration.cloud_max_angle =
+      static_cast<int>(std::lround(100 * (2 * M_PI - max_angle) * 180 / M_PI));
     if (sensor_configuration.cloud_min_angle == sensor_configuration.cloud_max_angle) {
       // avoid returning empty cloud if min_angle = max_angle
       sensor_configuration.cloud_min_angle = 0;

--- a/nebula_tests/velodyne/velodyne_ros_decoder_test_vls128.cpp
+++ b/nebula_tests/velodyne/velodyne_ros_decoder_test_vls128.cpp
@@ -14,6 +14,7 @@
 #include <gtest/gtest.h>
 #include <rcutils/time.h>
 
+#include <cmath>
 #include <filesystem>
 #include <memory>
 #include <regex>
@@ -183,8 +184,10 @@ Status VelodyneRosDecoderTest::get_parameters(
   } else {
     double min_angle = fmod(fmod(view_direction + view_width / 2, 2 * M_PI) + 2 * M_PI, 2 * M_PI);
     double max_angle = fmod(fmod(view_direction - view_width / 2, 2 * M_PI) + 2 * M_PI, 2 * M_PI);
-    sensor_configuration.cloud_min_angle = 100 * (2 * M_PI - min_angle) * 180 / M_PI + 0.5;
-    sensor_configuration.cloud_max_angle = 100 * (2 * M_PI - max_angle) * 180 / M_PI + 0.5;
+    sensor_configuration.cloud_min_angle =
+      static_cast<int>(std::lround(100 * (2 * M_PI - min_angle) * 180 / M_PI));
+    sensor_configuration.cloud_max_angle =
+      static_cast<int>(std::lround(100 * (2 * M_PI - max_angle) * 180 / M_PI));
     if (sensor_configuration.cloud_min_angle == sensor_configuration.cloud_max_angle) {
       // avoid returning empty cloud if min_angle = max_angle
       sensor_configuration.cloud_min_angle = 0;


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Improvement

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description
This is a fix based on clang-tidy `bugprone-incorrect-roundings` error.

```
/home/emb4/autoware/autoware/src/sensor_component/external/nebula/nebula_tests/velodyne/velodyne_ros_decoder_test_vlp16.cpp:185:44: error: casting (double + 0.5) to integer leads to incorrect rounding; consider using lround (#include <cmath>) instead [bugprone-incorrect-roundings,-warnings-as-errors]
    sensor_configuration.cloud_min_angle = 100 * (2 * M_PI - min_angle) * 180 / M_PI + 0.5;
                                           ^
/home/emb4/autoware/autoware/src/sensor_component/external/nebula/nebula_tests/velodyne/velodyne_ros_decoder_test_vlp16.cpp:186:44: error: casting (double + 0.5) to integer leads to incorrect rounding; consider using lround (#include <cmath>) instead [bugprone-incorrect-roundings,-warnings-as-errors]
    sensor_configuration.cloud_max_angle = 100 * (2 * M_PI - max_angle) * 180 / M_PI + 0.5;
                                           ^
/home/emb4/autoware/autoware/src/sensor_component/external/nebula/nebula_tests/velodyne/velodyne_ros_decoder_test_vlp32.cpp:183:44: error: casting (double + 0.5) to integer leads to incorrect rounding; consider using lround (#include <cmath>) instead [bugprone-incorrect-roundings,-warnings-as-errors]
    sensor_configuration.cloud_min_angle = 100 * (2 * M_PI - min_angle) * 180 / M_PI + 0.5;
                                           ^
/home/emb4/autoware/autoware/src/sensor_component/external/nebula/nebula_tests/velodyne/velodyne_ros_decoder_test_vlp32.cpp:184:44: error: casting (double + 0.5) to integer leads to incorrect rounding; consider using lround (#include <cmath>) instead [bugprone-incorrect-roundings,-warnings-as-errors]
    sensor_configuration.cloud_max_angle = 100 * (2 * M_PI - max_angle) * 180 / M_PI + 0.5;
                                           ^
/home/emb4/autoware/autoware/src/sensor_component/external/nebula/nebula_tests/velodyne/velodyne_ros_decoder_test_vls128.cpp:188:44: error: casting (double + 0.5) to integer leads to incorrect rounding; consider using lround (#include <cmath>) instead [bugprone-incorrect-roundings,-warnings-as-errors]
    sensor_configuration.cloud_min_angle = 100 * (2 * M_PI - min_angle) * 180 / M_PI + 0.5;
                                           ^
/home/emb4/autoware/autoware/src/sensor_component/external/nebula/nebula_tests/velodyne/velodyne_ros_decoder_test_vls128.cpp:189:44: error: casting (double + 0.5) to integer leads to incorrect rounding; consider using lround (#include <cmath>) instead [bugprone-incorrect-roundings,-warnings-as-errors]
    sensor_configuration.cloud_max_angle = 100 * (2 * M_PI - max_angle) * 180 / M_PI + 0.5;
                                           ^
```
<!-- Describe what this PR changes. -->

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
