### PR TITLE
perf(robosense): remove mtqueue

### DIFF
--- a/nebula_ros/CMakeLists.txt
+++ b/nebula_ros/CMakeLists.txt
@@ -228,7 +228,7 @@ if(BUILD_TESTING)
 
     ament_lint_auto_find_test_dependencies()
 
-    foreach(MODEL Pandar40P Pandar64 PandarQT64 PandarQT128 Pandar128E4X PandarAT128 PandarXT16 PandarXT32 PandarXT32M)
+    foreach(MODEL Pandar40P Pandar64 PandarQT64 PandarQT128 Pandar128E4X PandarAT128 PandarXT16 PandarXT32 PandarXT32M Helios Bpearl)
         string(TOLOWER ${MODEL}_smoke_test test_name)
         add_ros_test(
             test/smoke_test.py

--- a/nebula_ros/include/nebula_ros/robosense/robosense_ros_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/robosense/robosense_ros_wrapper.hpp
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include "nebula_ros/common/mt_queue.hpp"
 #include "nebula_ros/robosense/decoder_wrapper.hpp"
 #include "nebula_ros/robosense/hw_interface_wrapper.hpp"
 #include "nebula_ros/robosense/hw_monitor_wrapper.hpp"
@@ -83,11 +82,6 @@ private:
   nebula::Status wrapper_status_;
 
   std::shared_ptr<const nebula::drivers::RobosenseSensorConfiguration> sensor_cfg_ptr_;
-
-  /// @brief Stores received packets that have not been processed yet by the decoder thread
-  MtQueue<std::unique_ptr<nebula_msgs::msg::NebulaPacket>> packet_queue_;
-  /// @brief Thread to isolate decoding from receiving
-  std::thread decoder_thread_;
 
   rclcpp::Publisher<robosense_msgs::msg::RobosenseInfoPacket>::SharedPtr info_packets_pub_;
 

--- a/nebula_ros/test/smoke_test.py
+++ b/nebula_ros/test/smoke_test.py
@@ -37,7 +37,7 @@ def generate_test_description():
 class TestCorrectStartup(unittest.TestCase):
     def test_wait_for_startup_then_shutdown(self):
         self.proc_output: launch_testing.ActiveIoHandler
-        self.proc_output.assertWaitFor("Wrapper=OK", timeout=2)
+        self.proc_output.assertWaitFor("Hardware connection disabled", timeout=2)
 
 
 @launch_testing.post_shutdown_test()


### PR DESCRIPTION
## PR Type

- Improvement
- Bug fix

## Related Links

- #226 -- Hesai for reference
- #240 -- smoke tests for reference

## Description

Does what the title says.

Reasons for this change:
* The multithreaded queue is not needed (receive buffers in the network stack take care of arriving data while decoding).
* The decoder thread had no mechanism for gracefully stopping, thus causing an exception on exit
* The above excption caused our smoke tests to fail

## Review Procedure

* Compare to the linked Hesai reference PR #226
* Test with `launch_hw:=false` and a rosbag
* Test with `launch_hw:=true` and a real sensor or pcap

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
