### PR TITLE
fix(velodyne): remove heavy get_snapshot from HW monitor

### DIFF
--- a/nebula_ros/include/nebula_ros/velodyne/hw_monitor_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/velodyne/hw_monitor_wrapper.hpp
@@ -54,9 +54,6 @@ private:
   /// @brief Callback of the timer for getting the current lidar status
   void on_velodyne_status_timer();
 
-  /// @brief Callback of the timer for getting the current lidar snapshot
-  void on_velodyne_snapshot_timer();
-
   /// @brief Callback of the timer for getting the current lidar status & updating the diagnostics
   void on_velodyne_diagnostics_timer();
 
@@ -250,10 +247,6 @@ private:
   /// @param diagnostics DiagnosticStatusWrapper
   void velodyne_check_laser_state(diagnostic_updater::DiagnosticStatusWrapper & diagnostics);
 
-  /// @brief Check the current snapshot for diagnostic_updater
-  /// @param diagnostics DiagnosticStatusWrapper
-  void velodyne_check_snapshot(diagnostic_updater::DiagnosticStatusWrapper & diagnostics);
-
   /// @brief Check the current states of motor & laser for diagnostic_updater
   /// @param diagnostics DiagnosticStatusWrapper
   void velodyne_check_status(diagnostic_updater::DiagnosticStatusWrapper & diagnostics);
@@ -282,17 +275,11 @@ private:
   uint16_t diag_span_;
   bool show_advanced_diagnostics_;
 
-  rclcpp::TimerBase::SharedPtr diagnostics_snapshot_timer_;
   rclcpp::TimerBase::SharedPtr diagnostics_update_timer_;
   rclcpp::TimerBase::SharedPtr diagnostics_diag_timer_;
 
-  std::shared_ptr<std::string> current_snapshot_;
-  std::shared_ptr<boost::property_tree::ptree> current_snapshot_tree_;
   std::shared_ptr<boost::property_tree::ptree> current_diag_tree_;
-  std::shared_ptr<rclcpp::Time> current_snapshot_time_;
-  uint8_t current_diag_status_;
 
-  std::mutex mtx_snapshot_;
   std::mutex mtx_status_;
   std::mutex mtx_diag_;
 

--- a/nebula_ros/src/velodyne/hw_monitor_wrapper.cpp
+++ b/nebula_ros/src/velodyne/hw_monitor_wrapper.cpp
@@ -30,18 +30,19 @@ VelodyneHwMonitorWrapper::VelodyneHwMonitorWrapper(
   std::cout << "Get model name and serial." << std::endl;
   auto str = hw_interface_->get_snapshot();
   if (!str.has_value()) return;
-  current_snapshot_time_.reset(new rclcpp::Time(parent_node_->now()));
-  current_snapshot_tree_ =
+
+  auto snapshot_tree =
     std::make_shared<boost::property_tree::ptree>(hw_interface_->parse_json(str.value()));
   current_diag_tree_ =
-    std::make_shared<boost::property_tree::ptree>(current_snapshot_tree_->get_child("diag"));
+    std::make_shared<boost::property_tree::ptree>(snapshot_tree->get_child("diag"));
   current_status_tree_ =
-    std::make_shared<boost::property_tree::ptree>(current_snapshot_tree_->get_child("status"));
-  current_snapshot_.reset(new std::string(str.value()));
+    std::make_shared<boost::property_tree::ptree>(snapshot_tree->get_child("status"));
 
   try {
-    info_model_ = get_ptree_value(current_snapshot_tree_, mtx_snapshot_, key_info_model);
-    info_serial_ = get_ptree_value(current_snapshot_tree_, mtx_snapshot_, key_info_serial);
+    // get_ptree_value requires a mutex but we are only accessing a local variable
+    std::mutex dummy_mtx;
+    info_model_ = get_ptree_value(snapshot_tree, dummy_mtx, key_info_model);
+    info_serial_ = get_ptree_value(snapshot_tree, dummy_mtx, key_info_serial);
     RCLCPP_INFO_STREAM(logger_, "Model: " << info_model_);
     RCLCPP_INFO_STREAM(logger_, "Serial: " << info_serial_);
   } catch (boost::bad_lexical_cast & ex) {
@@ -62,10 +63,6 @@ void VelodyneHwMonitorWrapper::initialize_velodyne_diagnostics()
   RCLCPP_INFO_STREAM(logger_, "Hardware ID: " << hardware_id);
 
   if (show_advanced_diagnostics_) {
-    diagnostics_updater_.add(
-      "velodyne_snapshot-" + sensor_configuration_->frame_id, this,
-      &VelodyneHwMonitorWrapper::velodyne_check_snapshot);
-
     diagnostics_updater_.add(
       "velodyne_volt_temp_top_hv-" + sensor_configuration_->frame_id, this,
       &VelodyneHwMonitorWrapper::velodyne_check_top_hv);
@@ -164,55 +161,8 @@ void VelodyneHwMonitorWrapper::initialize_velodyne_diagnostics()
   diagnostics_updater_.add(
     "velodyne_voltage", this, &VelodyneHwMonitorWrapper::velodyne_check_voltage);
 
-  {
-    std::lock_guard lock(mtx_snapshot_);
-    current_snapshot_.reset(new std::string(""));
-    current_snapshot_time_.reset(new rclcpp::Time(parent_node_->now()));
-  }
-
-  current_diag_status_ = diagnostic_msgs::msg::DiagnosticStatus::STALE;
-
-  auto on_timer_snapshot = [this] { on_velodyne_snapshot_timer(); };
-  diagnostics_snapshot_timer_ = parent_node_->create_wall_timer(
-    std::chrono::milliseconds(diag_span_), std::move(on_timer_snapshot));
-
-  auto on_timer_update = [this] {
-    auto now = parent_node_->now();
-    double dif;
-    {
-      std::lock_guard lock(mtx_snapshot_);
-      dif = (now - *current_snapshot_time_).seconds();
-    }
-    if (diag_span_ * 2.0 < dif * 1000) {
-      current_diag_status_ = diagnostic_msgs::msg::DiagnosticStatus::STALE;
-      RCLCPP_DEBUG_STREAM(logger_, "STALE");
-    } else {
-      current_diag_status_ = diagnostic_msgs::msg::DiagnosticStatus::OK;
-      RCLCPP_DEBUG_STREAM(logger_, "OK");
-    }
-    diagnostics_updater_.force_update();
-  };
-  diagnostics_update_timer_ =
-    parent_node_->create_wall_timer(std::chrono::milliseconds(1000), std::move(on_timer_update));
-}
-
-void VelodyneHwMonitorWrapper::on_velodyne_snapshot_timer()
-{
-  auto str = hw_interface_->get_snapshot();
-  if (!str.has_value()) return;
-  auto ptree = hw_interface_->parse_json(str.value());
-
-  {
-    std::lock_guard lock(mtx_snapshot_);
-
-    current_snapshot_time_.reset(new rclcpp::Time(parent_node_->now()));
-    current_snapshot_tree_ = std::make_shared<boost::property_tree::ptree>(ptree);
-    current_diag_tree_ =
-      std::make_shared<boost::property_tree::ptree>(current_snapshot_tree_->get_child("diag"));
-    current_status_tree_ =
-      std::make_shared<boost::property_tree::ptree>(current_snapshot_tree_->get_child("status"));
-    current_snapshot_.reset(new std::string(str.value()));
-  }
+  diagnostics_update_timer_ = parent_node_->create_wall_timer(
+    std::chrono::milliseconds(1000), [this] { diagnostics_updater_.force_update(); });
 }
 
 void VelodyneHwMonitorWrapper::on_velodyne_diagnostics_timer()
@@ -1236,14 +1186,6 @@ void VelodyneHwMonitorWrapper::velodyne_check_laser_state(
     diagnostics.add("sensor", sensor_configuration_->frame_id);
     diagnostics.summary(std::get<1>(tpl), std::get<2>(tpl));
   }
-}
-
-void VelodyneHwMonitorWrapper::velodyne_check_snapshot(
-  diagnostic_updater::DiagnosticStatusWrapper & diagnostics)
-{
-  uint8_t level = current_diag_status_;
-  diagnostics.add("sensor", sensor_configuration_->frame_id);
-  diagnostics.summary(level, *current_snapshot_);
 }
 
 void VelodyneHwMonitorWrapper::velodyne_check_status(

--- a/nebula_ros/src/velodyne/hw_monitor_wrapper.cpp
+++ b/nebula_ros/src/velodyne/hw_monitor_wrapper.cpp
@@ -161,8 +161,7 @@ void VelodyneHwMonitorWrapper::initialize_velodyne_diagnostics()
   diagnostics_updater_.add(
     "velodyne_voltage", this, &VelodyneHwMonitorWrapper::velodyne_check_voltage);
 
-  diagnostics_update_timer_ = parent_node_->create_wall_timer(
-    std::chrono::milliseconds(1000), [this] { diagnostics_updater_.force_update(); });
+  diagnostics_updater_.setPeriod(1.0);
 }
 
 void VelodyneHwMonitorWrapper::on_velodyne_diagnostics_timer()


### PR DESCRIPTION
## PR Type

- Bug Fix

## Related Links

- [TIER IV INTERNAL](https://star4.slack.com/archives/C076E8EBJTG/p1739770915233339) -- the reported issue

## Description

The `/cgi/snapshot.hdl` endpoint of the sensor is not meant to be polled every second. Doing that causes the sensor to sometimes drop communication for a while (see the linked issue above).

This hotfix removes the timer polling `get_snapshot` and the related, now unused code.
As far as I can tell, marking diag info stale did not work reliably before (updates from `get_diag` and `get_status` were ignored, and will not work at all now.
All diag information will still be output as before.

## Review Procedure

Test with a real VLP16, VLP32 and VLS128 and compare before/after, especially with advanced diag enabled.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
