### PR TITLE
chore(hesai): enable PTP lock threshold setting for XT series sensors

### DIFF
--- a/nebula_hw_interfaces/src/nebula_hesai_hw_interfaces/hesai_hw_interface.cpp
+++ b/nebula_hw_interfaces/src/nebula_hesai_hw_interfaces/hesai_hw_interface.cpp
@@ -1080,17 +1080,24 @@ HesaiStatus HesaiHwInterface::check_and_set_config(
     t.join();
     logger_->debug("Thread finished");
 
-    if (
-      sensor_configuration_->sensor_model == SensorModel::HESAI_PANDAR128_E4X ||
-      sensor_configuration_->sensor_model == SensorModel::HESAI_PANDARQT128) {
-      uint8_t sensor_ptp_lock_threshold = get_ptp_lock_offset();
-      if (sensor_ptp_lock_threshold != sensor_configuration_->ptp_lock_threshold) {
-        NEBULA_LOG_STREAM(
-          logger_->info, "changing sensor PTP lock offset from "
-                           << static_cast<int>(sensor_ptp_lock_threshold) << " to "
-                           << static_cast<int>(sensor_configuration_->ptp_lock_threshold));
-        set_ptp_lock_offset(sensor_configuration_->ptp_lock_threshold);
+    switch (sensor_configuration_->sensor_model) {
+      case SensorModel::HESAI_PANDAR128_E4X:
+      case SensorModel::HESAI_PANDARQT128:
+      case SensorModel::HESAI_PANDARXT16:
+      case SensorModel::HESAI_PANDARXT32:
+      case SensorModel::HESAI_PANDARXT32M: {
+        uint8_t sensor_ptp_lock_threshold = get_ptp_lock_offset();
+        if (sensor_ptp_lock_threshold != sensor_configuration_->ptp_lock_threshold) {
+          NEBULA_LOG_STREAM(
+            logger_->info, "changing sensor PTP lock offset from "
+                             << static_cast<int>(sensor_ptp_lock_threshold) << " to "
+                             << static_cast<int>(sensor_configuration_->ptp_lock_threshold));
+          set_ptp_lock_offset(sensor_configuration_->ptp_lock_threshold);
+        }
+        break;
       }
+      default:
+        break;
     }
 
     std::this_thread::sleep_for(wait_time);


### PR DESCRIPTION
## PR Type

- Improvement

## Related Links

- [TIER IV INTERNAL LINK](https://star4.slack.com/archives/C076E8EBJTG/p1738827319580859) -- inquiry

## Description

The new datasheets for the XT series also contain the `SET/GET_PTP_LOCK_OFFSET` command, enable it for those sensors.

## Review Procedure

Test whether there is a PTC error thrown when using XT32 on its newest firmware.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
