### PR TITLE
chore(pre-commit): fix pre-commit error when prettier has no files to process

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,7 @@ repos:
     rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
+        args: [--no-error-on-unmatched-pattern]
 
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.35.1


### PR DESCRIPTION
## PR Type

- Improvement

## Related Links

- #174 -- upgraded to a new version of prettier, which complains when there are no files to process

## Description

Add the `--no-error-on-unmatched-pattern` option to prettier so an empty file list will not cause pre-commit to fail.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
