### PR TITLE
feat(ars548): use new UDP socket

### DIFF
--- a/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_continental/continental_ars548_hw_interface.hpp
+++ b/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_continental/continental_ars548_hw_interface.hpp
@@ -15,7 +15,8 @@
 #ifndef NEBULA_CONTINENTAL_ARS548_HW_INTERFACE_H
 #define NEBULA_CONTINENTAL_ARS548_HW_INTERFACE_H
 
-#include "nebula_hw_interfaces/nebula_hw_interfaces_common/nebula_hw_interface_base.hpp"
+#include "nebula_common/nebula_status.hpp"
+#include "nebula_hw_interfaces/nebula_hw_interfaces_common/connections/udp.hpp"
 
 #include <boost_udp_driver/udp_driver.hpp>
 #include <nebula_common/continental/continental_ars548.hpp>
@@ -145,15 +146,16 @@ private:
 
   /// @brief Callback function to receive the Cloud Packet data from the UDP Driver
   /// @param buffer Buffer containing the data received from the UDP socket
-  void receive_sensor_packet_callback_with_sender(
-    std::vector<uint8_t> & buffer, const std::string & sender_ip);
+  /// @param metadata Metadata of the received packet
+  void receive_sensor_packet_callback(
+    const std::vector<uint8_t> & buffer, const connections::UdpSocket::RxMetadata & metadata);
 
-  /// @brief Callback function to receive the Cloud Packet data from the UDP Driver
-  /// @param buffer Buffer containing the data received from the UDP socket
-  void receive_sensor_packet_callback(std::vector<uint8_t> & buffer);
+  /// @brief Try to send a buffer via UDP and return an error on failure. Never throws.
+  /// @param buffer Buffer to send
+  /// @return Resulting status
+  [[nodiscard]] Status safe_send(const std::vector<uint8_t> & buffer);
 
-  std::unique_ptr<::drivers::common::IoContext> sensor_io_context_ptr_;
-  std::unique_ptr<::drivers::udp_driver::UdpDriver> sensor_udp_driver_ptr_;
+  std::optional<connections::UdpSocket> udp_socket_;
   std::shared_ptr<const ContinentalARS548SensorConfiguration> config_ptr_;
   std::function<void(std::unique_ptr<nebula_msgs::msg::NebulaPacket>)> packet_callback_;
   std::shared_ptr<loggers::Logger> logger_;


### PR DESCRIPTION
## PR Type

- Improvement

## Related Links

- #231 -- introduces the new UDP socket (receive-only)
- #272 -- provides the send functionality needed for this PR

## Description

Introduce the new UDP socket to the ARS548 hardware interface. This 
* allows for accurate ingress timestamping
* will allow us to phase out transport_drivers in the future (#267)

## Review Procedure

Test with a real sensor if all data is sent/received as expected.

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
