### PR TITLE
fix(docs): install mkdocs plugins in CI workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -33,7 +33,8 @@ jobs:
           mkdocs-material \
           Jinja2 \
           ruamel.yaml && \
-          pip install git+https://github.com/JakubAndrysek/mkdoxy
+          pip install git+https://github.com/JakubAndrysek/mkdoxy && \
+          pip install docs/requirements.txt
       - run: mkdocs build --site-dir _site
       - run: touch _site/.nojekyll
       - run: |


### PR DESCRIPTION
## PR Type

- Improvement

## Related Links

- #195 -- caused CI to fail

## Description

MkDocs fails in CI because the plugin `macros` was not installed correctly. Turns out, `docs/requirements.txt` was not being installed in the CI workflow, so I added it here.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
