### PR TITLE
chore(hesai): make `tracking` a `WARN`ing instead of an `ERROR`

### DIFF
--- a/nebula_ros/src/hesai/hw_monitor_wrapper.cpp
+++ b/nebula_ros/src/hesai/hw_monitor_wrapper.cpp
@@ -265,6 +265,9 @@ void HesaiHwMonitorWrapper::hesai_check_ptp(
         if (str == "locked") {
           level = diagnostic_msgs::msg::DiagnosticStatus::OK;
           msg = "synchronized";
+        } else if (str == "tracking") {
+          level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+          msg = "synchronized, degraded";
         }
       }
 


### PR DESCRIPTION
## PR Type

- Improvement

## Related Links

- [TIER IV INTERNAL LINK](https://star4.slack.com/archives/C076E8EBJTG/p1732785800907929) -- internal discussion

## Description

With this PR, the diagnostics status for `hesai_ptp` is set to `WARN`, not `ERROR` when `ptp_status` is `tracking`. Hesai's user manuals state that tracking still counts as synchronized, so Nebula should not report it as an error.

Since tracking can be a symptom of non-perfect PTP setups, the warning comes with a status message `synchronized, degraded`.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
