### PR TITLE
chore(ars548): change config for default IP to match the factory default

### DIFF
--- a/nebula_ros/config/radar/continental/ARS548.param.yaml
+++ b/nebula_ros/config/radar/continental/ARS548.param.yaml
@@ -1,7 +1,7 @@
 /**:
   ros__parameters:
     host_ip: 10.13.1.166
-    sensor_ip: 10.13.1.114
+    sensor_ip: 10.13.1.113
     data_port: 42102
     frame_id: continental
     base_frame: base_link


### PR DESCRIPTION
## PR Type

- Improvement

## Related Links

- [TIER IV INTERNAL](https://star4.slack.com/archives/C076E8EBJTG/p1740449556909039)

## Description

The factory default sensor IP ends in `.113` but Nebula's default was `.114`, which is confusing for users and doesn't make for a good out-of-the-box experience. Fixed in this PR.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
