### PR TITLE
chore(docs): ensure word breaks in long paths/URLs so that tables don't overflow

### DIFF
--- a/mkdocs_macros.py
+++ b/mkdocs_macros.py
@@ -18,6 +18,14 @@ def format_param_type(param_type):
         return param_type
 
 
+def ensure_word_breaks(text):
+    """For URLs/paths, insert HTML word break marks. Does not affect other or non-string inputs."""
+    if not isinstance(text, str):
+        return text
+
+    return text.replace("/", "/<wbr>")
+
+
 def format_param_range(param):
     list_of_range = []
     if "enum" in param.keys():
@@ -90,7 +98,7 @@ def extract_parameter_info(
             param["Name"] = namespace + k
             param["Type"] = format_param_type(v["type"])
             param["Description"] = v.get("description", "")
-            param["Default"] = v.get("default", "")
+            param["Default"] = ensure_word_breaks(v.get("default", ""))
             param["Range"] = format_param_range(v)
             params.append(param)
         else:  # if the object is namespace, then dive deeper in to json value


### PR DESCRIPTION
## PR Type

- Improvement

## Description

Markdown tables generated from parameter schemas were overflowing due to parameter defaults like `$(find-pkg-share nebula_decoders)/calibration/hesai/$(var sensor_model).csv` which don't have any word breaks.

While the parameters cannot really be changed/shortened, this PR introduces an improvement to the `json_to_markdown` macro which adds [HTML `<wbr>` (line break opportunity) tags](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr) after all `/`es in default parameters. If a parameter value is short enough to fit, this does not have any effect. For longer paths like the one above, line breaks can be added by the browser at those `<wbr>` marks, causing the table to render correctly.

| Before | After |
|-|-|
| ![Screenshot from 2025-04-10 12-00-26](https://github.com/user-attachments/assets/1b3ac8f4-67fb-4348-bd32-9941020af5ce) | ![Screenshot from 2025-04-10 12-00-52](https://github.com/user-attachments/assets/ecf1d946-ba1a-41be-9cb5-1863733dd90b) |

## Review Procedure

<!-- Explain how to review this PR. -->

* confirm the tables at https://tier4.github.io/nebula/parameters/vendors/hesai/ot128/ are broken for you
* build and view docs locally with `mkdocs serve` and see whether the issue is fixed

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
