### PR TITLE
perf(srr520): remove mtqueue

### DIFF
--- a/nebula_ros/CMakeLists.txt
+++ b/nebula_ros/CMakeLists.txt
@@ -228,7 +228,7 @@ if(BUILD_TESTING)
 
     ament_lint_auto_find_test_dependencies()
 
-    foreach(MODEL Pandar40P Pandar64 PandarQT64 PandarQT128 Pandar128E4X PandarAT128 PandarXT16 PandarXT32 PandarXT32M)
+    foreach(MODEL Pandar40P Pandar64 PandarQT64 PandarQT128 Pandar128E4X PandarAT128 PandarXT16 PandarXT32 PandarXT32M SRR520)
         string(TOLOWER ${MODEL}_smoke_test test_name)
         add_ros_test(
             test/smoke_test.py

--- a/nebula_ros/include/nebula_ros/continental/continental_srr520_ros_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/continental/continental_srr520_ros_wrapper.hpp
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include "nebula_ros/common/mt_queue.hpp"
 #include "nebula_ros/common/parameter_descriptors.hpp"
 #include "nebula_ros/continental/continental_srr520_decoder_wrapper.hpp"
 #include "nebula_ros/continental/continental_srr520_hw_interface_wrapper.hpp"
@@ -78,11 +77,6 @@ private:
 
   std::shared_ptr<const drivers::continental_srr520::ContinentalSRR520SensorConfiguration>
     config_ptr_{};
-
-  /// @brief Stores received packets that have not been processed yet by the decoder thread
-  MtQueue<std::unique_ptr<nebula_msgs::msg::NebulaPacket>> packet_queue_;
-  /// @brief Thread to isolate decoding from receiving
-  std::thread decoder_thread_;
 
   rclcpp::Subscription<nebula_msgs::msg::NebulaPackets>::SharedPtr packets_sub_{};
 

--- a/nebula_ros/src/continental/continental_srr520_ros_wrapper.cpp
+++ b/nebula_ros/src/continental/continental_srr520_ros_wrapper.cpp
@@ -29,10 +29,7 @@ namespace nebula::ros
 ContinentalSRR520RosWrapper::ContinentalSRR520RosWrapper(const rclcpp::NodeOptions & options)
 : rclcpp::Node(
     "continental_srr520_ros_wrapper", rclcpp::NodeOptions(options).use_intra_process_comms(true)),
-  wrapper_status_(Status::NOT_INITIALIZED),
-  packet_queue_(3000),
-  hw_interface_wrapper_(),
-  decoder_wrapper_()
+  wrapper_status_(Status::NOT_INITIALIZED)
 {
   setvbuf(stdout, NULL, _IONBF, BUFSIZ);
 
@@ -54,12 +51,6 @@ ContinentalSRR520RosWrapper::ContinentalSRR520RosWrapper(const rclcpp::NodeOptio
   }
 
   RCLCPP_DEBUG(get_logger(), "Starting stream");
-
-  decoder_thread_ = std::thread([this]() {
-    while (true) {
-      decoder_wrapper_->process_packet(packet_queue_.pop());
-    }
-  });
 
   if (launch_hw_) {
     hw_interface_wrapper_->hw_interface()->register_packet_callback(std::bind(
@@ -147,7 +138,7 @@ void ContinentalSRR520RosWrapper::receive_packets_callback(
     nebula_packet_ptr->stamp = packet.stamp;
     nebula_packet_ptr->data = std::move(packet.data);
 
-    packet_queue_.push(std::move(nebula_packet_ptr));
+    decoder_wrapper_->process_packet(std::move(nebula_packet_ptr));
   }
 }
 
@@ -158,9 +149,7 @@ void ContinentalSRR520RosWrapper::receive_packet_callback(
     return;
   }
 
-  if (!packet_queue_.try_push(std::move(msg_ptr))) {
-    RCLCPP_ERROR_THROTTLE(get_logger(), *get_clock(), 500, "Packet(s) dropped");
-  }
+  decoder_wrapper_->process_packet(std::move(msg_ptr));
 }
 
 Status ContinentalSRR520RosWrapper::get_status()


### PR DESCRIPTION
## PR Type

- Improvement
- Bug fix

## Related Links

- #226 -- Hesai for reference
- #240 -- smoke tests for reference

## Description

Does what the title says.

Reasons for this change:
* The multithreaded queue is not needed (receive buffers in the network stack take care of arriving data while decoding).
* The decoder thread had no mechanism for gracefully stopping, thus causing an exception on exit
* The above excption caused our smoke tests to fail

## Review Procedure

* Compare to the linked Hesai reference PR #226
* Test with `launch_hw:=false` and a rosbag
* Test with `launch_hw:=true` and a real sensor or pcap

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
