### PR TITLE
feat(velodyne): Enable dynamic reconfigure of launch_hw parameter

### DIFF
--- a/nebula_ros/CMakeLists.txt
+++ b/nebula_ros/CMakeLists.txt
@@ -3,7 +3,7 @@ project(nebula_ros)
 
 # Default to C++17
 if (NOT CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_CXX_STANDARD 20)
 endif ()
 
 if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/nebula_ros/include/nebula_ros/common/mt_queue.hpp
+++ b/nebula_ros/include/nebula_ros/common/mt_queue.hpp
@@ -46,7 +46,7 @@ public:
   void push(T && value)
   {
     std::unique_lock<std::mutex> lock(this->mutex_);
-    this->cv_not_full_.wait(lock, [=] { return this->queue_.size() < this->capacity_; });
+    this->cv_not_full_.wait(lock, [this] { return this->queue_.size() < this->capacity_; });
     queue_.push_front(std::move(value));
     this->cv_not_empty_.notify_all();
   }
@@ -54,7 +54,7 @@ public:
   T pop()
   {
     std::unique_lock<std::mutex> lock(this->mutex_);
-    this->cv_not_empty_.wait(lock, [=] { return !this->queue_.empty(); });
+    this->cv_not_empty_.wait(lock, [this] { return !this->queue_.empty(); });
     T return_value(std::move(this->queue_.back()));
     this->queue_.pop_back();
     this->cv_not_full_.notify_all();

--- a/nebula_ros/include/nebula_ros/velodyne/velodyne_ros_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/velodyne/velodyne_ros_wrapper.hpp
@@ -69,6 +69,22 @@ private:
 
   Status declare_and_get_sensor_config_params();
 
+  void reconfigure_hw_interface();
+
+  void create_packet_subscriber();
+  void reset_packet_subscriber();
+
+  // HW interface management
+  void bringup_hw(bool);
+  void cleanup_on_hw_reconfigure();
+  void setup_on_hw_reconfigure();
+
+  // Decoder thread management
+  void configure_decoder_wrapper_thread();
+  void start_decoder_thread();
+  void stop_decoder_thread();
+  void exit_decoder_thread();
+
   /// @brief rclcpp parameter callback
   /// @param parameters Received parameters
   /// @return SetParametersResult
@@ -90,10 +106,19 @@ private:
   rclcpp::Subscription<velodyne_msgs::msg::VelodyneScan>::SharedPtr packets_sub_{};
 
   bool launch_hw_;
+  bool use_udp_only_;
+
+  std::mutex decoder_thread_mutex_;
+  std::condition_variable decoder_thread_cv_;
+  bool decoder_thread_running_ = false;
+  bool exit_decoder_thread_ = false;
+  bool restart_hw_ = false;
+  bool restart_packet_subscriber_ = false;
 
   std::optional<VelodyneHwInterfaceWrapper> hw_interface_wrapper_;
   std::optional<VelodyneHwMonitorWrapper> hw_monitor_wrapper_;
   std::optional<VelodyneDecoderWrapper> decoder_wrapper_;
+  rclcpp::TimerBase::SharedPtr hw_reconfigure_timer_;
 
   std::mutex mtx_config_;
 

--- a/nebula_ros/include/nebula_ros/velodyne/velodyne_ros_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/velodyne/velodyne_ros_wrapper.hpp
@@ -80,10 +80,9 @@ private:
   void setup_on_hw_reconfigure();
 
   // Decoder thread management
-  void configure_decoder_wrapper_thread();
-  void start_decoder_thread();
-  void stop_decoder_thread();
-  void exit_decoder_thread();
+  void decoder_wrapper_thread(std::stop_token stoken);
+  void set_decoder_wrapper();
+  void stop_decoder_thread() { decoder_thread_.request_stop(); }
 
   /// @brief rclcpp parameter callback
   /// @param parameters Received parameters
@@ -101,17 +100,13 @@ private:
   /// @brief Stores received packets that have not been processed yet by the decoder thread
   MtQueue<std::unique_ptr<nebula_msgs::msg::NebulaPacket>> packet_queue_;
   /// @brief Thread to isolate decoding from receiving
-  std::thread decoder_thread_;
+  std::jthread decoder_thread_;
 
   rclcpp::Subscription<velodyne_msgs::msg::VelodyneScan>::SharedPtr packets_sub_{};
 
   bool launch_hw_;
   bool use_udp_only_;
 
-  std::mutex decoder_thread_mutex_;
-  std::condition_variable decoder_thread_cv_;
-  bool decoder_thread_running_ = false;
-  bool exit_decoder_thread_ = false;
   bool restart_hw_ = false;
   bool restart_packet_subscriber_ = false;
 

--- a/nebula_ros/src/velodyne/decoder_wrapper.cpp
+++ b/nebula_ros/src/velodyne/decoder_wrapper.cpp
@@ -31,8 +31,12 @@ VelodyneDecoderWrapper::VelodyneDecoderWrapper(
       "VelodyneDecoderWrapper cannot be instantiated without a valid config!");
   }
 
-  calibration_file_path_ =
-    parent_node->declare_parameter<std::string>("calibration_file", param_read_write());
+  if (parent_node->has_parameter("calibration_file")) {
+    calibration_file_path_ = parent_node->get_parameter("calibration_file").as_string();
+  } else {
+    calibration_file_path_ =
+      parent_node->declare_parameter<std::string>("calibration_file", param_read_write());
+  }
   auto calibration_result = get_calibration_data(calibration_file_path_);
 
   if (!calibration_result.has_value()) {

--- a/nebula_ros/src/velodyne/hw_interface_wrapper.cpp
+++ b/nebula_ros/src/velodyne/hw_interface_wrapper.cpp
@@ -17,8 +17,11 @@ VelodyneHwInterfaceWrapper::VelodyneHwInterfaceWrapper(
   status_(Status::NOT_INITIALIZED),
   use_udp_only_(use_udp_only)
 {
-  setup_sensor_ = parent_node->declare_parameter<bool>("setup_sensor", param_read_only());
-
+  if (parent_node->has_parameter("setup_sensor")) {
+    setup_sensor_ = parent_node->get_parameter("setup_sensor").as_bool();
+  } else {
+    setup_sensor_ = parent_node->declare_parameter<bool>("setup_sensor", param_read_only());
+  }
   hw_interface_->set_logger(
     std::make_shared<rclcpp::Logger>(parent_node->get_logger().get_child("HwInterface")));
   status_ = hw_interface_->initialize_sensor_configuration(config);

--- a/nebula_ros/src/velodyne/hw_monitor_wrapper.cpp
+++ b/nebula_ros/src/velodyne/hw_monitor_wrapper.cpp
@@ -23,9 +23,17 @@ VelodyneHwMonitorWrapper::VelodyneHwMonitorWrapper(
   parent_node_(parent_node),
   sensor_configuration_(config)
 {
-  diag_span_ = parent_node->declare_parameter<uint16_t>("diag_span", param_read_only());
-  show_advanced_diagnostics_ =
-    parent_node->declare_parameter<bool>("advanced_diagnostics", param_read_only());
+  if (parent_node->has_parameter("diag_span")) {
+    diag_span_ = parent_node->get_parameter("diag_span").as_int();
+  } else {
+    diag_span_ = parent_node->declare_parameter<uint16_t>("diag_span", param_read_only());
+  }
+  if (parent_node->has_parameter("advanced_diagnostics")) {
+    show_advanced_diagnostics_ = parent_node->get_parameter("advanced_diagnostics").as_bool();
+  } else {
+    show_advanced_diagnostics_ =
+      parent_node->declare_parameter<bool>("advanced_diagnostics", param_read_only());
+  }
 
   std::cout << "Get model name and serial." << std::endl;
   auto str = hw_interface_->get_snapshot();

--- a/nebula_ros/src/velodyne/velodyne_ros_wrapper.cpp
+++ b/nebula_ros/src/velodyne/velodyne_ros_wrapper.cpp
@@ -66,12 +66,14 @@ void VelodyneRosWrapper::reconfigure_hw_interface()
     bringup_hw(use_udp_only_);
     setup_on_hw_reconfigure();
     restart_hw_ = false;
+    hw_reconfigure_timer_->cancel();
   }
 
   if (restart_packet_subscriber_) {
     create_packet_subscriber();
     setup_on_hw_reconfigure();
     restart_packet_subscriber_ = false;
+    hw_reconfigure_timer_->cancel();
   }
 }
 
@@ -313,6 +315,7 @@ rcl_interfaces::msg::SetParametersResult VelodyneRosWrapper::on_parameter_change
     reset_packet_subscriber();
     cleanup_on_hw_reconfigure();
     restart_hw_ = true;
+    hw_reconfigure_timer_->reset();
   }
 
   if (got_any && !launch_hw_ && hw_interface_wrapper_) {
@@ -320,6 +323,7 @@ rcl_interfaces::msg::SetParametersResult VelodyneRosWrapper::on_parameter_change
     cleanup_on_hw_reconfigure();
     reset_packet_subscriber();
     restart_packet_subscriber_ = true;
+    hw_reconfigure_timer_->reset();
   }
 
   // Currently, HW interface and monitor wrappers have only read-only parameters, so their update


### PR DESCRIPTION
## PR Type
- New Feature

## Description
This PR introduces changes to allow for dynamically reconfiguring the `launch_hw` parameter for the velodyne driver so that the driver can be started at run time instead of always at startup

## Review Procedure

1. I guess the first step would be to establish consensus on whether the support for making `launch_hw` parameter reconfigurable is desired.
2. Then it would be good to agree on whether the approach taken in this PR is ok to go ahead with for other lidar types or a discussion on alternate approaches.
3. Reproduce the test results that are listed below

I tested these changes by running the driver with an actual VLP16 connected by doing the following tests:

- Start the driver with `launch_hw` set to `false`. Then change the parameter to `true`. The driver successfully starts communicating with connected hardware and publishes pointclouds
- Start the driver with `launch_hw` set to `true`. The driver publishes pointclouds as expected. Then change the parameter to `false`. The driver stops publishing pointclouds.
- If the parameter was already `true` and it is set to `true` again, nothing happens. Same if the parameter was `false` and set to `false` again.

## Remarks
1. I changed the C++ standard to C++ 20 because `jthread` support is integrated into stl. And `jthread` simplifies the stopping and starting of threads when `launch_hw` is changed at run time. The behavior in this PR could also be achieved with `std::thread` and C++ 17, but I just felt the possibility to use `request_stop` and the `stop_token` features made for better readability.
2. To avoid errors regarding redeclaration of already declared parameters on dynamic reconfigure, I added conditionals to only declare a parameter if it didn't already exist.

While the desired dynamic reconfiguration works without any errors, there is one unexplained behavior that I would like some feedback on:
  - It seems like the while loop in the thread gets stuck on `packet_queue_.pop()` and doesn't allow the thread to finish. For example, if I try to do a `decoder_thread_.join()` in the `clean_up_on_reconfigure()` function before deleting the hw interface and hw monitor objects, the call to `clean_up_on_reconfigure()` never finishes.

## Pre-Review Checklist for the PR Author

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
