### PR TITLE
refactor(nebula_hw_interfaces): use nebula logger everywhere

### DIFF
--- a/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_continental/continental_ars548_hw_interface.hpp
+++ b/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_continental/continental_ars548_hw_interface.hpp
@@ -19,7 +19,7 @@
 
 #include <boost_udp_driver/udp_driver.hpp>
 #include <nebula_common/continental/continental_ars548.hpp>
-#include <rclcpp/rclcpp.hpp>
+#include <nebula_common/loggers/logger.hpp>
 
 #include <nebula_msgs/msg/nebula_packet.hpp>
 
@@ -34,7 +34,7 @@ class ContinentalARS548HwInterface
 {
 public:
   /// @brief Constructor
-  ContinentalARS548HwInterface();
+  explicit ContinentalARS548HwInterface(const std::shared_ptr<loggers::Logger> & logger);
 
   /// @brief Starting the interface that handles UDP streams
   /// @return Resulting status
@@ -130,10 +130,6 @@ public:
   /// @return Resulting status
   Status set_yaw_rate(float yaw_rate);
 
-  /// @brief Setting rclcpp::Logger
-  /// @param node Logger
-  void set_logger(std::shared_ptr<rclcpp::Logger> node);
-
 private:
   /// @brief Printing the string to RCLCPP_INFO_STREAM
   /// @param info Target string
@@ -160,8 +156,7 @@ private:
   std::unique_ptr<::drivers::udp_driver::UdpDriver> sensor_udp_driver_ptr_;
   std::shared_ptr<const ContinentalARS548SensorConfiguration> config_ptr_;
   std::function<void(std::unique_ptr<nebula_msgs::msg::NebulaPacket>)> packet_callback_;
-
-  std::shared_ptr<rclcpp::Logger> parent_node_logger_ptr_;
+  std::shared_ptr<loggers::Logger> logger_;
 };
 }  // namespace nebula::drivers::continental_ars548
 

--- a/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_continental/continental_srr520_hw_interface.hpp
+++ b/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_continental/continental_srr520_hw_interface.hpp
@@ -18,7 +18,7 @@
 #include "nebula_hw_interfaces/nebula_hw_interfaces_common/nebula_hw_interface_base.hpp"
 
 #include <nebula_common/continental/continental_srr520.hpp>
-#include <rclcpp/rclcpp.hpp>
+#include <nebula_common/loggers/logger.hpp>
 #include <ros2_socketcan/socket_can_receiver.hpp>
 #include <ros2_socketcan/socket_can_sender.hpp>
 
@@ -28,6 +28,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <thread>
 #include <vector>
 
 namespace nebula::drivers::continental_srr520
@@ -37,7 +38,7 @@ class ContinentalSRR520HwInterface
 {
 public:
   /// @brief Constructor
-  ContinentalSRR520HwInterface();
+  explicit ContinentalSRR520HwInterface(const std::shared_ptr<loggers::Logger> & logger);
 
   /// @brief Starting the interface that handles UDP streams
   /// @return Resulting status
@@ -95,10 +96,6 @@ public:
     float longitudinal_acceleration, float lateral_acceleration, float yaw_rate,
     float longitudinal_velocity, bool standstill);
 
-  /// @brief Setting rclcpp::Logger
-  /// @param node Logger
-  void set_logger(std::shared_ptr<rclcpp::Logger> node);
-
 private:
   /// @brief Send a Fd frame
   /// @param data a buffer containing the data to send
@@ -135,7 +132,7 @@ private:
   bool sync_follow_up_sent_{true};
   builtin_interfaces::msg::Time last_sync_stamp_;
 
-  std::shared_ptr<rclcpp::Logger> parent_node_logger_ptr_;
+  std::shared_ptr<loggers::Logger> logger_;
 };
 }  // namespace nebula::drivers::continental_srr520
 

--- a/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_robosense/robosense_hw_interface.hpp
+++ b/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_robosense/robosense_hw_interface.hpp
@@ -26,8 +26,8 @@
 #endif
 
 #include <boost_udp_driver/udp_driver.hpp>
+#include <nebula_common/loggers/logger.hpp>
 #include <nebula_common/robosense/robosense_common.hpp>
-#include <rclcpp/rclcpp.hpp>
 
 #include <memory>
 #include <string>
@@ -54,19 +54,11 @@ private:
     scan_reception_callback_; /**This function pointer is called when the scan is complete*/
   std::function<void(std::vector<uint8_t> & buffer)>
     info_reception_callback_; /**This function pointer is called when DIFOP packet is received*/
-  std::shared_ptr<rclcpp::Logger> parent_node_logger_;
-
-  /// @brief Printing the string to RCLCPP_INFO_STREAM
-  /// @param info Target string
-  void print_info(std::string info);
-
-  /// @brief Printing the string to RCLCPP_DEBUG_STREAM
-  /// @param debug Target string
-  void print_debug(std::string debug);
+  std::shared_ptr<loggers::Logger> logger_;
 
 public:
   /// @brief Constructor
-  RobosenseHwInterface();
+  explicit RobosenseHwInterface(const std::shared_ptr<loggers::Logger> & logger);
 
   /// @brief Callback function to receive the Cloud Packet data from the UDP Driver
   /// @param buffer Buffer containing the data received from the UDP socket
@@ -99,10 +91,6 @@ public:
   /// @param scan_callback Callback function
   /// @return Resulting status
   Status register_info_callback(std::function<void(std::vector<uint8_t> &)> info_callback);
-
-  /// @brief Setting rclcpp::Logger
-  /// @param node Logger
-  void set_logger(std::shared_ptr<rclcpp::Logger> logger);
 };
 
 }  // namespace nebula::drivers

--- a/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_velodyne/velodyne_hw_interface.hpp
+++ b/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_velodyne/velodyne_hw_interface.hpp
@@ -31,15 +31,17 @@
 
 #include <boost_tcp_driver/http_client_driver.hpp>
 #include <boost_udp_driver/udp_driver.hpp>
+#include <nebula_common/loggers/logger.hpp>
 #include <nebula_common/velodyne/velodyne_common.hpp>
 #include <nebula_common/velodyne/velodyne_status.hpp>
-#include <rclcpp/rclcpp.hpp>
 
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 
+#include <chrono>
 #include <memory>
 #include <string>
+#include <thread>
 #include <vector>
 
 namespace nebula::drivers
@@ -136,20 +138,13 @@ private:
     std::shared_ptr<const VelodyneSensorConfiguration> sensor_configuration,
     boost::property_tree::ptree tree);
 
-  std::shared_ptr<rclcpp::Logger> parent_node_logger_;
-  /// @brief Printing the string to RCLCPP_INFO_STREAM
-  /// @param info Target string
-  void print_info(std::string info);
-  /// @brief Printing the string to RCLCPP_ERROR_STREAM
-  /// @param error Target string
-  void print_error(std::string error);
-  /// @brief Printing the string to RCLCPP_DEBUG_STREAM
-  /// @param debug Target string
-  void print_debug(std::string debug);
+  std::shared_ptr<loggers::Logger> logger_;
 
 public:
   /// @brief Constructor
-  VelodyneHwInterface();
+  explicit VelodyneHwInterface(const std::shared_ptr<loggers::Logger> & logger);
+
+  virtual ~VelodyneHwInterface() = default;
 
   /// @brief Callback function to receive the Cloud Packet data from the UDP Driver
   /// @param buffer Buffer containing the data received from the UDP socket
@@ -261,12 +256,7 @@ public:
   /// @param use_dhcp DHCP on
   /// @return Resulting status
   VelodyneStatus set_net_dhcp(bool use_dhcp);
-
-  /// @brief Setting rclcpp::Logger
-  /// @param node Logger
-  void set_logger(std::shared_ptr<rclcpp::Logger> node);
 };
-
 }  // namespace nebula::drivers
 
 #endif  // NEBULA_VELODYNE_HW_INTERFACE_H

--- a/nebula_hw_interfaces/src/nebula_hesai_hw_interfaces/hesai_hw_interface.cpp
+++ b/nebula_hw_interfaces/src/nebula_hesai_hw_interfaces/hesai_hw_interface.cpp
@@ -234,21 +234,21 @@ Status HesaiHwInterface::get_calibration_configuration(
 Status HesaiHwInterface::initialize_tcp_driver()
 {
 #ifdef WITH_DEBUG_STDOUT_HESAI_HW_INTERFACE
-  std::cout << "HesaiHwInterface::InitializeTcpDriver" << std::endl;
-  std::cout << "st: tcp_driver_->init_socket" << std::endl;
-  std::cout << "sensor_configuration_->sensor_ip=" << sensor_configuration_->sensor_ip << std::endl;
-  std::cout << "sensor_configuration_->host_ip=" << sensor_configuration_->host_ip << std::endl;
-  std::cout << "PandarTcpCommandPort=" << PandarTcpCommandPort << std::endl;
+  logger_->debug("HesaiHwInterface::InitializeTcpDriver");
+  logger_->debug("st: tcp_driver_->init_socket");
+  logger_->debug("sensor_configuration_->sensor_ip=" + sensor_configuration_->sensor_ip);
+  logger_->debug("sensor_configuration_->host_ip=" + sensor_configuration_->host_ip);
+  logger_->debug("PandarTcpCommandPort=" + std::to_string(g_pandar_tcp_command_port));
 #endif
   tcp_driver_->init_socket(
     sensor_configuration_->sensor_ip, g_pandar_tcp_command_port, sensor_configuration_->host_ip,
     g_pandar_tcp_command_port);
 #ifdef WITH_DEBUG_STDOUT_HESAI_HW_INTERFACE
-  std::cout << "ed: tcp_driver_->init_socket" << std::endl;
+  logger_->debug("ed: tcp_driver_->init_socket");
 #endif
   if (!tcp_driver_->open()) {
 #ifdef WITH_DEBUG_STDOUT_HESAI_HW_INTERFACE
-    std::cout << "!tcp_driver_->open()" << std::endl;
+    logger_->debug("!tcp_driver_->open()");
 #endif
     //    tcp_driver_->close();
     tcp_driver_->closeSync();
@@ -278,7 +278,7 @@ boost::property_tree::ptree HesaiHwInterface::parse_json(const std::string & str
     ss << str;
     boost::property_tree::read_json(ss, tree);
   } catch (boost::property_tree::json_parser_error & e) {
-    std::cerr << e.what() << std::endl;
+    logger_->error(e.what());
   }
   return tree;
 }
@@ -959,7 +959,7 @@ HesaiStatus HesaiHwInterface::check_and_set_config(
 {
   using namespace std::chrono_literals;  // NOLINT(build/namespaces)
 #ifdef WITH_DEBUG_STDOUT_HESAI_HW_INTERFACE
-  std::cout << "Start CheckAndSetConfig(HesaiConfig)!!" << std::endl;
+  logger_->debug("Start CheckAndSetConfig(HesaiConfig)!");
 #endif
   const auto hesai_config = hesai_config_ptr->get();
   auto current_return_mode = nebula::drivers::return_mode_from_int_hesai(
@@ -1155,7 +1155,7 @@ HesaiStatus HesaiHwInterface::check_and_set_config(
   }
 
 #ifdef WITH_DEBUG_STDOUT_HESAI_HW_INTERFACE
-  std::cout << "End CheckAndSetConfig(HesaiConfig)!!" << std::endl;
+  logger_->debug("End CheckAndSetConfig(HesaiConfig)!");
 #endif
   logger_->debug("GetAndCheckConfig(HesaiConfig) finished");
 
@@ -1167,15 +1167,15 @@ HesaiStatus HesaiHwInterface::check_and_set_config(
   HesaiLidarRangeAll hesai_lidar_range_all)
 {
 #ifdef WITH_DEBUG_STDOUT_HESAI_HW_INTERFACE
-  std::cout << "Start CheckAndSetConfig(HesaiLidarRangeAll)!!" << std::endl;
+  logger_->debug("Start CheckAndSetConfig(HesaiLidarRangeAll)!");
 #endif
   //*
   // g_ptc_command_set_lidar_range
   bool set_flg = false;
   if (hesai_lidar_range_all.method != 0) {
 #ifdef WITH_DEBUG_STDOUT_HESAI_HW_INTERFACE
-    std::cout << "current hesai_lidar_range_all.method: " << hesai_lidar_range_all.method
-              << std::endl;
+    logger_->debug(
+      "current hesai_lidar_range_all.method: " + std::to_string(hesai_lidar_range_all.method));
 #endif
     set_flg = true;
   } else {
@@ -1216,7 +1216,7 @@ HesaiStatus HesaiHwInterface::check_and_set_config(
   }
 
 #ifdef WITH_DEBUG_STDOUT_HESAI_HW_INTERFACE
-  std::cout << "End CheckAndSetConfig(HesaiLidarRangeAll)!!" << std::endl;
+  logger_->debug("End CheckAndSetConfig(HesaiLidarRangeAll)!");
 #endif
   return Status::WAITING_FOR_SENSOR_RESPONSE;
 }
@@ -1224,7 +1224,7 @@ HesaiStatus HesaiHwInterface::check_and_set_config(
 HesaiStatus HesaiHwInterface::check_and_set_config()
 {
 #ifdef WITH_DEBUG_STDOUT_HESAI_HW_INTERFACE
-  std::cout << "Start CheckAndSetConfig!!" << std::endl;
+  logger_->debug("Start CheckAndSetConfig!");
 #endif
   std::thread t([this] {
     auto result = get_config();
@@ -1246,7 +1246,7 @@ HesaiStatus HesaiHwInterface::check_and_set_config()
   });
   t2.join();
 #ifdef WITH_DEBUG_STDOUT_HESAI_HW_INTERFACE
-  std::cout << "End CheckAndSetConfig!!" << std::endl;
+  logger_->debug("End CheckAndSetConfig!");
 #endif
   return Status::OK;
 }

--- a/nebula_hw_interfaces/src/nebula_robosense_hw_interfaces/robosense_hw_interface.cpp
+++ b/nebula_hw_interfaces/src/nebula_robosense_hw_interfaces/robosense_hw_interface.cpp
@@ -2,17 +2,20 @@
 
 #include "nebula_hw_interfaces/nebula_hw_interfaces_robosense/robosense_hw_interface.hpp"
 
+#include "nebula_common/util/string_conversions.hpp"
+
 #include <iostream>
 #include <memory>
 #include <string>
 #include <utility>
 namespace nebula::drivers
 {
-RobosenseHwInterface::RobosenseHwInterface()
+RobosenseHwInterface::RobosenseHwInterface(const std::shared_ptr<loggers::Logger> & logger)
 : cloud_io_context_(new ::drivers::common::IoContext(1)),
   info_io_context_(new ::drivers::common::IoContext(1)),
   cloud_udp_driver_(new ::drivers::udp_driver::UdpDriver(*cloud_io_context_)),
-  info_udp_driver_(new ::drivers::udp_driver::UdpDriver(*info_io_context_))
+  info_udp_driver_(new ::drivers::udp_driver::UdpDriver(*info_io_context_)),
+  logger_(logger)
 {
 }
 
@@ -37,7 +40,9 @@ void RobosenseHwInterface::receive_info_packet_callback(std::vector<uint8_t> & b
 Status RobosenseHwInterface::sensor_interface_start()
 {
   try {
-    std::cout << "Starting UDP server for data packets on: " << *sensor_configuration_ << std::endl;
+    logger_->info(
+      "Starting UDP server for data packets on: " + sensor_configuration_->sensor_ip + ": " +
+      std::to_string(sensor_configuration_->data_port));
     cloud_udp_driver_->init_receiver(
       sensor_configuration_->host_ip, sensor_configuration_->data_port);
     cloud_udp_driver_->receiver()->open();
@@ -48,8 +53,9 @@ Status RobosenseHwInterface::sensor_interface_start()
         &RobosenseHwInterface::receive_sensor_packet_callback, this, std::placeholders::_1));
   } catch (const std::exception & ex) {
     Status status = Status::UDP_CONNECTION_ERROR;
-    std::cerr << status << sensor_configuration_->sensor_ip << ","
-              << sensor_configuration_->data_port << std::endl;
+    logger_->error(
+      util::to_string(status) + " " + sensor_configuration_->sensor_ip + "," +
+      std::to_string(sensor_configuration_->data_port));
     return status;
   }
   return Status::OK;
@@ -58,8 +64,7 @@ Status RobosenseHwInterface::sensor_interface_start()
 Status RobosenseHwInterface::info_interface_start()
 {
   try {
-    std::cout << "Starting UDP server for info packets on: " << *sensor_configuration_ << std::endl;
-    print_info(
+    logger_->info(
       "Starting UDP server for info packets on: " + sensor_configuration_->sensor_ip + ": " +
       std::to_string(sensor_configuration_->gnss_port));
     info_udp_driver_->init_receiver(
@@ -71,8 +76,9 @@ Status RobosenseHwInterface::info_interface_start()
       std::bind(&RobosenseHwInterface::receive_info_packet_callback, this, std::placeholders::_1));
   } catch (const std::exception & ex) {
     Status status = Status::UDP_CONNECTION_ERROR;
-    std::cerr << status << sensor_configuration_->sensor_ip << ","
-              << sensor_configuration_->gnss_port << std::endl;
+    logger_->error(
+      util::to_string(status) + " " + sensor_configuration_->sensor_ip + "," +
+      std::to_string(sensor_configuration_->gnss_port));
     return status;
   }
 
@@ -106,28 +112,4 @@ Status RobosenseHwInterface::register_info_callback(
   info_reception_callback_ = std::move(info_callback);
   return Status::OK;
 }
-
-void RobosenseHwInterface::print_debug(std::string debug)
-{
-  if (parent_node_logger_) {
-    RCLCPP_DEBUG_STREAM((*parent_node_logger_), debug);
-  } else {
-    std::cout << debug << std::endl;
-  }
-}
-
-void RobosenseHwInterface::print_info(std::string info)
-{
-  if (parent_node_logger_) {
-    RCLCPP_INFO_STREAM((*parent_node_logger_), info);
-  } else {
-    std::cout << info << std::endl;
-  }
-}
-
-void RobosenseHwInterface::set_logger(std::shared_ptr<rclcpp::Logger> logger)
-{
-  parent_node_logger_ = logger;
-}
-
 }  // namespace nebula::drivers

--- a/nebula_ros/src/continental/continental_ars548_hw_interface_wrapper.cpp
+++ b/nebula_ros/src/continental/continental_ars548_hw_interface_wrapper.cpp
@@ -14,6 +14,8 @@
 
 #include "nebula_ros/continental/continental_ars548_hw_interface_wrapper.hpp"
 
+#include "nebula_ros/common/rclcpp_logger.hpp"
+
 #include <nebula_common/util/string_conversions.hpp>
 
 #include <tf2_ros/buffer.h>
@@ -30,7 +32,8 @@ ContinentalARS548HwInterfaceWrapper::ContinentalARS548HwInterfaceWrapper(
     config_ptr)
 : parent_node_(parent_node),
   hw_interface_(
-    std::make_shared<nebula::drivers::continental_ars548::ContinentalARS548HwInterface>()),
+    std::make_shared<drivers::continental_ars548::ContinentalARS548HwInterface>(
+      drivers::loggers::RclcppLogger(parent_node->get_logger()).child("HwInterface"))),
   logger_(parent_node->get_logger().get_child("HwInterfaceWrapper")),
   status_(Status::NOT_INITIALIZED),
   config_ptr_(config_ptr),
@@ -44,8 +47,6 @@ ContinentalARS548HwInterfaceWrapper::ContinentalARS548HwInterfaceWrapper(
     nebula::drivers::continental_ars548::min_odometry_hz,
     nebula::drivers::continental_ars548::max_odometry_hz, 100)
 {
-  hw_interface_->set_logger(
-    std::make_shared<rclcpp::Logger>(parent_node->get_logger().get_child("HwInterface")));
   status_ = hw_interface_->set_sensor_configuration(config_ptr);
 
   if (status_ != Status::OK) {

--- a/nebula_ros/src/continental/continental_srr520_hw_interface_wrapper.cpp
+++ b/nebula_ros/src/continental/continental_srr520_hw_interface_wrapper.cpp
@@ -14,6 +14,8 @@
 
 #include "nebula_ros/continental/continental_srr520_hw_interface_wrapper.hpp"
 
+#include "nebula_ros/common/rclcpp_logger.hpp"
+
 #include <nebula_common/util/string_conversions.hpp>
 
 #include <tf2_ros/buffer.h>
@@ -31,13 +33,12 @@ ContinentalSRR520HwInterfaceWrapper::ContinentalSRR520HwInterfaceWrapper(
     config_ptr)
 : parent_node_(parent_node),
   hw_interface_(
-    std::make_shared<nebula::drivers::continental_srr520::ContinentalSRR520HwInterface>()),
+    std::make_shared<drivers::continental_srr520::ContinentalSRR520HwInterface>(
+      drivers::loggers::RclcppLogger(parent_node->get_logger()).child("HwInterface"))),
   logger_(parent_node->get_logger().get_child("HwInterfaceWrapper")),
   status_(Status::NOT_INITIALIZED),
   config_ptr_(config_ptr)
 {
-  hw_interface_->set_logger(
-    std::make_shared<rclcpp::Logger>(parent_node->get_logger().get_child("HwInterface")));
   status_ = hw_interface_->set_sensor_configuration(config_ptr_);
 
   if (status_ != Status::OK) {

--- a/nebula_ros/src/robosense/hw_interface_wrapper.cpp
+++ b/nebula_ros/src/robosense/hw_interface_wrapper.cpp
@@ -2,6 +2,8 @@
 
 #include "nebula_ros/robosense/hw_interface_wrapper.hpp"
 
+#include "nebula_ros/common/rclcpp_logger.hpp"
+
 #include <nebula_common/util/string_conversions.hpp>
 
 #include <memory>
@@ -11,12 +13,12 @@ namespace nebula::ros
 RobosenseHwInterfaceWrapper::RobosenseHwInterfaceWrapper(
   rclcpp::Node * const parent_node,
   std::shared_ptr<const nebula::drivers::RobosenseSensorConfiguration> & config)
-: hw_interface_(new nebula::drivers::RobosenseHwInterface()),
+: hw_interface_(
+    std::make_shared<drivers::RobosenseHwInterface>(
+      drivers::loggers::RclcppLogger(parent_node->get_logger()).child("HwInterface"))),
   logger_(parent_node->get_logger().get_child("HwInterfaceWrapper")),
   status_(nebula::Status::NOT_INITIALIZED)
 {
-  hw_interface_->set_logger(
-    std::make_shared<rclcpp::Logger>(parent_node->get_logger().get_child("HwInterface")));
   status_ = hw_interface_->set_sensor_configuration(config);
 
   if (Status::OK != status_) {

--- a/nebula_ros/src/velodyne/hw_interface_wrapper.cpp
+++ b/nebula_ros/src/velodyne/hw_interface_wrapper.cpp
@@ -2,6 +2,8 @@
 
 #include "nebula_ros/velodyne/hw_interface_wrapper.hpp"
 
+#include "nebula_ros/common/rclcpp_logger.hpp"
+
 #include <nebula_common/util/string_conversions.hpp>
 
 #include <memory>
@@ -12,15 +14,15 @@ namespace nebula::ros
 VelodyneHwInterfaceWrapper::VelodyneHwInterfaceWrapper(
   rclcpp::Node * const parent_node,
   std::shared_ptr<const nebula::drivers::VelodyneSensorConfiguration> & config, bool use_udp_only)
-: hw_interface_(new nebula::drivers::VelodyneHwInterface()),
+: hw_interface_(
+    std::make_shared<drivers::VelodyneHwInterface>(
+      drivers::loggers::RclcppLogger(parent_node->get_logger()).child("HwInterface"))),
   logger_(parent_node->get_logger().get_child("HwInterfaceWrapper")),
   status_(Status::NOT_INITIALIZED),
   use_udp_only_(use_udp_only)
 {
   setup_sensor_ = parent_node->declare_parameter<bool>("setup_sensor", param_read_only());
 
-  hw_interface_->set_logger(
-    std::make_shared<rclcpp::Logger>(parent_node->get_logger().get_child("HwInterface")));
   status_ = hw_interface_->initialize_sensor_configuration(config);
 
   if (status_ != Status::OK) {


### PR DESCRIPTION
## PR Type

- Improvement

## Related Links

- #233 - introduction of the Nebula logger
- #232 - reference PR (Hesai) for this one

## Description

Replace all `RCLCPP_` and `std::cout`, `std::cerr` etc. usage by `logger->` calls for all remaining vendors. For Hesai, this has already been done in #232, but there were some print statements remaining.

Supersedes #301.

## Review Procedure

- code review (should be straight-forward), commits are split by sensor/vendor
- confirm using PCAP or sensor that logging works as expected

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
