### PR TITLE
refactor(velodyne): remove unused private variables from HW monitor

### DIFF
--- a/nebula_ros/include/nebula_ros/velodyne/hw_monitor_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/velodyne/hw_monitor_wrapper.hpp
@@ -274,7 +274,6 @@ private:
   uint16_t diag_span_;
   bool show_advanced_diagnostics_;
 
-
   std::shared_ptr<boost::property_tree::ptree> current_diag_tree_;
 
   std::mutex mtx_status_;

--- a/nebula_ros/include/nebula_ros/velodyne/hw_monitor_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/velodyne/hw_monitor_wrapper.hpp
@@ -265,7 +265,6 @@ private:
 
   rclcpp::Logger logger_;
   diagnostic_updater::Updater diagnostics_updater_;
-  nebula::Status status_;
 
   const std::shared_ptr<nebula::drivers::VelodyneHwInterface> hw_interface_;
   rclcpp::Node * const parent_node_;
@@ -275,8 +274,6 @@ private:
   uint16_t diag_span_;
   bool show_advanced_diagnostics_;
 
-  rclcpp::TimerBase::SharedPtr diagnostics_update_timer_;
-  rclcpp::TimerBase::SharedPtr diagnostics_diag_timer_;
 
   std::shared_ptr<boost::property_tree::ptree> current_diag_tree_;
 

--- a/nebula_ros/src/velodyne/hw_monitor_wrapper.cpp
+++ b/nebula_ros/src/velodyne/hw_monitor_wrapper.cpp
@@ -19,7 +19,6 @@ VelodyneHwMonitorWrapper::VelodyneHwMonitorWrapper(
 : logger_(parent_node->get_logger().get_child("HwMonitor")),
   diagnostics_updater_(
     (parent_node->declare_parameter<bool>("diagnostic_updater.use_fqn", true), parent_node)),
-  status_(Status::OK),
   hw_interface_(hw_interface),
   parent_node_(parent_node),
   sensor_configuration_(config)


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Refactor

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->
https://github.com/tier4/nebula/pull/279

## Description

<!-- Describe what this PR changes. -->
Some private variables in the Velodyne hardware monitor class were not being used. 
Therefore, these variables have been removed.

## Review Procedure

<!-- Explain how to review this PR. -->
Please verify that the `nebula_ros` package compiles successfully using the following command:
```bash
colcon build --packages-up-to nebula_ros
```

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [x] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [x] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
