### PR TITLE
fix(nebula_hw_interfaces): handling http get post request exception

### DIFF
--- a/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_velodyne/velodyne_hw_interface.hpp
+++ b/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_velodyne/velodyne_hw_interface.hpp
@@ -88,14 +88,16 @@ private:
         return nebula::util::expected<std::string, VelodyneStatus>(response);
       } catch (const std::exception & ex) {
         if (retry == max_retries - 1) {
-          return nebula::util::expected<std::string, VelodyneStatus>(VelodyneStatus::HTTP_CONNECTION_ERROR);
+          return nebula::util::expected<std::string, VelodyneStatus>(
+            VelodyneStatus::HTTP_CONNECTION_ERROR);
         }
 
         if (client->client()->isOpen()) {
           try {
             client->client()->close();
           } catch (const std::exception & ex) {
-            return nebula::util::expected<std::string, VelodyneStatus>(VelodyneStatus::HTTP_CONNECTION_ERROR);
+            return nebula::util::expected<std::string, VelodyneStatus>(
+              VelodyneStatus::HTTP_CONNECTION_ERROR);
           }
         }
 
@@ -103,10 +105,12 @@ private:
       }
     }
 
-    return nebula::util::expected<std::string, VelodyneStatus>(VelodyneStatus::HTTP_CONNECTION_ERROR);
+    return nebula::util::expected<std::string, VelodyneStatus>(
+      VelodyneStatus::HTTP_CONNECTION_ERROR);
   }
 
-  nebula::util::expected<std::string, VelodyneStatus> http_get_request(const std::string & endpoint);
+  nebula::util::expected<std::string, VelodyneStatus> http_get_request(
+    const std::string & endpoint);
   nebula::util::expected<std::string, VelodyneStatus> http_post_request(
     const std::string & endpoint, const std::string & body);
 

--- a/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_velodyne/velodyne_hw_interface.hpp
+++ b/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_velodyne/velodyne_hw_interface.hpp
@@ -72,12 +72,11 @@ private:
 
   template <typename CallbackType>
   nebula::util::expected<std::string, Status> do_http_request_with_retries(
-    CallbackType do_request,
-    std::unique_ptr<::drivers::tcp_driver::HttpClientDriver> & client)
+    CallbackType do_request, std::unique_ptr<::drivers::tcp_driver::HttpClientDriver> & client)
   {
     constexpr int max_retries = 3;
     constexpr int retry_delay_ms = 100;
-    
+
     for (int retry = 0; retry < max_retries; ++retry) {
       try {
         if (!client->client()->isOpen()) {
@@ -91,7 +90,7 @@ private:
         if (retry == max_retries - 1) {
           return nebula::util::expected<std::string, Status>(Status::HTTP_CONNECTION_ERROR);
         }
-        
+
         if (client->client()->isOpen()) {
           try {
             client->client()->close();
@@ -99,11 +98,11 @@ private:
             return nebula::util::expected<std::string, Status>(Status::HTTP_CONNECTION_ERROR);
           }
         }
-        
+
         std::this_thread::sleep_for(std::chrono::milliseconds(retry_delay_ms));
       }
     }
-    
+
     return nebula::util::expected<std::string, Status>(Status::HTTP_CONNECTION_ERROR);
   }
 

--- a/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_velodyne/velodyne_hw_interface.hpp
+++ b/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_velodyne/velodyne_hw_interface.hpp
@@ -71,7 +71,7 @@ private:
   void string_callback(const std::string & str);
 
   template <typename CallbackType>
-  nebula::util::expected<std::string, Status> do_http_request_with_retries(
+  nebula::util::expected<std::string, VelodyneStatus> do_http_request_with_retries(
     CallbackType do_request, std::unique_ptr<::drivers::tcp_driver::HttpClientDriver> & client)
   {
     constexpr int max_retries = 3;
@@ -85,17 +85,17 @@ private:
 
         std::string response = do_request();
         client->client()->close();
-        return nebula::util::expected<std::string, Status>(response);
+        return nebula::util::expected<std::string, VelodyneStatus>(response);
       } catch (const std::exception & ex) {
         if (retry == max_retries - 1) {
-          return nebula::util::expected<std::string, Status>(Status::HTTP_CONNECTION_ERROR);
+          return nebula::util::expected<std::string, VelodyneStatus>(VelodyneStatus::HTTP_CONNECTION_ERROR);
         }
 
         if (client->client()->isOpen()) {
           try {
             client->client()->close();
           } catch (const std::exception & ex) {
-            return nebula::util::expected<std::string, Status>(Status::HTTP_CONNECTION_ERROR);
+            return nebula::util::expected<std::string, VelodyneStatus>(VelodyneStatus::HTTP_CONNECTION_ERROR);
           }
         }
 
@@ -103,11 +103,11 @@ private:
       }
     }
 
-    return nebula::util::expected<std::string, Status>(Status::HTTP_CONNECTION_ERROR);
+    return nebula::util::expected<std::string, VelodyneStatus>(VelodyneStatus::HTTP_CONNECTION_ERROR);
   }
 
-  nebula::util::expected<std::string, Status> http_get_request(const std::string & endpoint);
-  nebula::util::expected<std::string, Status> http_post_request(
+  nebula::util::expected<std::string, VelodyneStatus> http_get_request(const std::string & endpoint);
+  nebula::util::expected<std::string, VelodyneStatus> http_post_request(
     const std::string & endpoint, const std::string & body);
 
   /// @brief Get a one-off HTTP client to communicate with the hardware
@@ -190,13 +190,13 @@ public:
   VelodyneStatus init_http_client();
   /// @brief Getting the current operational state and parameters of the sensor (sync)
   /// @return Resulting JSON string
-  nebula::util::expected<std::string, Status> get_status();
+  nebula::util::expected<std::string, VelodyneStatus> get_status();
   /// @brief Getting diagnostic information from the sensor (sync)
   /// @return Resulting JSON string
-  nebula::util::expected<std::string, Status> get_diag();
+  nebula::util::expected<std::string, VelodyneStatus> get_diag();
   /// @brief Getting current sensor configuration and status data (sync)
   /// @return Resulting JSON string
-  nebula::util::expected<std::string, Status> get_snapshot();
+  nebula::util::expected<std::string, VelodyneStatus> get_snapshot();
   /// @brief Setting Motor RPM (sync)
   /// @param rpm the RPM of the motor
   /// @return Resulting status

--- a/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_velodyne/velodyne_hw_interface.hpp
+++ b/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_velodyne/velodyne_hw_interface.hpp
@@ -27,6 +27,7 @@
 #endif
 
 #include "nebula_hw_interfaces/nebula_hw_interfaces_common/nebula_hw_interface_base.hpp"
+#include "nebula_common/util/expected.hpp"
 
 #include <boost_tcp_driver/http_client_driver.hpp>
 #include <boost_udp_driver/udp_driver.hpp>
@@ -69,8 +70,8 @@ private:
   std::string target_reset_{"/cgi/reset"};
   void string_callback(const std::string & str);
 
-  std::string http_get_request(const std::string & endpoint);
-  std::string http_post_request(const std::string & endpoint, const std::string & body);
+  nebula::util::expected<std::string, Status>  http_get_request(const std::string & endpoint);
+  nebula::util::expected<std::string, Status>  http_post_request(const std::string & endpoint, const std::string & body);
 
   /// @brief Get a one-off HTTP client to communicate with the hardware
   /// @param ctx IO Context
@@ -152,13 +153,13 @@ public:
   VelodyneStatus init_http_client();
   /// @brief Getting the current operational state and parameters of the sensor (sync)
   /// @return Resulting JSON string
-  std::string get_status();
+  nebula::util::expected<std::string, Status> get_status();
   /// @brief Getting diagnostic information from the sensor (sync)
   /// @return Resulting JSON string
-  std::string get_diag();
+  nebula::util::expected<std::string, Status> get_diag();
   /// @brief Getting current sensor configuration and status data (sync)
   /// @return Resulting JSON string
-  std::string get_snapshot();
+  nebula::util::expected<std::string, Status> get_snapshot();
   /// @brief Setting Motor RPM (sync)
   /// @param rpm the RPM of the motor
   /// @return Resulting status

--- a/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_velodyne/velodyne_hw_interface.hpp
+++ b/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_velodyne/velodyne_hw_interface.hpp
@@ -26,8 +26,8 @@
 #define BOOST_ALLOW_DEPRECATED_HEADERS
 #endif
 
-#include "nebula_hw_interfaces/nebula_hw_interfaces_common/nebula_hw_interface_base.hpp"
 #include "nebula_common/util/expected.hpp"
+#include "nebula_hw_interfaces/nebula_hw_interfaces_common/nebula_hw_interface_base.hpp"
 
 #include <boost_tcp_driver/http_client_driver.hpp>
 #include <boost_udp_driver/udp_driver.hpp>
@@ -70,8 +70,9 @@ private:
   std::string target_reset_{"/cgi/reset"};
   void string_callback(const std::string & str);
 
-  nebula::util::expected<std::string, Status>  http_get_request(const std::string & endpoint);
-  nebula::util::expected<std::string, Status>  http_post_request(const std::string & endpoint, const std::string & body);
+  nebula::util::expected<std::string, Status> http_get_request(const std::string & endpoint);
+  nebula::util::expected<std::string, Status> http_post_request(
+    const std::string & endpoint, const std::string & body);
 
   /// @brief Get a one-off HTTP client to communicate with the hardware
   /// @param ctx IO Context

--- a/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
+++ b/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
@@ -73,8 +73,9 @@ nebula::util::expected<std::string, Status> VelodyneHwInterface::http_post_reque
       if (retry == max_retries - 1) {
         return nebula::util::expected<std::string, Status>(Status::HTTP_CONNECTION_ERROR);
       }
-      print_debug("HTTP POST retry " + std::to_string(retry + 1) + "/" +
-                 std::to_string(max_retries) + ": " + std::string(ex.what()));
+      print_debug(
+        "HTTP POST retry " + std::to_string(retry + 1) + "/" + std::to_string(max_retries) + ": " +
+        std::string(ex.what()));
 
       if (http_client_driver_->client()->isOpen()) {
         try {

--- a/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
+++ b/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
@@ -19,12 +19,11 @@ VelodyneHwInterface::VelodyneHwInterface()
 
 template <typename CallbackType>
 nebula::util::expected<std::string, Status> do_http_request_with_retries(
-  CallbackType do_request,
-  std::shared_ptr<drivers::tcp_driver::HttpClientDriver> client)
+  CallbackType do_request, std::shared_ptr<drivers::tcp_driver::HttpClientDriver> client)
 {
   constexpr int max_retries = 3;
   constexpr int retry_delay_ms = 100;
-  
+
   for (int retry = 0; retry < max_retries; ++retry) {
     try {
       if (!client->client()->isOpen()) {
@@ -38,7 +37,7 @@ nebula::util::expected<std::string, Status> do_http_request_with_retries(
       if (retry == max_retries - 1) {
         return nebula::util::expected<std::string, Status>(Status::HTTP_CONNECTION_ERROR);
       }
-      
+
       if (client->client()->isOpen()) {
         try {
           client->client()->close();
@@ -46,11 +45,11 @@ nebula::util::expected<std::string, Status> do_http_request_with_retries(
           return nebula::util::expected<std::string, Status>(Status::HTTP_CONNECTION_ERROR);
         }
       }
-      
+
       std::this_thread::sleep_for(std::chrono::milliseconds(retry_delay_ms));
     }
   }
-  
+
   return nebula::util::expected<std::string, Status>(Status::HTTP_CONNECTION_ERROR);
 }
 
@@ -59,8 +58,7 @@ nebula::util::expected<std::string, Status> VelodyneHwInterface::http_get_reques
 {
   std::lock_guard lock(mtx_inflight_request_);
   return do_http_request_with_retries(
-    [&]() { return http_client_driver_->get(endpoint); },
-    http_client_driver_);
+    [&]() { return http_client_driver_->get(endpoint); }, http_client_driver_);
 }
 
 nebula::util::expected<std::string, Status> VelodyneHwInterface::http_post_request(
@@ -68,8 +66,7 @@ nebula::util::expected<std::string, Status> VelodyneHwInterface::http_post_reque
 {
   std::lock_guard lock(mtx_inflight_request_);
   return do_http_request_with_retries(
-    [&]() { return http_client_driver_->post(endpoint, body); },
-    http_client_driver_);
+    [&]() { return http_client_driver_->post(endpoint, body); }, http_client_driver_);
 }
 
 Status VelodyneHwInterface::initialize_sensor_configuration(

--- a/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
+++ b/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
@@ -103,10 +103,10 @@ Status VelodyneHwInterface::set_sensor_configuration(
   std::shared_ptr<const VelodyneSensorConfiguration> sensor_configuration)
 {
   auto snapshot = get_snapshot();
-  if (!snapshot_result.has_value()) {
+  if (!snapshot.has_value()) {
     return Status::HTTP_CONNECTION_ERROR;
   }
-  auto tree = parse_json(snapshot);
+  auto tree = parse_json(snapshot.value());
   VelodyneStatus status = check_and_set_config(sensor_configuration, tree);
 
   return status;

--- a/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
+++ b/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
@@ -20,26 +20,36 @@ VelodyneHwInterface::VelodyneHwInterface()
 std::string VelodyneHwInterface::http_get_request(const std::string & endpoint)
 {
   std::lock_guard lock(mtx_inflight_request_);
-  if (!http_client_driver_->client()->isOpen()) {
-    http_client_driver_->client()->open();
-  }
+  try {
+    if (!http_client_driver_->client()->isOpen()) {
+      http_client_driver_->client()->open();
+    }
 
-  std::string response = http_client_driver_->get(endpoint);
-  http_client_driver_->client()->close();
-  return response;
+    std::string response = http_client_driver_->get(endpoint);
+    http_client_driver_->client()->close();
+    return response;
+  } catch (const std::exception & ex) {
+    VelodyneStatus status = Status::HTTP_CONNECTION_ERROR;
+    return status;
+  }
 }
 
 std::string VelodyneHwInterface::http_post_request(
   const std::string & endpoint, const std::string & body)
 {
   std::lock_guard lock(mtx_inflight_request_);
-  if (!http_client_driver_->client()->isOpen()) {
-    http_client_driver_->client()->open();
-  }
+  try {
+    if (!http_client_driver_->client()->isOpen()) {
+      http_client_driver_->client()->open();
+    }
 
-  std::string response = http_client_driver_->post(endpoint, body);
-  http_client_driver_->client()->close();
-  return response;
+    std::string response = http_client_driver_->post(endpoint, body);
+    http_client_driver_->client()->close();
+    return response;
+  } catch (const std::exception & ex) {
+    VelodyneStatus status = Status::HTTP_CONNECTION_ERROR;
+    return status;
+  }
 }
 
 Status VelodyneHwInterface::initialize_sensor_configuration(

--- a/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
+++ b/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
@@ -17,42 +17,6 @@ VelodyneHwInterface::VelodyneHwInterface()
 {
 }
 
-template <typename CallbackType>
-nebula::util::expected<std::string, Status> do_http_request_with_retries(
-  CallbackType do_request, std::unique_ptr<::drivers::tcp_driver::HttpClientDriver> & client)
-{
-  constexpr int max_retries = 3;
-  constexpr int retry_delay_ms = 100;
-
-  for (int retry = 0; retry < max_retries; ++retry) {
-    try {
-      if (!client->client()->isOpen()) {
-        client->client()->open();
-      }
-
-      std::string response = do_request();
-      client->client()->close();
-      return nebula::util::expected<std::string, Status>(response);
-    } catch (const std::exception & ex) {
-      if (retry == max_retries - 1) {
-        return nebula::util::expected<std::string, Status>(Status::HTTP_CONNECTION_ERROR);
-      }
-
-      if (client->client()->isOpen()) {
-        try {
-          client->client()->close();
-        } catch (const std::exception & ex) {
-          return nebula::util::expected<std::string, Status>(Status::HTTP_CONNECTION_ERROR);
-        }
-      }
-
-      std::this_thread::sleep_for(std::chrono::milliseconds(retry_delay_ms));
-    }
-  }
-
-  return nebula::util::expected<std::string, Status>(Status::HTTP_CONNECTION_ERROR);
-}
-
 nebula::util::expected<std::string, Status> VelodyneHwInterface::http_get_request(
   const std::string & endpoint)
 {

--- a/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
+++ b/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
@@ -98,7 +98,7 @@ Status VelodyneHwInterface::get_sensor_configuration(SensorConfigurationBase & s
   std::stringstream ss;
   ss << sensor_configuration;
   print_debug(ss.str());
-  return Status::HTTP_CONNECTION_ERROR;
+  return Status::ERROR_1;
 }
 
 VelodyneStatus VelodyneHwInterface::init_http_client()
@@ -265,7 +265,7 @@ VelodyneStatus VelodyneHwInterface::set_rpm(uint16_t rpm)
   }
   auto rt = http_post_request(target_setting_, (boost::format("rpm=%d") % rpm).str());
   if (!rt.has_value()) {
-    return Status::HTTP_CONNECTION_ERROR;
+    return rt.error();
   }
   string_callback(rt.value());
   return Status::OK;
@@ -278,7 +278,7 @@ VelodyneStatus VelodyneHwInterface::set_fov_start(uint16_t fov_start)
   }
   auto rt = http_post_request(target_fov_, (boost::format("start=%d") % fov_start).str());
   if (!rt.has_value()) {
-    return Status::HTTP_CONNECTION_ERROR;
+    return rt.error();
   }
   string_callback(rt.value());
   return Status::OK;
@@ -291,7 +291,7 @@ VelodyneStatus VelodyneHwInterface::set_fov_end(uint16_t fov_end)
   }
   auto rt = http_post_request(target_fov_, (boost::format("end=%d") % fov_end).str());
   if (!rt.has_value()) {
-    return Status::HTTP_CONNECTION_ERROR;
+    return rt.error();
   }
   string_callback(rt.value());
   return Status::OK;
@@ -315,7 +315,7 @@ VelodyneStatus VelodyneHwInterface::set_return_type(nebula::drivers::ReturnMode 
   }
   auto rt = http_post_request(target_setting_, body_str);
   if (!rt.has_value()) {
-    return Status::HTTP_CONNECTION_ERROR;
+    return rt.error();
   }
   string_callback(rt.value());
   return Status::OK;
@@ -326,7 +326,7 @@ VelodyneStatus VelodyneHwInterface::save_config()
   std::string body_str = "submit";
   auto rt = http_post_request(target_save_, body_str);
   if (!rt.has_value()) {
-    return Status::HTTP_CONNECTION_ERROR;
+    return rt.error();
   }
   string_callback(rt.value());
   return Status::OK;
@@ -337,7 +337,7 @@ VelodyneStatus VelodyneHwInterface::reset_system()
   std::string body_str = "reset_system";
   auto rt = http_post_request(target_reset_, body_str);
   if (!rt.has_value()) {
-    return Status::HTTP_CONNECTION_ERROR;
+    return rt.error();
   }
   string_callback(rt.value());
   return Status::OK;
@@ -348,7 +348,7 @@ VelodyneStatus VelodyneHwInterface::laser_on()
   std::string body_str = "laser=on";
   auto rt = http_post_request(target_setting_, body_str);
   if (!rt.has_value()) {
-    return Status::HTTP_CONNECTION_ERROR;
+    return rt.error();
   }
   string_callback(rt.value());
   return Status::OK;
@@ -359,7 +359,7 @@ VelodyneStatus VelodyneHwInterface::laser_off()
   std::string body_str = "laser=off";
   auto rt = http_post_request(target_setting_, body_str);
   if (!rt.has_value()) {
-    return Status::HTTP_CONNECTION_ERROR;
+    return rt.error();
   }
   string_callback(rt.value());
   return Status::OK;
@@ -370,7 +370,7 @@ VelodyneStatus VelodyneHwInterface::laser_on_off(bool on)
   std::string body_str = (boost::format("laser=%s") % (on ? "on" : "off")).str();
   auto rt = http_post_request(target_setting_, body_str);
   if (!rt.has_value()) {
-    return Status::HTTP_CONNECTION_ERROR;
+    return rt.error();
   }
   string_callback(rt.value());
   return Status::OK;
@@ -380,7 +380,7 @@ VelodyneStatus VelodyneHwInterface::set_host_addr(std::string addr)
 {
   auto rt = http_post_request(target_host_, (boost::format("addr=%s") % addr).str());
   if (!rt.has_value()) {
-    return Status::HTTP_CONNECTION_ERROR;
+    return rt.error();
   }
   string_callback(rt.value());
   return Status::OK;
@@ -390,7 +390,7 @@ VelodyneStatus VelodyneHwInterface::set_host_dport(uint16_t dport)
 {
   auto rt = http_post_request(target_host_, (boost::format("dport=%d") % dport).str());
   if (!rt.has_value()) {
-    return Status::HTTP_CONNECTION_ERROR;
+    return rt.error();
   }
   string_callback(rt.value());
   return Status::OK;
@@ -400,7 +400,7 @@ VelodyneStatus VelodyneHwInterface::set_host_tport(uint16_t tport)
 {
   auto rt = http_post_request(target_host_, (boost::format("tport=%d") % tport).str());
   if (!rt.has_value()) {
-    return Status::HTTP_CONNECTION_ERROR;
+    return rt.error();
   }
   string_callback(rt.value());
   return Status::OK;
@@ -410,7 +410,7 @@ VelodyneStatus VelodyneHwInterface::set_net_addr(std::string addr)
 {
   auto rt = http_post_request(target_net_, (boost::format("addr=%s") % addr).str());
   if (!rt.has_value()) {
-    return Status::HTTP_CONNECTION_ERROR;
+    return rt.error();
   }
   string_callback(rt.value());
   return Status::OK;
@@ -420,7 +420,7 @@ VelodyneStatus VelodyneHwInterface::set_net_mask(std::string mask)
 {
   auto rt = http_post_request(target_net_, (boost::format("mask=%s") % mask).str());
   if (!rt.has_value()) {
-    return Status::HTTP_CONNECTION_ERROR;
+    return rt.error();
   }
   string_callback(rt.value());
   return Status::OK;
@@ -430,7 +430,7 @@ VelodyneStatus VelodyneHwInterface::set_net_gateway(std::string gateway)
 {
   auto rt = http_post_request(target_net_, (boost::format("gateway=%s") % gateway).str());
   if (!rt.has_value()) {
-    return Status::HTTP_CONNECTION_ERROR;
+    return rt.error();
   }
   string_callback(rt.value());
   return Status::OK;
@@ -441,7 +441,7 @@ VelodyneStatus VelodyneHwInterface::set_net_dhcp(bool use_dhcp)
   auto rt =
     http_post_request(target_net_, (boost::format("dhcp=%s") % (use_dhcp ? "on" : "off")).str());
   if (!rt.has_value()) {
-    return Status::HTTP_CONNECTION_ERROR;
+    return rt.error();
   }
   string_callback(rt.value());
   return Status::OK;

--- a/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
+++ b/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
@@ -17,7 +17,7 @@ VelodyneHwInterface::VelodyneHwInterface()
 {
 }
 
-nebula::util::expected<std::string, Status> VelodyneHwInterface::http_get_request(
+nebula::util::expected<std::string, VelodyneStatus> VelodyneHwInterface::http_get_request(
   const std::string & endpoint)
 {
   std::lock_guard lock(mtx_inflight_request_);
@@ -25,7 +25,7 @@ nebula::util::expected<std::string, Status> VelodyneHwInterface::http_get_reques
   return do_http_request_with_retries(do_request, http_client_driver_);
 }
 
-nebula::util::expected<std::string, Status> VelodyneHwInterface::http_post_request(
+nebula::util::expected<std::string, VelodyneStatus> VelodyneHwInterface::http_post_request(
   const std::string & endpoint, const std::string & body)
 {
   std::lock_guard lock(mtx_inflight_request_);
@@ -239,12 +239,12 @@ VelodyneStatus VelodyneHwInterface::check_and_set_config(
 
 // sync
 
-nebula::util::expected<std::string, Status> VelodyneHwInterface::get_status()
+nebula::util::expected<std::string, VelodyneStatus> VelodyneHwInterface::get_status()
 {
   return http_get_request(target_status_);
 }
 
-nebula::util::expected<std::string, Status> VelodyneHwInterface::get_diag()
+nebula::util::expected<std::string, VelodyneStatus> VelodyneHwInterface::get_diag()
 {
   auto response = http_get_request(target_diag_);
   if (response.has_value()) {
@@ -253,7 +253,7 @@ nebula::util::expected<std::string, Status> VelodyneHwInterface::get_diag()
   return response;
 }
 
-nebula::util::expected<std::string, Status> VelodyneHwInterface::get_snapshot()
+nebula::util::expected<std::string, VelodyneStatus> VelodyneHwInterface::get_snapshot()
 {
   return http_get_request(target_snapshot_);
 }

--- a/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
+++ b/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
@@ -86,7 +86,7 @@ Status VelodyneHwInterface::set_sensor_configuration(
 {
   auto snapshot = get_snapshot();
   if (!snapshot.has_value()) {
-    return Status::HTTP_CONNECTION_ERROR;
+    return snapshot.error();
   }
   auto tree = parse_json(snapshot.value());
   VelodyneStatus status = check_and_set_config(sensor_configuration, tree);

--- a/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
+++ b/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
@@ -19,12 +19,11 @@ VelodyneHwInterface::VelodyneHwInterface()
 
 template <typename CallbackType>
 nebula::util::expected<std::string, Status> do_http_request_with_retries(
-  CallbackType do_request,
-  std::unique_ptr<::drivers::tcp_driver::HttpClientDriver> & client)
+  CallbackType do_request, std::unique_ptr<::drivers::tcp_driver::HttpClientDriver> & client)
 {
   constexpr int max_retries = 3;
   constexpr int retry_delay_ms = 100;
-  
+
   for (int retry = 0; retry < max_retries; ++retry) {
     try {
       if (!client->client()->isOpen()) {
@@ -38,7 +37,7 @@ nebula::util::expected<std::string, Status> do_http_request_with_retries(
       if (retry == max_retries - 1) {
         return nebula::util::expected<std::string, Status>(Status::HTTP_CONNECTION_ERROR);
       }
-      
+
       if (client->client()->isOpen()) {
         try {
           client->client()->close();
@@ -46,11 +45,11 @@ nebula::util::expected<std::string, Status> do_http_request_with_retries(
           return nebula::util::expected<std::string, Status>(Status::HTTP_CONNECTION_ERROR);
         }
       }
-      
+
       std::this_thread::sleep_for(std::chrono::milliseconds(retry_delay_ms));
     }
   }
-  
+
   return nebula::util::expected<std::string, Status>(Status::HTTP_CONNECTION_ERROR);
 }
 
@@ -58,9 +57,7 @@ nebula::util::expected<std::string, Status> VelodyneHwInterface::http_get_reques
   const std::string & endpoint)
 {
   std::lock_guard lock(mtx_inflight_request_);
-  auto do_request = [this, &endpoint]() {
-    return http_client_driver_->get(endpoint);
-  };
+  auto do_request = [this, &endpoint]() { return http_client_driver_->get(endpoint); };
   return do_http_request_with_retries(do_request, http_client_driver_);
 }
 

--- a/nebula_ros/src/velodyne/hw_monitor_wrapper.cpp
+++ b/nebula_ros/src/velodyne/hw_monitor_wrapper.cpp
@@ -211,7 +211,7 @@ void VelodyneHwMonitorWrapper::on_velodyne_snapshot_timer()
       std::make_shared<boost::property_tree::ptree>(current_snapshot_tree_->get_child("diag"));
     current_status_tree_ =
       std::make_shared<boost::property_tree::ptree>(current_snapshot_tree_->get_child("status"));
-    current_snapshot_.reset(new std::string(str));
+    current_snapshot_.reset(new std::string(str.value()));
   }
 }
 

--- a/nebula_ros/src/velodyne/hw_monitor_wrapper.cpp
+++ b/nebula_ros/src/velodyne/hw_monitor_wrapper.cpp
@@ -29,7 +29,7 @@ VelodyneHwMonitorWrapper::VelodyneHwMonitorWrapper(
 
   std::cout << "Get model name and serial." << std::endl;
   auto str = hw_interface_->get_snapshot();
-  if (!str.has_value()) return; 
+  if (!str.has_value()) return;
   current_snapshot_time_.reset(new rclcpp::Time(parent_node_->now()));
   current_snapshot_tree_ =
     std::make_shared<boost::property_tree::ptree>(hw_interface_->parse_json(str));
@@ -199,7 +199,7 @@ void VelodyneHwMonitorWrapper::initialize_velodyne_diagnostics()
 void VelodyneHwMonitorWrapper::on_velodyne_snapshot_timer()
 {
   auto str = hw_interface_->get_snapshot();
-  if (!str.has_value()) return; 
+  if (!str.has_value()) return;
   auto ptree = hw_interface_->parse_json(str);
 
   {
@@ -219,7 +219,7 @@ void VelodyneHwMonitorWrapper::on_velodyne_diagnostics_timer()
 {
   std::cout << "OnVelodyneDiagnosticsTimer" << std::endl;
   auto str = hw_interface_->get_diag();
-  if (!str.has_value()) return; 
+  if (!str.has_value()) return;
 
   {
     std::lock_guard lock(mtx_diag_);
@@ -1159,7 +1159,7 @@ void VelodyneHwMonitorWrapper::velodyne_check_adctp_stat(
 void VelodyneHwMonitorWrapper::on_velodyne_status_timer()
 {
   auto str = hw_interface_->get_status();
-  if (!str.has_value() ) return;
+  if (!str.has_value()) return;
   {
     std::lock_guard lock(mtx_status_);
     current_status_tree_ =

--- a/nebula_ros/src/velodyne/hw_monitor_wrapper.cpp
+++ b/nebula_ros/src/velodyne/hw_monitor_wrapper.cpp
@@ -29,6 +29,7 @@ VelodyneHwMonitorWrapper::VelodyneHwMonitorWrapper(
 
   std::cout << "Get model name and serial." << std::endl;
   auto str = hw_interface_->get_snapshot();
+  if (!str.has_value()) return; 
   current_snapshot_time_.reset(new rclcpp::Time(parent_node_->now()));
   current_snapshot_tree_ =
     std::make_shared<boost::property_tree::ptree>(hw_interface_->parse_json(str));
@@ -198,6 +199,7 @@ void VelodyneHwMonitorWrapper::initialize_velodyne_diagnostics()
 void VelodyneHwMonitorWrapper::on_velodyne_snapshot_timer()
 {
   auto str = hw_interface_->get_snapshot();
+  if (!str.has_value()) return; 
   auto ptree = hw_interface_->parse_json(str);
 
   {
@@ -217,6 +219,8 @@ void VelodyneHwMonitorWrapper::on_velodyne_diagnostics_timer()
 {
   std::cout << "OnVelodyneDiagnosticsTimer" << std::endl;
   auto str = hw_interface_->get_diag();
+  if (!str.has_value()) return; 
+
   {
     std::lock_guard lock(mtx_diag_);
     current_diag_tree_ =
@@ -1155,6 +1159,7 @@ void VelodyneHwMonitorWrapper::velodyne_check_adctp_stat(
 void VelodyneHwMonitorWrapper::on_velodyne_status_timer()
 {
   auto str = hw_interface_->get_status();
+  if (!str.has_value() ) return;
   {
     std::lock_guard lock(mtx_status_);
     current_status_tree_ =

--- a/nebula_ros/src/velodyne/hw_monitor_wrapper.cpp
+++ b/nebula_ros/src/velodyne/hw_monitor_wrapper.cpp
@@ -199,7 +199,7 @@ void VelodyneHwMonitorWrapper::initialize_velodyne_diagnostics()
 void VelodyneHwMonitorWrapper::on_velodyne_snapshot_timer()
 {
   auto str = hw_interface_->get_snapshot();
-  if (!str.has_value()) return; 
+  if (!str.has_value()) return;
   auto ptree = hw_interface_->parse_json(str.value());
 
   {

--- a/nebula_ros/src/velodyne/hw_monitor_wrapper.cpp
+++ b/nebula_ros/src/velodyne/hw_monitor_wrapper.cpp
@@ -32,12 +32,12 @@ VelodyneHwMonitorWrapper::VelodyneHwMonitorWrapper(
   if (!str.has_value()) return;
   current_snapshot_time_.reset(new rclcpp::Time(parent_node_->now()));
   current_snapshot_tree_ =
-    std::make_shared<boost::property_tree::ptree>(hw_interface_->parse_json(str));
+    std::make_shared<boost::property_tree::ptree>(hw_interface_->parse_json(str.value()));
   current_diag_tree_ =
     std::make_shared<boost::property_tree::ptree>(current_snapshot_tree_->get_child("diag"));
   current_status_tree_ =
     std::make_shared<boost::property_tree::ptree>(current_snapshot_tree_->get_child("status"));
-  current_snapshot_.reset(new std::string(str));
+  current_snapshot_.reset(new std::string(str.value()));
 
   try {
     info_model_ = get_ptree_value(current_snapshot_tree_, mtx_snapshot_, key_info_model);
@@ -199,8 +199,8 @@ void VelodyneHwMonitorWrapper::initialize_velodyne_diagnostics()
 void VelodyneHwMonitorWrapper::on_velodyne_snapshot_timer()
 {
   auto str = hw_interface_->get_snapshot();
-  if (!str.has_value()) return;
-  auto ptree = hw_interface_->parse_json(str);
+  if (!str.has_value()) return; 
+  auto ptree = hw_interface_->parse_json(str.value());
 
   {
     std::lock_guard lock(mtx_snapshot_);
@@ -224,7 +224,7 @@ void VelodyneHwMonitorWrapper::on_velodyne_diagnostics_timer()
   {
     std::lock_guard lock(mtx_diag_);
     current_diag_tree_ =
-      std::make_shared<boost::property_tree::ptree>(hw_interface_->parse_json(str));
+      std::make_shared<boost::property_tree::ptree>(hw_interface_->parse_json(str.value()));
   }
   diagnostics_updater_.force_update();
 }
@@ -1163,7 +1163,7 @@ void VelodyneHwMonitorWrapper::on_velodyne_status_timer()
   {
     std::lock_guard lock(mtx_status_);
     current_status_tree_ =
-      std::make_shared<boost::property_tree::ptree>(hw_interface_->parse_json(str));
+      std::make_shared<boost::property_tree::ptree>(hw_interface_->parse_json(str.value()));
   }
   diagnostics_updater_.force_update();
 }


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Bug Fix

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->
Bug found slack thread: 
https://star4.slack.com/archives/CEV8XMJBV/p1739142264251479?thread_ts=1739139390.099319&cid=CEV8XMJBV

## Description

<!-- Describe what this PR changes. -->

Added error handling for HTTP GET/POST requests in VelodyneHwInterface to address system crashes caused by unhandled exceptions during HTTP communication.

The system would crash with "Interrupted system call" errors when exceptions occurred during HTTP requests to the Velodyne sensor:

```
1739140782.9432542 [component_container_mt-52] ^[[0m[INFO 1739140768.990953850] [rclcpp] signal_handler(): "signal_handler(signum=2)" at (/home/autoware/pilot-auto.xx1/src/rclcpp/rclcpp/src/rclcpp/signal_handler.cpp:L71)^[[0m
1739140782.9433613 [component_container_mt-52] terminate called after throwing an instance of 'boost::wrapexcept<boost::system::system_error>'
1739140782.9435017 [component_container_mt-52]   what():  Interrupted system call
1739140782.9435987 [component_container_mt-52] *** Aborted at 1739140768 (unix time) try "date -d @1739140768" if you are using GNU date ***
1739140782.9436829 [component_container_mt-52] PC: @                0x0 (unknown)
1739140782.9437885 [component_container_mt-52] *** SIGABRT (@0x3e8000009fa) received by PID 2554 (TID 0x7f1d91b9d680) from PID 2554; stack trace: ***
1739140782.9438906 [component_container_mt-52]     @     0x7f1d926634d6 google::(anonymous namespace)::FailureSignalHandler()
1739140782.9440007 [component_container_mt-52]     @     0x7f1d91f13520 (unknown)
1739140782.9441085 [component_container_mt-52]     @     0x7f1d91f679fc pthread_kill
1739140782.9441876 [component_container_mt-52]     @     0x7f1d91f13476 raise
1739140782.9442828 [component_container_mt-52]     @     0x7f1d91ef97f3 abort
1739140782.9443274 [component_container_mt-52]     @     0x7f1d921bcb9e (unknown)
1739140782.9444058 [component_container_mt-52]     @     0x7f1d921c820c (unknown)
1739140782.9444652 [component_container_mt-52]     @     0x7f1d921c8277 std::terminate()
1739140782.9445279 [component_container_mt-52]     @     0x7f1d921c84d8 __cxa_throw
1739140782.9446065 [component_container_mt-52]     @     0x7f1d8c07f055 boost::throw_exception<>()
1739140782.9446507 [component_container_mt-52]     @     0x7f1d8c07eb7c _ZN7drivers10tcp_driver10HttpClient5writeENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEN5boost5beast4http4verbES7_.cold
1739140782.9446948 [component_container_mt-52]     @     0x7f1d8c0abc4a drivers::tcp_driver::HttpClient::get()
1739140782.9447391 [component_container_mt-52]     @     0x7f1d8c0cef88 drivers::tcp_driver::HttpClientDriver::get()
1739140782.9447834 [component_container_mt-52]     @     0x7f1d8e1f992d nebula::drivers::VelodyneHwInterface::http_get_request()
1739140782.9448268 [component_container_mt-52]     @     0x7f1d8e1f9b69 nebula::drivers::VelodyneHwInterface::get_snapshot()
1739140782.9448709 [component_container_mt-52]     @     0x7f1d847c0eb4 nebula::ros::VelodyneHwMonitorWrapper::on_velodyne_snapshot_timer()
1739140782.9449153 [component_container_mt-52]     @     0x7f1d847c12d4 _ZN6rclcpp12GenericTimerIZN6nebula3ros24VelodyneHwMonitorWrapper31initialize_velodyne_diagnosticsEvEUlvE_LPv0EE16execute_callbackEv
1739140782.9449596 [component_container_mt-52]     @     0x7f1d924e0ffe rclcpp::Executor::execute_any_executable()
1739140782.9450040 [component_container_mt-52]     @     0x7f1d924e7432 rclcpp::executors::MultiThreadedExecutor::run()
1739140782.9450479 [component_container_mt-52]     @     0x7f1d924e7808 rclcpp::executors::MultiThreadedExecutor::spin()
1739140782.9450917 [component_container_mt-52]     @     0x55f2b35b9771 main
1739140782.9451358 [component_container_mt-52]     @     0x7f1d91efad90 (unknown)
1739140782.9451797 [component_container_mt-52]     @     0x7f1d91efae40 __libc_start_main
1739140782.9452233 [component_container_mt-52]     @     0x55f2b35b9a95 _start
```


## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->
I'm not sure if returning `Status::HTTP_CONNECTION_ERROR` is ok for the exception.
Please confirm :pray:  @mojomex 

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
