### PR TITLE
fix(xt16): update default parameters and schema to comply with #239, #256

### DIFF
--- a/nebula_ros/config/lidar/hesai/PandarXT16.param.yaml
+++ b/nebula_ros/config/lidar/hesai/PandarXT16.param.yaml
@@ -1,6 +1,6 @@
 /**:
   ros__parameters:
-    host_ip: 255.255.255.255
+    host_ip: 192.168.1.10
     sensor_ip: 192.168.1.201
     multicast_ip: ""
     data_port: 2368
@@ -25,5 +25,6 @@
     ptp_domain: 0
     ptp_transport_type: UDP
     ptp_switch_type: TSN
+    ptp_lock_threshold: 100
     retry_hw: true
     dual_return_distance_threshold: 0.1

--- a/nebula_ros/schema/PandarXT16.schema.json
+++ b/nebula_ros/schema/PandarXT16.schema.json
@@ -93,6 +93,9 @@
         "ptp_switch_type": {
           "$ref": "sub/lidar_hesai.json#/definitions/ptp_switch_type"
         },
+        "ptp_lock_threshold": {
+          "$ref": "sub/lidar_hesai.json#/definitions/ptp_lock_threshold"
+        },
         "retry_hw": {
           "$ref": "sub/hardware.json#/definitions/retry_hw"
         },
@@ -124,6 +127,7 @@
         "ptp_domain",
         "ptp_transport_type",
         "ptp_switch_type",
+        "ptp_lock_threshold",
         "retry_hw",
         "dual_return_distance_threshold"
       ],


### PR DESCRIPTION
## PR Type

- Bug Fix

## Related Links

- #239 -- introduced a new parameter that was not yet defined for XT16
- #256 -- replaced the now-disallowed broadcast IP with an example host IP address

## Description

Update parameter file and schema of XT16 to match the newest changes already merged for ther sensors.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
