### PR TITLE
feat(hesai): implement mask-based pruning filter for Hesai

### DIFF
--- a/docs/filters.md
+++ b/docs/filters.md
@@ -34,7 +34,7 @@ The following filter types are supported:
 
 | Filter Name            | Filter Type       | Hesai | Robosense | Velodyne |
 | ---------------------- | ----------------- | :---: | :-------: | :------: |
-| Downsample Mask Filter | `downsample_mask` |  ❌   |    ❌     |    ❌    |
+| Downsample Mask Filter | `downsample_mask` |  ✅   |    ❌     |    ❌    |
 
 Compatibility:  
 ✅: compatible  

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -89,9 +89,16 @@ ros2 param set /<vendor>_ros_wrapper_node point_filters.downsample_mask.path ""'
 
 #### Behavior
 
+<!-- prettier-ignore-start -->
+!!! warning
+    Color spaces in image editors can be confusing and can lead to unexpected results (more/less downsampling than expected). 
+    To work on monochrome images, use the `Grayscale` color mode and use the `Value` in the HSV color space to choose greyscale values.
+    For example, a `Value` (HSV) of 50% is equal to a downsampling factor of 2, but a `Luminosity` (LCh) of 50% is equal to a downsampling factor of 2.17.
+    Check the generated `_dithered.png` mask to see whether you are getting the expected results.
+<!-- prettier-ignore-end -->
+
 - Greyscale values are quantized to the nearest 10th (yielding 11 quantization levels in total)
 - Mask resolution is dictated by the sensor's maximum FoV, the number of channels (for rotational LiDARs) and the peak angular resolution:
   - For a 40-channel LiDAR with `360 deg` FoV and `0.1 deg` peak azimuth resolution, the mask has to be `(360 / 0.1, 40) = (3600, 40)` pixels
   - Currently, non-rotational LiDARs are not yet supported
-- Image editors like GIMP use perceptual color profiles, which can lead to unexpected results (more/less downsampling than expected). Check the generated `_dithered.png` mask to see if you are affected.
 - Dithering performed by Nebula is spatial only, meaning that it stays constant over time. Decoded points are checked against the nearest pixel in the dithered mask

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -91,7 +91,7 @@ ros2 param set /<vendor>_ros_wrapper_node point_filters.downsample_mask.path ""'
 
 <!-- prettier-ignore-start -->
 !!! warning
-    Color spaces in image editors can be confusing and can lead to unexpected results (more/less downsampling than expected). 
+    Color spaces in image editors can be confusing and can lead to unexpected results (more/less downsampling than expected).
     To work on monochrome images, use the `Grayscale` color mode and use the `Value` in the HSV color space to choose greyscale values.
     For example, a `Value` (HSV) of 50% is equal to a downsampling factor of 2, but a `Luminosity` (LCh) of 50% is equal to a downsampling factor of 2.17.
     Check the generated `_dithered.png` mask to see whether you are getting the expected results.

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -87,6 +87,25 @@ The filter can be disabled by omitting the `downsample_mask` config item, or by 
 ros2 param set /<vendor>_ros_wrapper_node point_filters.downsample_mask.path ""'
 ```
 
+The required resolution of the mask is sensor-dependent:
+
+| Sensor Model | Required Resolution |
+| ------------ | ------------------- |
+| Pandar40P    | 1800 x 40           |
+| Pandar64     | 1800 x 64           |
+| PandarXT16   | 2000 x 16           |
+| PandarXT32   | 2000 x 32           |
+| PandarXT32M  | 2000 x 32           |
+| PandarAT128  | 1200 x 128          |
+| PandarQT64   | 600 x 64            |
+| PandarQT128  | 900 x 128           |
+| Pandar128E4X | 3600 x 128          |
+
+<!-- prettier-ignore-start -->
+!!! warning
+    If the mask resolution does not match the required resolution, Nebula will not start (if configured on launch) or reject the setting (if set during runtime).
+<!-- prettier-ignore-end -->
+
 #### Behavior
 
 <!-- prettier-ignore-start -->

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,7 @@ markdown==3.3.7
 mdx_truly_sane_lists
 mkdocs-awesome-pages-plugin==2.9.1
 mkdocs-exclude
-mkdocs-macros-plugin
+mkdocs-macros-plugin>=1.2.0
 mkdocs-same-dir
 mkdocs-static-i18n
 mkdocs-video

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -167,6 +167,7 @@ plugins:
       force_render_paths: |
         *
         !*_source.md
+        !class*.md
   - mkdoxy:
       projects:
         nebula_common:

--- a/nebula_common/include/nebula_common/hesai/hesai_common.hpp
+++ b/nebula_common/include/nebula_common/hesai/hesai_common.hpp
@@ -50,6 +50,7 @@ struct HesaiSensorConfiguration : public LidarConfigurationBase
   PtpTransportType ptp_transport_type;
   PtpSwitchType ptp_switch_type;
   uint8_t ptp_lock_threshold;
+  std::string downsample_mask_path;
 };
 /// @brief Convert HesaiSensorConfiguration to string (Overloading the << operator)
 /// @param os
@@ -73,7 +74,8 @@ inline std::ostream & operator<<(std::ostream & os, HesaiSensorConfiguration con
   os << "PTP Domain: " << std::to_string(arg.ptp_domain) << '\n';
   os << "PTP Transport Type: " << arg.ptp_transport_type << '\n';
   os << "PTP Switch Type: " << arg.ptp_switch_type << '\n';
-  os << "PTP Lock Threshold: " << std::to_string(arg.ptp_lock_threshold);
+  os << "PTP Lock Threshold: " << std::to_string(arg.ptp_lock_threshold) << '\n';
+  os << "Downsample Mask Path: " << arg.downsample_mask_path;
   return os;
 }
 

--- a/nebula_common/include/nebula_common/hesai/hesai_common.hpp
+++ b/nebula_common/include/nebula_common/hesai/hesai_common.hpp
@@ -24,6 +24,7 @@
 #include <fstream>
 #include <iostream>
 #include <map>
+#include <optional>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -50,7 +51,7 @@ struct HesaiSensorConfiguration : public LidarConfigurationBase
   PtpTransportType ptp_transport_type;
   PtpSwitchType ptp_switch_type;
   uint8_t ptp_lock_threshold;
-  std::string downsample_mask_path;
+  std::optional<std::string> downsample_mask_path;
 };
 /// @brief Convert HesaiSensorConfiguration to string (Overloading the << operator)
 /// @param os
@@ -61,7 +62,7 @@ inline std::ostream & operator<<(std::ostream & os, HesaiSensorConfiguration con
   os << "Hesai Sensor Configuration:" << '\n';
   os << (LidarConfigurationBase)(arg) << '\n';
   os << "Multicast: "
-     << (arg.multicast_ip.empty() ? "disabled" : "enabled, group " + arg.multicast_ip) << '\n';
+     << (arg.multicast_ip.empty() ? "disabled" : "enabled, group: " + arg.multicast_ip) << '\n';
   os << "GNSS Port: " << arg.gnss_port << '\n';
   os << "Rotation Speed: " << arg.rotation_speed << '\n';
   os << "Sync Angle: " << arg.sync_angle << '\n';
@@ -75,7 +76,9 @@ inline std::ostream & operator<<(std::ostream & os, HesaiSensorConfiguration con
   os << "PTP Transport Type: " << arg.ptp_transport_type << '\n';
   os << "PTP Switch Type: " << arg.ptp_switch_type << '\n';
   os << "PTP Lock Threshold: " << std::to_string(arg.ptp_lock_threshold) << '\n';
-  os << "Downsample Mask Path: " << arg.downsample_mask_path;
+  os << "Downsample Filter: "
+     << (arg.downsample_mask_path ? "enabled, path: " + arg.downsample_mask_path.value()
+                                  : "disabled");
   return os;
 }
 

--- a/nebula_decoders/CMakeLists.txt
+++ b/nebula_decoders/CMakeLists.txt
@@ -53,10 +53,12 @@ add_library(nebula_decoders_hesai SHARED
 )
 target_link_libraries(nebula_decoders_hesai PUBLIC
     ${pandar_msgs_TARGETS}
+    ${PNG_LIBRARIES}
 )
 
 target_include_directories(nebula_decoders_hesai PUBLIC
     ${pandar_msgs_INCLUDE_DIRS}
+    ${PNG_INCLUDE_DIRS}
 )
 
 # Velodyne

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/hesai_decoder.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/hesai_decoder.hpp
@@ -270,9 +270,9 @@ public:
     decode_pc_ = std::make_shared<NebulaPointCloud>();
     output_pc_ = std::make_shared<NebulaPointCloud>();
 
-    if (!sensor_configuration->downsample_mask_path.empty()) {
+    if (sensor_configuration->downsample_mask_path) {
       mask_filter_ = point_filters::DownsampleMaskFilter(
-        sensor_configuration->downsample_mask_path, SensorT::fov_mdeg.azimuth,
+        sensor_configuration->downsample_mask_path.value(), SensorT::fov_mdeg.azimuth,
         SensorT::peak_resolution_mdeg.azimuth, SensorT::packet_t::n_channels,
         logger_->child("Downsample Mask"), true);
     }

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_128e3x.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_128e3x.hpp
@@ -220,6 +220,8 @@ public:
   static constexpr float min_range = 0.1;
   static constexpr float max_range = 230.0;
   static constexpr size_t max_scan_buffer_points = 691200;
+  static constexpr FieldOfView<int32_t> fov_mdeg{{0, 360'000}, {-25'000, 14'400}};
+  static constexpr AnglePair<int32_t> peak_resolution_mdeg{100, 125};
 
   int get_packet_relative_point_time_offset(
     uint32_t block_id, uint32_t channel_id, const packet_t & packet) override

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_128e3x.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_128e3x.hpp
@@ -220,8 +220,8 @@ public:
   static constexpr float min_range = 0.1;
   static constexpr float max_range = 230.0;
   static constexpr size_t max_scan_buffer_points = 691200;
-  static constexpr FieldOfView<int32_t> fov_mdeg{{0, 360'000}, {-25'000, 14'400}};
-  static constexpr AnglePair<int32_t> peak_resolution_mdeg{100, 125};
+  static constexpr FieldOfView<int32_t, MilliDegrees> fov_mdeg{{0, 360'000}, {-25'000, 14'400}};
+  static constexpr AnglePair<int32_t, MilliDegrees> peak_resolution_mdeg{100, 125};
 
   int get_packet_relative_point_time_offset(
     uint32_t block_id, uint32_t channel_id, const packet_t & packet) override

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_128e4x.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_128e4x.hpp
@@ -83,6 +83,8 @@ public:
   static constexpr float min_range = 0.1;
   static constexpr float max_range = 230.0;
   static constexpr size_t max_scan_buffer_points = 691200;
+  static constexpr FieldOfView<int32_t> fov_mdeg{{0, 360'000}, {-24'800, 15'000}};
+  static constexpr AnglePair<int32_t> peak_resolution_mdeg{100, 125};
 
   int get_packet_relative_point_time_offset(
     uint32_t block_id, uint32_t channel_id, const packet_t & packet) override

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_128e4x.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_128e4x.hpp
@@ -83,8 +83,8 @@ public:
   static constexpr float min_range = 0.1;
   static constexpr float max_range = 230.0;
   static constexpr size_t max_scan_buffer_points = 691200;
-  static constexpr FieldOfView<int32_t> fov_mdeg{{0, 360'000}, {-24'800, 15'000}};
-  static constexpr AnglePair<int32_t> peak_resolution_mdeg{100, 125};
+  static constexpr FieldOfView<int32_t, MilliDegrees> fov_mdeg{{0, 360'000}, {-24'800, 14'400}};
+  static constexpr AnglePair<int32_t, MilliDegrees> peak_resolution_mdeg{100, 125};
 
   int get_packet_relative_point_time_offset(
     uint32_t block_id, uint32_t channel_id, const packet_t & packet) override

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_40.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_40.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "nebula_decoders/nebula_decoders_common/angles.hpp"
 #include "nebula_decoders/nebula_decoders_hesai/decoders/hesai_packet.hpp"
 #include "nebula_decoders/nebula_decoders_hesai/decoders/hesai_sensor.hpp"
 
@@ -74,6 +75,8 @@ public:
   static constexpr float min_range = 0.3f;
   static constexpr float max_range = 200.f;
   static constexpr size_t max_scan_buffer_points = 144000;
+  static constexpr FieldOfView<int32_t> fov_mdeg{{0, 360'000}, {-25'000, 15'000}};
+  static constexpr AnglePair<int32_t> peak_resolution_mdeg{200, 334};
 
   int get_packet_relative_point_time_offset(
     uint32_t block_id, uint32_t channel_id, const packet_t & packet) override

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_40.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_40.hpp
@@ -75,8 +75,8 @@ public:
   static constexpr float min_range = 0.3f;
   static constexpr float max_range = 200.f;
   static constexpr size_t max_scan_buffer_points = 144000;
-  static constexpr FieldOfView<int32_t> fov_mdeg{{0, 360'000}, {-25'000, 15'000}};
-  static constexpr AnglePair<int32_t> peak_resolution_mdeg{200, 334};
+  static constexpr FieldOfView<int32_t, MilliDegrees> fov_mdeg{{0, 360'000}, {-25'000, 15'000}};
+  static constexpr AnglePair<int32_t, MilliDegrees> peak_resolution_mdeg{200, 334};
 
   int get_packet_relative_point_time_offset(
     uint32_t block_id, uint32_t channel_id, const packet_t & packet) override

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_64.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_64.hpp
@@ -54,6 +54,8 @@ public:
   static constexpr float min_range = 0.3f;
   static constexpr float max_range = 200.f;
   static constexpr size_t max_scan_buffer_points = 230400;
+  static constexpr FieldOfView<int32_t> fov_mdeg{{0, 360'000}, {-25'000, 15'000}};
+  static constexpr AnglePair<int32_t> peak_resolution_mdeg{200, 167};
 
   int get_packet_relative_point_time_offset(
     uint32_t block_id, uint32_t channel_id, const packet_t & packet) override

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_64.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_64.hpp
@@ -54,8 +54,8 @@ public:
   static constexpr float min_range = 0.3f;
   static constexpr float max_range = 200.f;
   static constexpr size_t max_scan_buffer_points = 230400;
-  static constexpr FieldOfView<int32_t> fov_mdeg{{0, 360'000}, {-25'000, 15'000}};
-  static constexpr AnglePair<int32_t> peak_resolution_mdeg{200, 167};
+  static constexpr FieldOfView<int32_t, MilliDegrees> fov_mdeg{{0, 360'000}, {-25'000, 15'000}};
+  static constexpr AnglePair<int32_t, MilliDegrees> peak_resolution_mdeg{200, 167};
 
   int get_packet_relative_point_time_offset(
     uint32_t block_id, uint32_t channel_id, const packet_t & packet) override

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_at128.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_at128.hpp
@@ -80,6 +80,8 @@ public:
   static constexpr float min_range = 1.f;
   static constexpr float max_range = 180.0f;
   static constexpr size_t max_scan_buffer_points = 307200;
+  static constexpr FieldOfView<int32_t> fov_mdeg{{30'000, 150'000}, {-12'500, 12'900}};
+  static constexpr AnglePair<int32_t> peak_resolution_mdeg{100, 200};
 
   int get_packet_relative_point_time_offset(
     uint32_t block_id, uint32_t channel_id, const packet_t & packet) override

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_at128.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_at128.hpp
@@ -80,8 +80,9 @@ public:
   static constexpr float min_range = 1.f;
   static constexpr float max_range = 180.0f;
   static constexpr size_t max_scan_buffer_points = 307200;
-  static constexpr FieldOfView<int32_t> fov_mdeg{{30'000, 150'000}, {-12'500, 12'900}};
-  static constexpr AnglePair<int32_t> peak_resolution_mdeg{100, 200};
+  static constexpr FieldOfView<int32_t, MilliDegrees> fov_mdeg{
+    {30'000, 150'000}, {-12'500, 12'900}};
+  static constexpr AnglePair<int32_t, MilliDegrees> peak_resolution_mdeg{100, 200};
 
   int get_packet_relative_point_time_offset(
     uint32_t block_id, uint32_t channel_id, const packet_t & packet) override

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_qt128.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_qt128.hpp
@@ -93,6 +93,8 @@ public:
   static constexpr float min_range = 0.05;
   static constexpr float max_range = 50.0;
   static constexpr size_t max_scan_buffer_points = 172800;
+  static constexpr FieldOfView<int32_t> fov_mdeg{{0, 360'000}, {-52'630, 52'630}};
+  static constexpr AnglePair<int32_t> peak_resolution_mdeg{400, 100};
 
   int get_packet_relative_point_time_offset(
     uint32_t block_id, uint32_t channel_id, const packet_t & packet) override

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_qt128.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_qt128.hpp
@@ -93,8 +93,8 @@ public:
   static constexpr float min_range = 0.05;
   static constexpr float max_range = 50.0;
   static constexpr size_t max_scan_buffer_points = 172800;
-  static constexpr FieldOfView<int32_t> fov_mdeg{{0, 360'000}, {-52'630, 52'630}};
-  static constexpr AnglePair<int32_t> peak_resolution_mdeg{400, 100};
+  static constexpr FieldOfView<int32_t, MilliDegrees> fov_mdeg{{0, 360'000}, {-52'630, 52'630}};
+  static constexpr AnglePair<int32_t, MilliDegrees> peak_resolution_mdeg{400, 100};
 
   int get_packet_relative_point_time_offset(
     uint32_t block_id, uint32_t channel_id, const packet_t & packet) override

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_qt64.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_qt64.hpp
@@ -63,6 +63,8 @@ public:
   static constexpr float min_range = 0.1f;
   static constexpr float max_range = 60.f;
   static constexpr size_t max_scan_buffer_points = 76800;
+  static constexpr FieldOfView<int32_t> fov_mdeg{{0, 360'000}, {-52'100, 52'100}};
+  static constexpr AnglePair<int32_t> peak_resolution_mdeg{600, 1'450};
 
   int get_packet_relative_point_time_offset(
     uint32_t block_id, uint32_t channel_id, const packet_t & packet) override

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_qt64.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_qt64.hpp
@@ -63,8 +63,8 @@ public:
   static constexpr float min_range = 0.1f;
   static constexpr float max_range = 60.f;
   static constexpr size_t max_scan_buffer_points = 76800;
-  static constexpr FieldOfView<int32_t> fov_mdeg{{0, 360'000}, {-52'100, 52'100}};
-  static constexpr AnglePair<int32_t> peak_resolution_mdeg{600, 1'450};
+  static constexpr FieldOfView<int32_t, MilliDegrees> fov_mdeg{{0, 360'000}, {-52'100, 52'100}};
+  static constexpr AnglePair<int32_t, MilliDegrees> peak_resolution_mdeg{600, 1'450};
 
   int get_packet_relative_point_time_offset(
     uint32_t block_id, uint32_t channel_id, const packet_t & packet) override

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_xt16.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_xt16.hpp
@@ -49,6 +49,8 @@ public:
   static constexpr float min_range = 0.05f;
   static constexpr float max_range = 120.0f;
   static constexpr size_t max_scan_buffer_points = 128000;
+  static constexpr FieldOfView<int32_t, MilliDegrees> fov_mdeg{{0, 360'000}, {-15'000, 15'000}};
+  static constexpr AnglePair<int32_t, MilliDegrees> peak_resolution_mdeg{180, 1'000};
 
   int get_packet_relative_point_time_offset(
     uint32_t block_id, uint32_t channel_id, const packet_t & packet) override

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_xt32.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_xt32.hpp
@@ -56,6 +56,8 @@ public:
   static constexpr float min_range = 0.05f;
   static constexpr float max_range = 120.0f;
   static constexpr size_t max_scan_buffer_points = 256000;
+  static constexpr FieldOfView<int32_t> fov_mdeg{{0, 360'000}, {-16'000, 15'000}};
+  static constexpr AnglePair<int32_t> peak_resolution_mdeg{180, 1'000};
 
   int get_packet_relative_point_time_offset(
     uint32_t block_id, uint32_t channel_id, const packet_t & packet) override

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_xt32.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_xt32.hpp
@@ -56,8 +56,8 @@ public:
   static constexpr float min_range = 0.05f;
   static constexpr float max_range = 120.0f;
   static constexpr size_t max_scan_buffer_points = 256000;
-  static constexpr FieldOfView<int32_t> fov_mdeg{{0, 360'000}, {-16'000, 15'000}};
-  static constexpr AnglePair<int32_t> peak_resolution_mdeg{180, 1'000};
+  static constexpr FieldOfView<int32_t, MilliDegrees> fov_mdeg{{0, 360'000}, {-16'000, 15'000}};
+  static constexpr AnglePair<int32_t, MilliDegrees> peak_resolution_mdeg{180, 1'000};
 
   int get_packet_relative_point_time_offset(
     uint32_t block_id, uint32_t channel_id, const packet_t & packet) override

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_xt32m.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_xt32m.hpp
@@ -46,6 +46,8 @@ public:
   static constexpr float min_range = 0.5f;
   static constexpr float max_range = 300.0f;
   static constexpr size_t max_scan_buffer_points = 384000;
+  static constexpr FieldOfView<int32_t> fov_mdeg{{0, 360'000}, {-20'800, 19'500}};
+  static constexpr AnglePair<int32_t> peak_resolution_mdeg{180, 1'300};
 
   int get_packet_relative_point_time_offset(
     uint32_t block_id, uint32_t channel_id, const packet_t & packet) override

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_xt32m.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/pandar_xt32m.hpp
@@ -46,8 +46,8 @@ public:
   static constexpr float min_range = 0.5f;
   static constexpr float max_range = 300.0f;
   static constexpr size_t max_scan_buffer_points = 384000;
-  static constexpr FieldOfView<int32_t> fov_mdeg{{0, 360'000}, {-20'800, 19'500}};
-  static constexpr AnglePair<int32_t> peak_resolution_mdeg{180, 1'300};
+  static constexpr FieldOfView<int32_t, MilliDegrees> fov_mdeg{{0, 360'000}, {-20'800, 19'500}};
+  static constexpr AnglePair<int32_t, MilliDegrees> peak_resolution_mdeg{180, 1'300};
 
   int get_packet_relative_point_time_offset(
     uint32_t block_id, uint32_t channel_id, const packet_t & packet) override

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/hesai_driver.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/hesai_driver.hpp
@@ -20,6 +20,8 @@
 #include "nebula_common/point_types.hpp"
 #include "nebula_decoders/nebula_decoders_hesai/decoders/hesai_scan_decoder.hpp"
 
+#include <nebula_common/loggers/logger.hpp>
+
 #include <pcl_conversions/pcl_conversions.h>
 
 #include <memory>
@@ -34,6 +36,7 @@ class HesaiDriver
 private:
   /// @brief Current driver status
   Status driver_status_;
+  std::shared_ptr<loggers::Logger> logger_;
   /// @brief Decoder according to the model
   std::shared_ptr<HesaiScanDecoder> scan_decoder_;
 
@@ -52,7 +55,8 @@ public:
   explicit HesaiDriver(
     const std::shared_ptr<const drivers::HesaiSensorConfiguration> & sensor_configuration,
     const std::shared_ptr<const drivers::HesaiCalibrationConfigurationBase> &
-      calibration_configuration);
+      calibration_configuration,
+    const std::shared_ptr<loggers::Logger> & logger);
 
   /// @brief Get current status of this driver
   /// @return Current status

--- a/nebula_decoders/src/nebula_decoders_hesai/hesai_driver.cpp
+++ b/nebula_decoders/src/nebula_decoders_hesai/hesai_driver.cpp
@@ -18,13 +18,13 @@
 #include <tuple>
 #include <vector>
 
-// #define WITH_DEBUG_STD_COUT_HESAI_CLIENT // Use std::cout messages for debugging
-
 namespace nebula::drivers
 {
 HesaiDriver::HesaiDriver(
   const std::shared_ptr<const HesaiSensorConfiguration> & sensor_configuration,
-  const std::shared_ptr<const HesaiCalibrationConfigurationBase> & calibration_data)
+  const std::shared_ptr<const HesaiCalibrationConfigurationBase> & calibration_data,
+  const std::shared_ptr<loggers::Logger> & logger)
+: logger_(logger)
 {
   // initialize proper parser from cloud config's model and echo mode
   driver_status_ = nebula::Status::OK;
@@ -78,17 +78,17 @@ std::shared_ptr<HesaiScanDecoder> HesaiDriver::initialize_decoder(
 {
   using CalibT = typename SensorT::angle_corrector_t::correction_data_t;
   return std::make_shared<HesaiDecoder<SensorT>>(
-    sensor_configuration, std::dynamic_pointer_cast<const CalibT>(calibration_configuration));
+    sensor_configuration, std::dynamic_pointer_cast<const CalibT>(calibration_configuration),
+    logger_->child("Decoder"));
 }
 
 std::tuple<drivers::NebulaPointCloudPtr, double> HesaiDriver::parse_cloud_packet(
   const std::vector<uint8_t> & packet)
 {
   std::tuple<drivers::NebulaPointCloudPtr, double> pointcloud;
-  auto logger = rclcpp::get_logger("HesaiDriver");
 
   if (driver_status_ != nebula::Status::OK) {
-    RCLCPP_ERROR(logger, "Driver not OK.");
+    logger_->error("Driver not OK.");
     return pointcloud;
   }
 
@@ -96,13 +96,6 @@ std::tuple<drivers::NebulaPointCloudPtr, double> HesaiDriver::parse_cloud_packet
   if (scan_decoder_->has_scanned()) {
     pointcloud = scan_decoder_->get_pointcloud();
   }
-
-  // todo
-  // if (cnt == 0) {
-  //   RCLCPP_ERROR_STREAM(
-  //     logger, "Scanned " << pandar_scan->packets.size() << " packets, but no "
-  //                        << "pointclouds were generated. Last azimuth: " << last_azimuth);
-  // }
 
   return pointcloud;
 }

--- a/nebula_examples/CMakeLists.txt
+++ b/nebula_examples/CMakeLists.txt
@@ -31,6 +31,7 @@ include_directories(
 
 link_libraries(
     ${nebula_common_TARGETS}
+    ${nebula_ros_TARGETS}
     ${rosbag2_cpp_TARGETS}
     ${PCL_LIBRARIES}
 )

--- a/nebula_examples/src/hesai/hesai_ros_offline_extract_bag_pcd.cpp
+++ b/nebula_examples/src/hesai/hesai_ros_offline_extract_bag_pcd.cpp
@@ -14,15 +14,15 @@
 
 #include "hesai/hesai_ros_offline_extract_bag_pcd.hpp"
 
-#include "rclcpp/serialization.hpp"
-#include "rclcpp/serialized_message.hpp"
-#include "rcpputils/filesystem_helper.hpp"
-#include "rosbag2_cpp/reader.hpp"
-#include "rosbag2_cpp/readers/sequential_reader.hpp"
-#include "rosbag2_cpp/writers/sequential_writer.hpp"
-#include "rosbag2_storage/storage_options.hpp"
-
 #include <nebula_common/hesai/hesai_common.hpp>
+#include <nebula_ros/common/rclcpp_logger.hpp>
+#include <rclcpp/serialization.hpp>
+#include <rclcpp/serialized_message.hpp>
+#include <rcpputils/filesystem_helper.hpp>
+#include <rosbag2_cpp/reader.hpp>
+#include <rosbag2_cpp/readers/sequential_reader.hpp>
+#include <rosbag2_cpp/writers/sequential_writer.hpp>
+#include <rosbag2_storage/storage_options.hpp>
 
 #include <pcl_conversions/pcl_conversions.h>
 
@@ -76,7 +76,7 @@ Status HesaiRosOfflineExtractBag::initialize_driver(
 {
   driver_ptr_ = std::make_shared<drivers::HesaiDriver>(
     std::static_pointer_cast<drivers::HesaiSensorConfiguration>(sensor_configuration),
-    calibration_configuration);
+    calibration_configuration, std::make_shared<drivers::loggers::RclcppLogger>(get_logger()));
   return driver_ptr_->get_status();
 }
 

--- a/nebula_examples/src/hesai/hesai_ros_offline_extract_pcd.cpp
+++ b/nebula_examples/src/hesai/hesai_ros_offline_extract_pcd.cpp
@@ -14,14 +14,12 @@
 
 #include "hesai/hesai_ros_offline_extract_pcd.hpp"
 
-#include "rclcpp/serialization.hpp"
-#include "rclcpp/serialized_message.hpp"
-#include "rcpputils/filesystem_helper.hpp"
-#include "rosbag2_cpp/reader.hpp"
-#include "rosbag2_cpp/readers/sequential_reader.hpp"
-#include "rosbag2_storage/storage_options.hpp"
-
 #include <nebula_common/hesai/hesai_common.hpp>
+#include <nebula_ros/common/rclcpp_logger.hpp>
+#include <rclcpp/serialization.hpp>
+#include <rosbag2_cpp/converter_options.hpp>
+#include <rosbag2_cpp/reader.hpp>
+#include <rosbag2_storage/storage_options.hpp>
 
 #include <iostream>
 #include <memory>
@@ -74,7 +72,7 @@ Status HesaiRosOfflineExtractSample::initialize_driver(
   // driver should be initialized here with proper decoder
   driver_ptr_ = std::make_shared<drivers::HesaiDriver>(
     std::static_pointer_cast<drivers::HesaiSensorConfiguration>(sensor_configuration),
-    calibration_configuration);
+    calibration_configuration, std::make_shared<drivers::loggers::RclcppLogger>(get_logger()));
   return driver_ptr_->get_status();
 }
 

--- a/nebula_ros/schema/Pandar128E4X.schema.json
+++ b/nebula_ros/schema/Pandar128E4X.schema.json
@@ -107,6 +107,9 @@
         },
         "dual_return_distance_threshold": {
           "$ref": "sub/misc.json#/definitions/dual_return_distance_threshold"
+        },
+        "point_filters": {
+          "$ref": "sub/misc.json#/definitions/point_filters"
         }
       },
       "required": [

--- a/nebula_ros/schema/Pandar40P.schema.json
+++ b/nebula_ros/schema/Pandar40P.schema.json
@@ -98,6 +98,9 @@
         },
         "dual_return_distance_threshold": {
           "$ref": "sub/misc.json#/definitions/dual_return_distance_threshold"
+        },
+        "point_filters": {
+          "$ref": "sub/misc.json#/definitions/point_filters"
         }
       },
       "required": [

--- a/nebula_ros/schema/Pandar64.schema.json
+++ b/nebula_ros/schema/Pandar64.schema.json
@@ -98,6 +98,9 @@
         },
         "dual_return_distance_threshold": {
           "$ref": "sub/misc.json#/definitions/dual_return_distance_threshold"
+        },
+        "point_filters": {
+          "$ref": "sub/misc.json#/definitions/point_filters"
         }
       },
       "required": [

--- a/nebula_ros/schema/PandarAT128.schema.json
+++ b/nebula_ros/schema/PandarAT128.schema.json
@@ -118,6 +118,9 @@
         },
         "dual_return_distance_threshold": {
           "$ref": "sub/misc.json#/definitions/dual_return_distance_threshold"
+        },
+        "point_filters": {
+          "$ref": "sub/misc.json#/definitions/point_filters"
         }
       },
       "required": [

--- a/nebula_ros/schema/PandarQT128.schema.json
+++ b/nebula_ros/schema/PandarQT128.schema.json
@@ -101,6 +101,9 @@
         },
         "dual_return_distance_threshold": {
           "$ref": "sub/misc.json#/definitions/dual_return_distance_threshold"
+        },
+        "point_filters": {
+          "$ref": "sub/misc.json#/definitions/point_filters"
         }
       },
       "required": [

--- a/nebula_ros/schema/PandarQT64.schema.json
+++ b/nebula_ros/schema/PandarQT64.schema.json
@@ -98,6 +98,9 @@
         },
         "dual_return_distance_threshold": {
           "$ref": "sub/misc.json#/definitions/dual_return_distance_threshold"
+        },
+        "point_filters": {
+          "$ref": "sub/misc.json#/definitions/point_filters"
         }
       },
       "required": [

--- a/nebula_ros/schema/PandarXT32.schema.json
+++ b/nebula_ros/schema/PandarXT32.schema.json
@@ -101,6 +101,9 @@
         },
         "dual_return_distance_threshold": {
           "$ref": "sub/misc.json#/definitions/dual_return_distance_threshold"
+        },
+        "point_filters": {
+          "$ref": "sub/misc.json#/definitions/point_filters"
         }
       },
       "required": [

--- a/nebula_ros/schema/PandarXT32M.schema.json
+++ b/nebula_ros/schema/PandarXT32M.schema.json
@@ -101,6 +101,9 @@
         },
         "dual_return_distance_threshold": {
           "$ref": "sub/misc.json#/definitions/dual_return_distance_threshold"
+        },
+        "point_filters": {
+          "$ref": "sub/misc.json#/definitions/point_filters"
         }
       },
       "required": [

--- a/nebula_ros/schema/sub/misc.json
+++ b/nebula_ros/schema/sub/misc.json
@@ -96,6 +96,7 @@
           "properties": {
             "path": {
               "title": "Path to a grayscale PNG mask (0: filter all, 128: keep 50%, 255: keep all)",
+              "description": "See [Filters](/filters/) for more information.",
               "type": "string",
               "default": "\"\""
             }

--- a/nebula_ros/src/hesai/decoder_wrapper.cpp
+++ b/nebula_ros/src/hesai/decoder_wrapper.cpp
@@ -2,6 +2,8 @@
 
 #include "nebula_ros/hesai/decoder_wrapper.hpp"
 
+#include "nebula_ros/common/rclcpp_logger.hpp"
+
 #include <nebula_common/hesai/hesai_common.hpp>
 #include <nebula_common/util/string_conversions.hpp>
 #include <rclcpp/logging.hpp>
@@ -42,7 +44,8 @@ HesaiDecoderWrapper::HesaiDecoderWrapper(
 
   RCLCPP_INFO(logger_, "Starting Decoder");
 
-  driver_ptr_ = std::make_shared<drivers::HesaiDriver>(config, calibration_cfg_ptr_);
+  driver_ptr_ = std::make_shared<drivers::HesaiDriver>(
+    config, calibration_cfg_ptr_, std::make_shared<drivers::loggers::RclcppLogger>(logger_));
   status_ = driver_ptr_->get_status();
 
   if (Status::OK != status_) {
@@ -81,7 +84,8 @@ void HesaiDecoderWrapper::on_config_change(
   const std::shared_ptr<const nebula::drivers::HesaiSensorConfiguration> & new_config)
 {
   std::lock_guard lock(mtx_driver_ptr_);
-  auto new_driver = std::make_shared<drivers::HesaiDriver>(new_config, calibration_cfg_ptr_);
+  auto new_driver = std::make_shared<drivers::HesaiDriver>(
+    new_config, calibration_cfg_ptr_, std::make_shared<drivers::loggers::RclcppLogger>(logger_));
   driver_ptr_ = new_driver;
   sensor_cfg_ = new_config;
 }
@@ -90,7 +94,8 @@ void HesaiDecoderWrapper::on_calibration_change(
   const std::shared_ptr<const nebula::drivers::HesaiCalibrationConfigurationBase> & new_calibration)
 {
   std::lock_guard lock(mtx_driver_ptr_);
-  auto new_driver = std::make_shared<drivers::HesaiDriver>(sensor_cfg_, new_calibration);
+  auto new_driver = std::make_shared<drivers::HesaiDriver>(
+    sensor_cfg_, new_calibration, std::make_shared<drivers::loggers::RclcppLogger>(logger_));
   driver_ptr_ = new_driver;
   calibration_cfg_ptr_ = new_calibration;
 }

--- a/nebula_tests/CMakeLists.txt
+++ b/nebula_tests/CMakeLists.txt
@@ -24,6 +24,7 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 find_package(nebula_common REQUIRED)
 find_package(nebula_decoders REQUIRED)
+find_package(nebula_ros REQUIRED)
 find_package(PCL REQUIRED COMPONENTS common)
 find_package(rosbag2_cpp REQUIRED)
 find_package(diagnostic_updater REQUIRED)
@@ -42,6 +43,7 @@ if(BUILD_TESTING)
     set(NEBULA_TEST_INCLUDE_DIRS
         ${nebula_common_INCLUDE_DIRS}
         ${nebula_decoders_INCLUDE_DIRS}
+        ${nebula_ros_INCLUDE_DIRS}
         ${PCL_INCLUDE_DIRS}
         ${rosbag2_cpp_INCLUDE_DIRS}
         ${diagnostic_updater_INCLUDE_DIRS}
@@ -49,6 +51,7 @@ if(BUILD_TESTING)
 
     set(NEBULA_TEST_LIBRARIES
         ${nebula_common_TARGETS}
+        ${nebula_ros_TARGETS}
         ${PCL_LIBRARIES}
         ${rosbag2_cpp_TARGETS}
         ${diagnostic_updater_TARGETS}

--- a/nebula_tests/hesai/hesai_ros_decoder_test.cpp
+++ b/nebula_tests/hesai/hesai_ros_decoder_test.cpp
@@ -2,9 +2,9 @@
 
 #include "hesai_ros_decoder_test.hpp"
 
-#include "nebula_common/hesai/hesai_common.hpp"
-#include "nebula_common/nebula_common.hpp"
-
+#include <nebula_common/hesai/hesai_common.hpp>
+#include <nebula_common/nebula_common.hpp>
+#include <nebula_ros/common/rclcpp_logger.hpp>
 #include <rclcpp/serialization.hpp>
 #include <rclcpp/serialized_message.hpp>
 #include <rcpputils/filesystem_helper.hpp>
@@ -68,7 +68,7 @@ Status HesaiRosDecoderTest::InitializeDriver(
 {
   driver_ptr_ = std::make_shared<drivers::HesaiDriver>(
     std::static_pointer_cast<drivers::HesaiSensorConfiguration>(sensor_configuration),
-    calibration_configuration);
+    calibration_configuration, std::make_shared<drivers::loggers::RclcppLogger>(get_logger()));
   return driver_ptr_->get_status();
 }
 


### PR DESCRIPTION
## PR Type

- New Feature

## Related Links

- #250 -- based on this PR

## Description

This PR implements the mask-based pruning filter introduced in #250 for all Hesai sensors. For more specifics on sensor configuration changes and filter behavior, see #250.

## Review Procedure

* Test whether pointcloud output is as expected when not specifying a filter
* Try and create a downsample mask, e.g. in GIMP, and see if it works expected

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
