### PR TITLE
feat(ars548): disable object output for corner radars

### DIFF
--- a/nebula_common/include/nebula_common/continental/continental_ars548.hpp
+++ b/nebula_common/include/nebula_common/continental/continental_ars548.hpp
@@ -32,6 +32,11 @@ namespace drivers
 namespace continental_ars548
 {
 
+inline bool is_corner_radar(float yaw)
+{
+  return std::abs(yaw) > deg2rad(5.0) && std::abs(yaw) < deg2rad(90.0);
+}
+
 /// @brief struct for ARS548 sensor configuration
 struct ContinentalARS548SensorConfiguration : EthernetSensorConfigurationBase
 {

--- a/nebula_decoders/src/nebula_decoders_continental/decoders/continental_ars548_decoder.cpp
+++ b/nebula_decoders/src/nebula_decoders_continental/decoders/continental_ars548_decoder.cpp
@@ -345,6 +345,7 @@ bool ContinentalARS548Decoder::parse_objects_list_packet(
     object_msg.orientation = object.position_orientation.value();
     object_msg.orientation_std = object.position_orientation_std.value();
 
+    // cSpell:ignore knzo25
     // NOTE(knzo25): In the radar firmware used when developing this driver,
     // corner radars are not supported. We can partially address this,
     // but the coordinates look only spatially correct (not the dynamics).

--- a/nebula_decoders/src/nebula_decoders_continental/decoders/continental_ars548_decoder.cpp
+++ b/nebula_decoders/src/nebula_decoders_continental/decoders/continental_ars548_decoder.cpp
@@ -249,9 +249,7 @@ bool ContinentalARS548Decoder::parse_objects_list_packet(
   // NOTE(knzo25): In the radar firmware used when developing this driver,
   // corner radars were not supported. When a new firmware addresses this,
   // the driver will be updated.
-  if (
-    std::abs(radar_status_.yaw) > 5.0 * M_PI / 180.0 &&
-    std::abs(radar_status_.yaw) < 90.0 * M_PI / 180.0) {
+  if (nebula::drivers::continental_ars548::is_corner_radar(radar_status_.yaw)) {
     return true;
   }
 

--- a/nebula_decoders/src/nebula_decoders_continental/decoders/continental_ars548_decoder.cpp
+++ b/nebula_decoders/src/nebula_decoders_continental/decoders/continental_ars548_decoder.cpp
@@ -345,6 +345,20 @@ bool ContinentalARS548Decoder::parse_objects_list_packet(
     object_msg.orientation = object.position_orientation.value();
     object_msg.orientation_std = object.position_orientation_std.value();
 
+    if (
+      std::abs(radar_status_.yaw) > 5.0 * M_PI / 180.0 &&
+      std::abs(radar_status_.yaw) < 90.0 * M_PI / 180.0) {
+      const double dx = radar_status_.longitudinal + radar_status_.wheel_base;
+      const double dy = radar_status_.lateral;
+      double x = object_msg.position.x - dx;
+      double y = object_msg.position.y - dy;
+      const auto & yaw = radar_status_.yaw;
+
+      object_msg.position.x = x * std::cos(yaw) - y * std::sin(yaw) + dx;
+      object_msg.position.y = x * std::sin(yaw) + y * std::cos(yaw) + dy;
+      object_msg.orientation += yaw;
+    }
+
     object_msg.existence_probability = object.existence_probability.value();
     object_msg.classification_car = object.classification_car;
     object_msg.classification_truck = object.classification_truck;

--- a/nebula_decoders/src/nebula_decoders_continental/decoders/continental_ars548_decoder.cpp
+++ b/nebula_decoders/src/nebula_decoders_continental/decoders/continental_ars548_decoder.cpp
@@ -345,6 +345,12 @@ bool ContinentalARS548Decoder::parse_objects_list_packet(
     object_msg.orientation = object.position_orientation.value();
     object_msg.orientation_std = object.position_orientation_std.value();
 
+    // NOTE(knzo25): In the radar firmware used when developing this driver,
+    // corner radars are not supported. We can partially address this,
+    // but the coordinates look only spatially correct (not the dynamics).
+    // so its use is the responsibility of the user.
+    // Corner radars are expected to be supported in a new firmware version,
+    // but this is not yet confirmed.
     if (
       std::abs(radar_status_.yaw) > 5.0 * M_PI / 180.0 &&
       std::abs(radar_status_.yaw) < 90.0 * M_PI / 180.0) {

--- a/nebula_ros/src/continental/continental_ars548_decoder_wrapper.cpp
+++ b/nebula_ros/src/continental/continental_ars548_decoder_wrapper.cpp
@@ -206,26 +206,21 @@ void ContinentalARS548DecoderWrapper::sensor_status_callback(
 
   // cSpell:ignore knzo25
   // NOTE(knzo25): In the radar firmware used when developing this driver,
-  // corner radars are not supported. We can partially address this,
-  // but the coordinates look only spatially correct (not the dynamics).
-  // so its use is the responsibility of the user.
-  // Corner radars are expected to be supported in a new firmware version,
-  // but this is not yet confirmed.
+  // corner radars were not supported. When a new firmware addresses this,
+  // the driver will be updated.
   if (
     std::abs(sensor_status.yaw) > 5.0 * M_PI / 180.0 &&
     std::abs(sensor_status.yaw) < 90.0 * M_PI / 180.0) {
     rclcpp::Clock clock{RCL_ROS_TIME};
     RCLCPP_WARN_THROTTLE(
       logger_, clock, 5000,
-      "This radar has been configured as a corner radar, which is not supported by the sensor. We "
-      "can partially address this, but the coordinates look only spatially correct (not the "
-      "dynamics). so its use is the responsibility of the user. Corner radars are expected to be "
-      "supported in a new firmware version, but this is not yet confirmed.");
+      "This radar has been configured as a corner radar, which is not supported by the sensor. The "
+      "driver will not output any objects");
 
     status.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
     status.message +=
-      ". Unsupported mounting configuration (corner radar). This should only be used for "
-      "evaluation purposes.";
+      ". Unsupported mounting configuration (corner radar). Only detections should be used under "
+      "these conditions.";
   }
 
   auto add_diagnostic = [&status](const std::string & key, const std::string & value) {

--- a/nebula_ros/src/continental/continental_ars548_decoder_wrapper.cpp
+++ b/nebula_ros/src/continental/continental_ars548_decoder_wrapper.cpp
@@ -208,9 +208,7 @@ void ContinentalARS548DecoderWrapper::sensor_status_callback(
   // NOTE(knzo25): In the radar firmware used when developing this driver,
   // corner radars were not supported. When a new firmware addresses this,
   // the driver will be updated.
-  if (
-    std::abs(sensor_status.yaw) > 5.0 * M_PI / 180.0 &&
-    std::abs(sensor_status.yaw) < 90.0 * M_PI / 180.0) {
+  if (nebula::drivers::continental_ars548::is_corner_radar(sensor_status.yaw)) {
     rclcpp::Clock clock{RCL_ROS_TIME};
     RCLCPP_WARN_THROTTLE(
       logger_, clock, 5000,

--- a/nebula_ros/src/continental/continental_ars548_decoder_wrapper.cpp
+++ b/nebula_ros/src/continental/continental_ars548_decoder_wrapper.cpp
@@ -191,6 +191,23 @@ void ContinentalARS548DecoderWrapper::object_list_callback(
 void ContinentalARS548DecoderWrapper::sensor_status_callback(
   const drivers::continental_ars548::ContinentalARS548Status & sensor_status)
 {
+  // NOTE(knzo25): In the radar firmware used when developing this driver,
+  // corner radars are not supported. We can partially address this,
+  // but the coordinates look only spatially correct (not the dynamics).
+  // so its use is the responsibility of the user.
+  // Corner radars are expected to be supported in a new firmware version,
+  // but this is not yet confirmed.
+  if (
+    std::abs(radar_status_.yaw) > 5.0 * M_PI / 180.0 &&
+    std::abs(radar_status_.yaw) < 90.0 * M_PI / 180.0) {
+    RCLCPP_WARN_THROTTLE(
+      logger_, *rclcpp::Clock::now(), 5000,
+      "This radar has been configured as a corner radar, which is not supported by the sensor. We "
+      "can partially address this, but the coordinates look only spatially correct (not the "
+      "dynamics). so its use is the responsibility of the user. Corner radars are expected to be "
+      "supported in a new firmware version, but this is not yet confirmed.");
+  }
+
   diagnostic_msgs::msg::DiagnosticArray diagnostic_array_msg;
   diagnostic_array_msg.header.stamp.sec = sensor_status.timestamp_seconds;
   diagnostic_array_msg.header.stamp.nanosec = sensor_status.timestamp_nanoseconds;

--- a/nebula_ros/src/continental/continental_ars548_decoder_wrapper.cpp
+++ b/nebula_ros/src/continental/continental_ars548_decoder_wrapper.cpp
@@ -191,6 +191,19 @@ void ContinentalARS548DecoderWrapper::object_list_callback(
 void ContinentalARS548DecoderWrapper::sensor_status_callback(
   const drivers::continental_ars548::ContinentalARS548Status & sensor_status)
 {
+  diagnostic_msgs::msg::DiagnosticArray diagnostic_array_msg;
+  diagnostic_array_msg.header.stamp.sec = sensor_status.timestamp_seconds;
+  diagnostic_array_msg.header.stamp.nanosec = sensor_status.timestamp_nanoseconds;
+  diagnostic_array_msg.header.frame_id = config_ptr_->frame_id;
+
+  diagnostic_array_msg.status.resize(1);
+  auto & status = diagnostic_array_msg.status[0];
+  status.values.reserve(36);
+  status.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+  status.hardware_id = config_ptr_->frame_id;
+  status.name = config_ptr_->frame_id;
+  status.message = "Diagnostic messages from ARS548";
+
   // cSpell:ignore knzo25
   // NOTE(knzo25): In the radar firmware used when developing this driver,
   // corner radars are not supported. We can partially address this,
@@ -208,20 +221,12 @@ void ContinentalARS548DecoderWrapper::sensor_status_callback(
       "can partially address this, but the coordinates look only spatially correct (not the "
       "dynamics). so its use is the responsibility of the user. Corner radars are expected to be "
       "supported in a new firmware version, but this is not yet confirmed.");
+
+    status.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+    status.message +=
+      ". Unsupported mounting configuration (corner radar). This should only be used for "
+      "evaluation purposes.";
   }
-
-  diagnostic_msgs::msg::DiagnosticArray diagnostic_array_msg;
-  diagnostic_array_msg.header.stamp.sec = sensor_status.timestamp_seconds;
-  diagnostic_array_msg.header.stamp.nanosec = sensor_status.timestamp_nanoseconds;
-  diagnostic_array_msg.header.frame_id = config_ptr_->frame_id;
-
-  diagnostic_array_msg.status.resize(1);
-  auto & status = diagnostic_array_msg.status[0];
-  status.values.reserve(36);
-  status.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
-  status.hardware_id = config_ptr_->frame_id;
-  status.name = config_ptr_->frame_id;
-  status.message = "Diagnostic messages from ARS548";
 
   auto add_diagnostic = [&status](const std::string & key, const std::string & value) {
     diagnostic_msgs::msg::KeyValue key_value;

--- a/nebula_ros/src/continental/continental_ars548_decoder_wrapper.cpp
+++ b/nebula_ros/src/continental/continental_ars548_decoder_wrapper.cpp
@@ -191,6 +191,7 @@ void ContinentalARS548DecoderWrapper::object_list_callback(
 void ContinentalARS548DecoderWrapper::sensor_status_callback(
   const drivers::continental_ars548::ContinentalARS548Status & sensor_status)
 {
+  // cSpell:ignore knzo25
   // NOTE(knzo25): In the radar firmware used when developing this driver,
   // corner radars are not supported. We can partially address this,
   // but the coordinates look only spatially correct (not the dynamics).
@@ -198,10 +199,11 @@ void ContinentalARS548DecoderWrapper::sensor_status_callback(
   // Corner radars are expected to be supported in a new firmware version,
   // but this is not yet confirmed.
   if (
-    std::abs(radar_status_.yaw) > 5.0 * M_PI / 180.0 &&
-    std::abs(radar_status_.yaw) < 90.0 * M_PI / 180.0) {
+    std::abs(sensor_status.yaw) > 5.0 * M_PI / 180.0 &&
+    std::abs(sensor_status.yaw) < 90.0 * M_PI / 180.0) {
+    rclcpp::Clock clock{RCL_ROS_TIME};
     RCLCPP_WARN_THROTTLE(
-      logger_, *rclcpp::Clock::now(), 5000,
+      logger_, clock, 5000,
       "This radar has been configured as a corner radar, which is not supported by the sensor. We "
       "can partially address this, but the coordinates look only spatially correct (not the "
       "dynamics). so its use is the responsibility of the user. Corner radars are expected to be "

--- a/nebula_ros/src/continental/continental_ars548_hw_interface_wrapper.cpp
+++ b/nebula_ros/src/continental/continental_ars548_hw_interface_wrapper.cpp
@@ -215,6 +215,23 @@ void ContinentalARS548HwInterfaceWrapper::set_sensor_mounting_request_callback(
     pitch = rpy.y;
   }
 
+  // NOTE(knzo25): In the radar firmware used when developing this driver,
+  // corner radars are not supported. We can partially address this,
+  // but the coordinates look only spatially correct (not the dynamics).
+  // so its use is the responsibility of the user.
+  // Corner radars are expected to be supported in a new firmware version,
+  // but this is not yet confirmed.
+  if (
+    std::abs(radar_status_.yaw) > 5.0 * M_PI / 180.0 &&
+    std::abs(radar_status_.yaw) < 90.0 * M_PI / 180.0) {
+    RCLCPP_WARN(
+      logger_, *rclcpp::Clock::now(), 5000,
+      "This radar has been configured as a corner radar, which is not supported by the sensor. We "
+      "can partially address this, but the coordinates look only spatially correct (not the "
+      "dynamics). so its use is the responsibility of the user. Corner radars are expected to be "
+      "supported in a new firmware version, but this is not yet confirmed.");
+  }
+
   auto result = hw_interface_->set_sensor_mounting(
     longitudinal, lateral, vertical, yaw, pitch, request->plug_orientation);
 

--- a/nebula_ros/src/continental/continental_ars548_hw_interface_wrapper.cpp
+++ b/nebula_ros/src/continental/continental_ars548_hw_interface_wrapper.cpp
@@ -217,18 +217,13 @@ void ContinentalARS548HwInterfaceWrapper::set_sensor_mounting_request_callback(
 
   // cSpell:ignore knzo25
   // NOTE(knzo25): In the radar firmware used when developing this driver,
-  // corner radars are not supported. We can partially address this,
-  // but the coordinates look only spatially correct (not the dynamics).
-  // so its use is the responsibility of the user.
-  // Corner radars are expected to be supported in a new firmware version,
-  // but this is not yet confirmed.
+  // corner radars were not supported. When a new firmware addresses this,
+  // the driver will be updated.
   if (std::abs(yaw) > 5.0 * M_PI / 180.0 && std::abs(yaw) < 90.0 * M_PI / 180.0) {
     RCLCPP_WARN(
       logger_,
-      "This radar has been configured as a corner radar, which is not supported by the sensor. We "
-      "can partially address this, but the coordinates look only spatially correct (not the "
-      "dynamics). so its use is the responsibility of the user. Corner radars are expected to be "
-      "supported in a new firmware version, but this is not yet confirmed.");
+      "You are attempting to configure the device as a corner radar, which is not supported so "
+      "far.");
   }
 
   auto result = hw_interface_->set_sensor_mounting(

--- a/nebula_ros/src/continental/continental_ars548_hw_interface_wrapper.cpp
+++ b/nebula_ros/src/continental/continental_ars548_hw_interface_wrapper.cpp
@@ -215,17 +215,16 @@ void ContinentalARS548HwInterfaceWrapper::set_sensor_mounting_request_callback(
     pitch = rpy.y;
   }
 
+  // cSpell:ignore knzo25
   // NOTE(knzo25): In the radar firmware used when developing this driver,
   // corner radars are not supported. We can partially address this,
   // but the coordinates look only spatially correct (not the dynamics).
   // so its use is the responsibility of the user.
   // Corner radars are expected to be supported in a new firmware version,
   // but this is not yet confirmed.
-  if (
-    std::abs(radar_status_.yaw) > 5.0 * M_PI / 180.0 &&
-    std::abs(radar_status_.yaw) < 90.0 * M_PI / 180.0) {
+  if (std::abs(yaw) > 5.0 * M_PI / 180.0 && std::abs(yaw) < 90.0 * M_PI / 180.0) {
     RCLCPP_WARN(
-      logger_, *rclcpp::Clock::now(), 5000,
+      logger_,
       "This radar has been configured as a corner radar, which is not supported by the sensor. We "
       "can partially address this, but the coordinates look only spatially correct (not the "
       "dynamics). so its use is the responsibility of the user. Corner radars are expected to be "

--- a/nebula_ros/src/continental/continental_ars548_hw_interface_wrapper.cpp
+++ b/nebula_ros/src/continental/continental_ars548_hw_interface_wrapper.cpp
@@ -219,7 +219,7 @@ void ContinentalARS548HwInterfaceWrapper::set_sensor_mounting_request_callback(
   // NOTE(knzo25): In the radar firmware used when developing this driver,
   // corner radars were not supported. When a new firmware addresses this,
   // the driver will be updated.
-  if (std::abs(yaw) > 5.0 * M_PI / 180.0 && std::abs(yaw) < 90.0 * M_PI / 180.0) {
+  if (nebula::drivers::continental_ars548::is_corner_radar(yaw)) {
     RCLCPP_WARN(
       logger_,
       "You are attempting to configure the device as a corner radar, which is not supported so "


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Bug Fix

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description

We were publishing objects for corner radars, which is not a supported feature (from the sensor).
This PR disables them and provides warnings when users attempt to use corner radars
<!-- Describe what this PR changes. -->

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
