### PR TITLE
Hot fix for VLP16 timestamp

### DIFF
--- a/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
+++ b/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
@@ -167,21 +167,44 @@ VelodyneStatus VelodyneHwInterface::check_and_set_config(
               << std::endl;
   }
 
+  int setting_cloud_min_angle = sensor_configuration->cloud_min_angle;
+  int setting_cloud_max_angle = sensor_configuration->cloud_max_angle;
+
+  // FIXME: VLP16 has problems for timestamp. Whatch github issue #
+  if (sensor_configuration->sensor_model == SensorModel::VELODYNE_VLP16) {
+    int angle_diff = (setting_cloud_max_angle - setting_cloud_min_angle + 360) % 360;
+
+    if (angle_diff >= 360 || angle_diff == 0) {
+      setting_cloud_min_angle = 0;
+      setting_cloud_max_angle = 359;
+    } else {
+      if (setting_cloud_min_angle < 5) {
+        setting_cloud_min_angle = (setting_cloud_min_angle + 355) % 360;
+      } else {
+        setting_cloud_min_angle -= 5;
+      }
+
+      if (setting_cloud_max_angle > 354) {
+        setting_cloud_max_angle = 359;
+      } else {
+        setting_cloud_max_angle += 5;
+        if (setting_cloud_max_angle >= 360) {
+          setting_cloud_max_angle = 359;
+        }
+      }
+    }
+
+  } else {
+    if (setting_cloud_min_angle == 360) {
+      setting_cloud_min_angle = 359;
+    }
+    if (setting_cloud_max_angle == 360) {
+      setting_cloud_max_angle = 359;
+    }
+  }
+
   target_key = "config.fov.start";
   auto current_cloud_min_angle = tree.get<std::uint16_t>(target_key);
-  int setting_cloud_min_angle = sensor_configuration->cloud_min_angle;
-  // // FIXME
-  // if (sensor_configuration->sensor_model == SensorModel::VELODYNE_VLP16) {
-  //   if (setting_cloud_min_angle < 5){
-  //     setting_cloud_min_angle = setting_cloud_min_angle + 360 - 5;
-  //   }else{
-  //     setting_cloud_min_angle -= 5;
-  //   }
-  // }
-  // Velodyne only allows a maximum of 359 in the setting
-  if (setting_cloud_min_angle == 360) {
-    setting_cloud_min_angle = 359;
-  }
   if (setting_cloud_min_angle != current_cloud_min_angle) {
     status = set_fov_start(setting_cloud_min_angle);
     if (status != ok) return status;
@@ -193,21 +216,6 @@ VelodyneStatus VelodyneHwInterface::check_and_set_config(
 
   target_key = "config.fov.end";
   auto current_cloud_max_angle = tree.get<std::uint16_t>(target_key);
-  int setting_cloud_max_angle = sensor_configuration->cloud_max_angle;
-  // FIXME
-  if (sensor_configuration->sensor_model == SensorModel::VELODYNE_VLP16) {
-    if (setting_cloud_max_angle > 354){
-      setting_cloud_max_angle = 360;
-    }else{
-      std::cout << "setting_cloud_max_angle: " << setting_cloud_max_angle << std::endl;
-      setting_cloud_max_angle += 5;
-      std::cout << "setting_cloud_max_angle: " << setting_cloud_max_angle << std::endl;
-    }
-  }
-  // Velodyne only allows a maximum of 359 in the setting
-  if (setting_cloud_max_angle == 360) {
-    setting_cloud_max_angle = 359;
-  }
   if (setting_cloud_max_angle != current_cloud_max_angle) {
     status = set_fov_end(setting_cloud_max_angle);
     if (status != ok) return status;

--- a/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
+++ b/nebula_hw_interfaces/src/nebula_velodyne_hw_interfaces/velodyne_hw_interface.cpp
@@ -170,6 +170,14 @@ VelodyneStatus VelodyneHwInterface::check_and_set_config(
   target_key = "config.fov.start";
   auto current_cloud_min_angle = tree.get<std::uint16_t>(target_key);
   int setting_cloud_min_angle = sensor_configuration->cloud_min_angle;
+  // // FIXME
+  // if (sensor_configuration->sensor_model == SensorModel::VELODYNE_VLP16) {
+  //   if (setting_cloud_min_angle < 5){
+  //     setting_cloud_min_angle = setting_cloud_min_angle + 360 - 5;
+  //   }else{
+  //     setting_cloud_min_angle -= 5;
+  //   }
+  // }
   // Velodyne only allows a maximum of 359 in the setting
   if (setting_cloud_min_angle == 360) {
     setting_cloud_min_angle = 359;
@@ -186,6 +194,16 @@ VelodyneStatus VelodyneHwInterface::check_and_set_config(
   target_key = "config.fov.end";
   auto current_cloud_max_angle = tree.get<std::uint16_t>(target_key);
   int setting_cloud_max_angle = sensor_configuration->cloud_max_angle;
+  // FIXME
+  if (sensor_configuration->sensor_model == SensorModel::VELODYNE_VLP16) {
+    if (setting_cloud_max_angle > 354){
+      setting_cloud_max_angle = 360;
+    }else{
+      std::cout << "setting_cloud_max_angle: " << setting_cloud_max_angle << std::endl;
+      setting_cloud_max_angle += 5;
+      std::cout << "setting_cloud_max_angle: " << setting_cloud_max_angle << std::endl;
+    }
+  }
   // Velodyne only allows a maximum of 359 in the setting
   if (setting_cloud_max_angle == 360) {
     setting_cloud_max_angle = 359;


### PR DESCRIPTION
## PR Type

Only vlp16 has problems for timestamp. In this PR, hot fix is created for this.

- Bug Fix

## Related Links
[VLP16 timestamp problem report
](https://tier4.atlassian.net/wiki/spaces/CT/pages/3607168528/VLP16+timestamp+problem+report?force_transition=7657d3d6-104a-4f92-8d0c-67bddab81400)

## Description

Only VLP16 has problems for timestamps in poincloud from nebula, **Last Filtered Pointcloud timestamp problem**.
When vlp16 pointcloud is filtered through nebula, last pointcloud timestamp is weird sometime. We research about this problem but we can't discover the cause of this clearly. 
But we Discover that VLP16 pointcloud timestamps are weird when it is filtered by hardware.
It's fine when VLP16 pointcloud are filtered by only nebula.

From this discovery, we decide that we create hardware filter offset as hot fix for this problem.

## Review Procedure


## Remarks


## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
