### PR TITLE
test(nebula_ros): fix flaky smoke test

### DIFF
--- a/nebula_ros/test/smoke_test.py
+++ b/nebula_ros/test/smoke_test.py
@@ -1,4 +1,3 @@
-import time
 import unittest
 
 from launch import LaunchContext
@@ -11,7 +10,6 @@ import launch_testing
 import launch_testing.actions
 import launch_testing.asserts
 import pytest
-import rclpy
 
 
 def resolve_launch_file(context: LaunchContext, *args, **kwargs):
@@ -29,25 +27,17 @@ def resolve_launch_file(context: LaunchContext, *args, **kwargs):
 @pytest.mark.launch_test
 def generate_test_description():
     return LaunchDescription(
-        [OpaqueFunction(function=resolve_launch_file), launch_testing.actions.ReadyToTest()]
+        [
+            OpaqueFunction(function=resolve_launch_file),
+            launch_testing.actions.ReadyToTest(),
+        ]
     )
 
 
-class DummyTest(unittest.TestCase):
-    def test_wait_for_node_ready(self):
-        """Waiting for the node coming online."""
-        rclpy.init()
-        test_node = rclpy.create_node("test_node")
-        # Wait until both dummy node "test_node" and real tested node are registered and then kill
-        # both of them, if tested node does not register within `timeout` seconds test will fail
-        start_time = time.time()
-        timeout = 2  # seconds
-        timeout_msg = "Smoke test timeout has been exceeded ({}s)".format(timeout)
-        print("waiting for nodes to be ready")
-        while len(test_node.get_node_names()) < 2:
-            assert time.time() - start_time < timeout, timeout_msg
-            time.sleep(0.1)
-        rclpy.shutdown()
+class TestCorrectStartup(unittest.TestCase):
+    def test_wait_for_startup_then_shutdown(self):
+        self.proc_output: launch_testing.ActiveIoHandler
+        self.proc_output.assertWaitFor("Wrapper=OK", timeout=2)
 
 
 @launch_testing.post_shutdown_test()


### PR DESCRIPTION
## PR Type

- Improvement

## Related Links

- #240 -- these turn out to be flaky in CI

## Description

#240 is flaky in CI but not on my local machine (works on my machine :clown_face:). This leads me to believe that it's a timing issue - Nebula might still be in its startup phase when it's interrupted by the test framework, resulting in a non-zero exit code.

This PR makes the test suite wait for the `Wrapper=OK` output before interrupting Nebula.

## Review Procedure

Hope and pray.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
