### PR TITLE
feat: add a logging interface, dependency injectable loggers

### DIFF
--- a/nebula_common/include/nebula_common/loggers/console_logger.hpp
+++ b/nebula_common/include/nebula_common/loggers/console_logger.hpp
@@ -1,0 +1,55 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "nebula_common/loggers/logger.hpp"
+
+#include <cstdio>
+#include <iostream>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <utility>
+
+namespace nebula::drivers::loggers
+{
+
+class ConsoleLogger : public Logger
+{
+public:
+  explicit ConsoleLogger(std::string name) : name_(std::move(name)) {}
+
+  void debug(const std::string & message) override { print_tagged(std::cout, "DEBUG", message); }
+  void info(const std::string & message) override { print_tagged(std::cout, "INFO", message); }
+  void warn(const std::string & message) override { print_tagged(std::cerr, "WARN", message); }
+  void error(const std::string & message) override { print_tagged(std::cerr, "ERROR", message); }
+
+  std::shared_ptr<Logger> child(const std::string & name) override
+  {
+    return std::make_shared<ConsoleLogger>(name_ + "." + name);
+  }
+
+private:
+  std::string name_;
+
+  void print_tagged(std::ostream & os, const std::string & severity, const std::string & message)
+  {
+    // In multithreaded logging, building the string first (... + ...) and then shifting to the
+    // stream will ensure that no other logger outputs between string fragments
+    os << ("[" + name_ + "][" + severity + "] " + message) << std::endl;
+  }
+};
+
+}  // namespace nebula::drivers::loggers

--- a/nebula_common/include/nebula_common/loggers/logger.hpp
+++ b/nebula_common/include/nebula_common/loggers/logger.hpp
@@ -1,0 +1,49 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <sstream>
+#include <string>
+
+#define NEBULA_LOG_STREAM(log_func, stream_args) \
+  {                                              \
+    std::stringstream ss{};                      \
+    ss << stream_args;                           \
+    log_func(ss.str());                          \
+  }
+
+namespace nebula::drivers::loggers
+{
+
+class Logger
+{
+public:
+  Logger() = default;
+  Logger(const Logger &) = default;
+  Logger(Logger &&) = delete;
+  Logger & operator=(const Logger &) = default;
+  Logger & operator=(Logger &&) = delete;
+  virtual ~Logger() = default;
+
+  virtual void debug(const std::string & message) = 0;
+  virtual void info(const std::string & message) = 0;
+  virtual void warn(const std::string & message) = 0;
+  virtual void error(const std::string & message) = 0;
+
+  virtual std::shared_ptr<Logger> child(const std::string & name) = 0;
+};
+
+}  // namespace nebula::drivers::loggers

--- a/nebula_common/include/nebula_common/loggers/logger.hpp
+++ b/nebula_common/include/nebula_common/loggers/logger.hpp
@@ -31,11 +31,6 @@ namespace nebula::drivers::loggers
 class Logger
 {
 public:
-  Logger() = default;
-  Logger(const Logger &) = default;
-  Logger(Logger &&) = delete;
-  Logger & operator=(const Logger &) = default;
-  Logger & operator=(Logger &&) = delete;
   virtual ~Logger() = default;
 
   virtual void debug(const std::string & message) = 0;

--- a/nebula_ros/include/nebula_ros/common/rclcpp_logger.hpp
+++ b/nebula_ros/include/nebula_ros/common/rclcpp_logger.hpp
@@ -1,0 +1,59 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <nebula_common/loggers/logger.hpp>
+#include <rclcpp/logger.hpp>
+#include <rclcpp/logging.hpp>
+
+#include <memory>
+#include <string>
+
+namespace nebula::drivers::loggers
+{
+
+class RclcppLogger : public Logger
+{
+public:
+  explicit RclcppLogger(const std::string & name) : underlying_logger_(rclcpp::get_logger(name)) {}
+  explicit RclcppLogger(const rclcpp::Logger & underlying) : underlying_logger_(underlying) {}
+
+  void debug(const std::string & message) override
+  {
+    RCLCPP_DEBUG_STREAM(underlying_logger_, message);
+  }
+  void info(const std::string & message) override
+  {
+    RCLCPP_INFO_STREAM(underlying_logger_, message);
+  }
+  void warn(const std::string & message) override
+  {
+    RCLCPP_WARN_STREAM(underlying_logger_, message);
+  }
+  void error(const std::string & message) override
+  {
+    RCLCPP_ERROR_STREAM(underlying_logger_, message);
+  }
+
+  std::shared_ptr<Logger> child(const std::string & name) override
+  {
+    return std::make_shared<RclcppLogger>(underlying_logger_.get_child(name));
+  }
+
+private:
+  rclcpp::Logger underlying_logger_;
+};
+
+}  // namespace nebula::drivers::loggers


### PR DESCRIPTION
## PR Type

- Improvement

## Related Links

- #169 -- first introduced here

## Description

This PR adds an abstract `nebula::drivers::loggers::Logger` interface that provides the following functions:

* `debug(msg)`
* `info(msg)`
* `warn(msg)`
* `error(msg)`
* `child(name) -> std::shared_ptr<Logger>` which creates a child logger (names are concatenated with `.`)

A `NEBULA_LOG_STREAM(log_func, stream_args)` macro is also provided for convenience.

There are currently two implementations of this interface:

* `nebula::drivers::loggers::ConsoleLogger` (in `nebula_common`)
* `nebula::drivers::loggers::RclcppLogger` (in `nebula_ros`)

The motivation of this PR is to, in the long run, remove the dependency on RCLCPP from all Nebula packages except `nebula_ros`.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
