### PR TITLE
fix(hesai_ros_wrapper): demote calibration fallback message to WARN

### DIFF
--- a/nebula_ros/src/hesai/hesai_ros_wrapper.cpp
+++ b/nebula_ros/src/hesai/hesai_ros_wrapper.cpp
@@ -483,7 +483,7 @@ HesaiRosWrapper::get_calibration_result_t HesaiRosWrapper::get_calibration_data(
 
     RCLCPP_ERROR_STREAM(logger, "Could not load downloaded calibration data: " << status);
   } else if (!ignore_others) {
-    RCLCPP_ERROR(logger, "No downloaded calibration data found.");
+    RCLCPP_WARN(logger, "No downloaded calibration data found.");
   }
 
   if (!ignore_others) {


### PR DESCRIPTION
## PR Type

- Improvement

## Related Links

- [TIER IV INTERNAL LINK](https://star4.slack.com/archives/C076E8EBJTG/p1733099784725949) -- internal discussion
- #243 -- this feature would rid us of the need to manage calibration files completely

## Description

When Nebula runs without a live Hesai sensor, it will search for an already-downloaded calibration file. If that is not found, it will log a message which was previously at log level `ERROR`.
As quite a common workflow is to decode recorded packets on a different machine without this downloaded file, it is more reasonable to demote this to `WARN`.

After the warning is emitted, Nebula falls back to a sensor-specific, generic calibration file and continues operation.

With #243, calibration data could be recorded alongside `/pandar_packets` and replayed on any machine, making this file handling routine obsolete. Pointclouds could also be perfectly reproduced without any extra steps.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
