### PR TITLE
chore(docs): disable markdown macro rendering for source file pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -162,6 +162,10 @@ nav:
 plugins:
   - macros:
       module_name: mkdocs_macros
+      render_by_default: false
+      force_render_paths: |
+        *
+        !*_source.md
   - mkdoxy:
       projects:
         nebula_common:


### PR DESCRIPTION


## PR Type

- Improvement

## Description

Some valid C++ sequences, such as `{{{`, overlap with the Jinja2 syntax and cause MkDocs errors. This PR disables the `macros` MkDocs plugin for all `*_source.md` files.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
