### PR TITLE
chore(build_depends): update the forks of Nebula's dependencies to the Autoware Foundation ones

### DIFF
--- a/build_depends.repos
+++ b/build_depends.repos
@@ -2,10 +2,10 @@ repositories:
   # TCP version of transport drivers
   transport_drivers:
     type: git
-    url: https://github.com/mojomex/transport_drivers
-    version: feat-set-rmem
+    url: https://github.com/autowarefoundation/transport_drivers
+    version: main
   # Continental compatible version of ROS 2 socket CAN
   ros2_socketcan:
     type: git
-    url: https://github.com/knzo25/ros2_socketcan
-    version: feat/continental_fd
+    url: https://github.com/autowarefoundation/ros2_socketcan
+    version: main


### PR DESCRIPTION
## PR Type

- Improvement

## Related Links

- [autoware.repos](https://github.com/autowarefoundation/autoware/blob/9c95a422999736f7c8594b3488a1b116c0d565ff/autoware.repos#L97-L105) -- the repositories used by Autoware

## Description

The personal forks of `transport_drivers` and `ros2_socketcan` were temporary measures, and the Autoware Foundation is now maintaining those forks.
This PR reflects this change in the `.repos` file.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
