### PR TITLE
fix(ot128): introduce anti-flicker downsample dithering pattern

### DIFF
--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_common/point_filters/downsample_mask.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_common/point_filters/downsample_mask.hpp
@@ -27,6 +27,7 @@
 #include <Eigen/src/Core/Matrix.h>
 #include <sys/types.h>
 
+#include <algorithm>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/hesai_decoder.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/hesai_decoder.hpp
@@ -274,7 +274,7 @@ public:
       mask_filter_ = point_filters::DownsampleMaskFilter(
         sensor_configuration->downsample_mask_path.value(), SensorT::fov_mdeg.azimuth,
         SensorT::peak_resolution_mdeg.azimuth, SensorT::packet_t::n_channels,
-        logger_->child("Downsample Mask"), true);
+        logger_->child("Downsample Mask"), true, sensor_.get_dither_transform());
     }
 
     decode_pc_->reserve(SensorT::max_scan_buffer_points);

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/hesai_sensor.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/hesai_sensor.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "nebula_decoders/nebula_decoders_common/point_filters/downsample_mask.hpp"
 #include "nebula_decoders/nebula_decoders_hesai/decoders/angle_corrector_calibration_based.hpp"
 #include "nebula_decoders/nebula_decoders_hesai/decoders/angle_corrector_correction_based.hpp"
 #include "nebula_decoders/nebula_decoders_hesai/decoders/hesai_packet.hpp"
@@ -188,6 +189,11 @@ public:
       default:
         return ReturnType::UNKNOWN;
     }
+  }
+
+  [[nodiscard]] virtual point_filters::DitherTransform get_dither_transform() const
+  {
+    return point_filters::g_default_dither_transform;
   }
 };
 

--- a/nebula_decoders/tests/point_filters/test_downsample_mask.cpp
+++ b/nebula_decoders/tests/point_filters/test_downsample_mask.cpp
@@ -43,6 +43,7 @@ static std::filesystem::path downsample_mask_path()
 
 TEST(TestDownsampleMask, TestDithering)
 {
+  using nebula::drivers::point_filters::g_default_dither_transform;
   using nebula::drivers::point_filters::impl::dither;
 
   size_t quantization_levels = 10;
@@ -57,7 +58,7 @@ TEST(TestDownsampleMask, TestDithering)
 
     png::image<png::gray_pixel> in{image_path};
     png::image<png::gray_pixel> out{in.get_width(), in.get_height()};
-    dither(in, out, quantization_levels);
+    dither(in, out, quantization_levels, g_default_dither_transform);
 
     size_t n_kept = 0;
     for (size_t x = 0; x < w; ++x) {
@@ -84,6 +85,7 @@ TEST(TestDownsampleMask, TestFilter)
   using nebula::drivers::NebulaPoint;
   using nebula::drivers::loggers::ConsoleLogger;
   using nebula::drivers::point_filters::DownsampleMaskFilter;
+  using nebula::drivers::point_filters::g_default_dither_transform;
 
   auto logger = std::make_shared<ConsoleLogger>("TestFilter");
   auto image_path = downsample_mask_path() / ("q50.png");
@@ -91,7 +93,9 @@ TEST(TestDownsampleMask, TestFilter)
   uint16_t azi_step_mdeg = 1;
   uint8_t n_channels = 10;
 
-  DownsampleMaskFilter f{image_path.native(), azi_range_mdeg, azi_step_mdeg, n_channels, logger};
+  DownsampleMaskFilter f{
+    image_path.native(),       azi_range_mdeg, azi_step_mdeg, n_channels, logger, false,
+    g_default_dither_transform};
 
   size_t n_kept = 0;
   int32_t azi_kept_min = std::numeric_limits<int32_t>::max();


### PR DESCRIPTION
## PR Type

- Improvement

## Related Links

- #251 -- introduced mask based pruning filter

## Description

:warning: The below use cases are **not** affected by the flickering issue (already working fine):
* masks converted from #182
* black-and-white masks
* OT128 in standard/non-high-resolution mode
* other sensors

While the mask based pruning filter introduced in #251 works well for all supported Hesai sensors, including OT128 in standard mode, OT128's high resolution mode employs a dithering pattern that interferes with the pruning filter's one.

This results in flicker and could degrade perception performance etc.
This PR extends the `DownsampleMaskFilter` by allowing sensors to specify a transform function for azimuth/channel coordinates passed to the dithering algorithm. This allows the developer to include knowledge about the sensor's dithering/scan pattern into the mask dithering step.
All sensors except OT128 are using the default transform, as before, with only OT128 using a specialized one.

For details on how OT128 dithers, see the chapter _B.4. Laser firing time of each channel_ of the [OT128 User Manual](https://www.hesaitech.com/wp-content/uploads/2025/03/OT128_User_Manual_O01-en-250310.pdf).

Basically, the pattern is repeating every 2 blocks x 4 channels, so the specialized transform ensures that the points that change within one tile are mapped to the same index for dithering.

### :green_circle: Evaluation

#### Filter disabled (unaffected by this PR)
The dithering pattern causes some oscillating points but the image is overall stable.

https://github.com/user-attachments/assets/9375efdc-9084-4331-a940-005df1778b19 
#### Filter enabled, before fix 
The interference between sensor dithering and downsample filter causes strong flickering.

https://github.com/user-attachments/assets/b005ad64-b256-4d39-bdb2-01c81930b2e2 
#### Filter enabled, after fix 
The specialized dithering pattern plays well with the sensor dithering.
Osillations are more noticeable than in the disabled case due to there being larger gaps between points.
The actual oscillation amplitude is the same.

https://github.com/user-attachments/assets/107d2bc2-ffbb-4432-9367-f1caef1e9402 

## Review Procedure

* Code review
* Compare implementation with datasheet
* Test with downsample mask (different downsample factors or gradients)

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
