### PR TITLE
refactor(hesai): centralized diagnostic_updater

### DIFF
--- a/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_hesai/hesai_cmd_response.hpp
+++ b/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_hesai/hesai_cmd_response.hpp
@@ -206,14 +206,6 @@ struct HesaiInventoryBase
 
   [[nodiscard]] virtual const Internal & get() const = 0;
 
-  [[nodiscard]] std::string to_hardware_id() const
-  {
-    auto j = to_json();
-    std::string model = j.at("model");
-    std::string serial = j.at("sn");
-    return model + ": " + serial;
-  }
-
 protected:
   [[nodiscard]] virtual ordered_json sensor_specifics_to_json() const = 0;
 

--- a/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_hesai/hesai_cmd_response.hpp
+++ b/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_hesai/hesai_cmd_response.hpp
@@ -206,6 +206,14 @@ struct HesaiInventoryBase
 
   [[nodiscard]] virtual const Internal & get() const = 0;
 
+  [[nodiscard]] std::string to_hardware_id() const
+  {
+    auto j = to_json();
+    std::string model = j.at("model");
+    std::string serial = j.at("sn");
+    return model + ": " + serial;
+  }
+
 protected:
   [[nodiscard]] virtual ordered_json sensor_specifics_to_json() const = 0;
 

--- a/nebula_ros/include/nebula_ros/hesai/hesai_ros_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/hesai/hesai_ros_wrapper.hpp
@@ -22,6 +22,7 @@
 #include "nebula_ros/hesai/hw_monitor_wrapper.hpp"
 
 #include <ament_index_cpp/get_package_prefix.hpp>
+#include <diagnostic_updater/diagnostic_updater.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
 
@@ -108,6 +109,8 @@ private:
   std::optional<HesaiHwInterfaceWrapper> hw_interface_wrapper_;
   std::optional<HesaiHwMonitorWrapper> hw_monitor_wrapper_;
   std::optional<HesaiDecoderWrapper> decoder_wrapper_;
+
+  diagnostic_updater::Updater diagnostic_updater_;
 
   std::mutex mtx_config_;
 

--- a/nebula_ros/include/nebula_ros/hesai/hw_interface_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/hesai/hw_interface_wrapper.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include "nebula_hw_interfaces/nebula_hw_interfaces_hesai/hesai_cmd_response.hpp"
+
 #include <nebula_common/hesai/hesai_common.hpp>
 #include <nebula_hw_interfaces/nebula_hw_interfaces_hesai/hesai_hw_interface.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -35,10 +37,14 @@ public:
 
   nebula::Status status();
 
-  std::shared_ptr<drivers::HesaiHwInterface> hw_interface() const;
+  [[nodiscard]] std::shared_ptr<drivers::HesaiHwInterface> hw_interface() const;
+
+  [[nodiscard]] std::shared_ptr<const HesaiInventoryBase> inventory() const;
 
 private:
   std::shared_ptr<drivers::HesaiHwInterface> hw_interface_;
+  std::shared_ptr<const HesaiInventoryBase> inventory_;
+
   rclcpp::Logger logger_;
   nebula::Status status_;
   bool setup_sensor_;

--- a/nebula_ros/include/nebula_ros/hesai/hw_monitor_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/hesai/hw_monitor_wrapper.hpp
@@ -38,7 +38,7 @@ class HesaiHwMonitorWrapper
 {
 public:
   HesaiHwMonitorWrapper(
-    rclcpp::Node * const parent_node,
+    rclcpp::Node * const parent_node, diagnostic_updater::Updater & diagnostic_updater,
     const std::shared_ptr<nebula::drivers::HesaiHwInterface> & hw_interface,
     std::shared_ptr<const nebula::drivers::HesaiSensorConfiguration> & config);
 
@@ -54,7 +54,8 @@ private:
     diagnostic_updater::DiagnosticStatusWrapper & diagnostics, const std::string & key,
     const json & value);
 
-  void initialize_hesai_diagnostics(bool monitor_enabled);
+  void initialize_hesai_diagnostics(
+    diagnostic_updater::Updater & diagnostic_updater, bool monitor_enabled);
 
   std::string get_ptree_value(boost::property_tree::ptree * pt, const std::string & key);
 
@@ -79,14 +80,12 @@ private:
   void hesai_check_voltage(diagnostic_updater::DiagnosticStatusWrapper & diagnostics);
 
   rclcpp::Logger logger_;
-  diagnostic_updater::Updater diagnostics_updater_;
   nebula::Status status_;
 
   const std::shared_ptr<nebula::drivers::HesaiHwInterface> hw_interface_;
   rclcpp::Node * const parent_node_;
 
   uint16_t diag_span_;
-  rclcpp::TimerBase::SharedPtr diagnostics_update_timer_{};
   rclcpp::TimerBase::SharedPtr fetch_diagnostics_timer_{};
 
   std::shared_ptr<HesaiLidarStatusBase> current_status_{};

--- a/nebula_ros/src/hesai/hesai_ros_wrapper.cpp
+++ b/nebula_ros/src/hesai/hesai_ros_wrapper.cpp
@@ -96,9 +96,7 @@ HesaiRosWrapper::HesaiRosWrapper(const rclcpp::NodeOptions & options)
       "Hardware connection disabled, listening for packets on " << packets_sub_->get_topic_name());
   }
 
-  auto hardware_id = hw_interface_wrapper_ && hw_interface_wrapper_->inventory()
-                       ? hw_interface_wrapper_->inventory()->to_hardware_id()
-                       : "none";
+  auto hardware_id = sensor_cfg_ptr_->frame_id;
 
   diagnostic_updater_.setHardwareID(hardware_id);
 

--- a/nebula_ros/src/hesai/hesai_ros_wrapper.cpp
+++ b/nebula_ros/src/hesai/hesai_ros_wrapper.cpp
@@ -28,7 +28,7 @@ HesaiRosWrapper::HesaiRosWrapper(const rclcpp::NodeOptions & options)
 : rclcpp::Node("hesai_ros_wrapper", rclcpp::NodeOptions(options).use_intra_process_comms(true)),
   wrapper_status_(Status::NOT_INITIALIZED),
   sensor_cfg_ptr_(nullptr),
-  diagnostic_updater_(this)
+  diagnostic_updater_((declare_parameter<bool>("diagnostic_updater.use_fqn", true), this))
 {
   setvbuf(stdout, nullptr, _IONBF, BUFSIZ);
 
@@ -53,7 +53,8 @@ HesaiRosWrapper::HesaiRosWrapper(const rclcpp::NodeOptions & options)
   if (launch_hw_) {
     hw_interface_wrapper_.emplace(this, sensor_cfg_ptr_, use_udp_only);
     if (!use_udp_only) {  // hardware monitor requires TCP connection
-      hw_monitor_wrapper_.emplace(this, hw_interface_wrapper_->hw_interface(), sensor_cfg_ptr_);
+      hw_monitor_wrapper_.emplace(
+        this, diagnostic_updater_, hw_interface_wrapper_->hw_interface(), sensor_cfg_ptr_);
     }
   }
 

--- a/nebula_ros/src/hesai/hesai_ros_wrapper.cpp
+++ b/nebula_ros/src/hesai/hesai_ros_wrapper.cpp
@@ -28,9 +28,7 @@ HesaiRosWrapper::HesaiRosWrapper(const rclcpp::NodeOptions & options)
 : rclcpp::Node("hesai_ros_wrapper", rclcpp::NodeOptions(options).use_intra_process_comms(true)),
   wrapper_status_(Status::NOT_INITIALIZED),
   sensor_cfg_ptr_(nullptr),
-  hw_interface_wrapper_(),
-  hw_monitor_wrapper_(),
-  decoder_wrapper_()
+  diagnostic_updater_(this)
 {
   setvbuf(stdout, nullptr, _IONBF, BUFSIZ);
 
@@ -96,6 +94,12 @@ HesaiRosWrapper::HesaiRosWrapper(const rclcpp::NodeOptions & options)
       get_logger(),
       "Hardware connection disabled, listening for packets on " << packets_sub_->get_topic_name());
   }
+
+  auto hardware_id = hw_interface_wrapper_ && hw_interface_wrapper_->inventory()
+                       ? hw_interface_wrapper_->inventory()->to_hardware_id()
+                       : "none";
+
+  diagnostic_updater_.setHardwareID(hardware_id);
 
   // Register parameter callback after all params have been declared. Otherwise it would be called
   // once for each declaration

--- a/nebula_ros/src/hesai/hw_interface_wrapper.cpp
+++ b/nebula_ros/src/hesai/hw_interface_wrapper.cpp
@@ -2,6 +2,7 @@
 
 #include "nebula_ros/hesai/hw_interface_wrapper.hpp"
 
+#include "nebula_hw_interfaces/nebula_hw_interfaces_hesai/hesai_cmd_response.hpp"
 #include "nebula_ros/common/parameter_descriptors.hpp"
 #include "nebula_ros/common/rclcpp_logger.hpp"
 
@@ -89,6 +90,11 @@ Status HesaiHwInterfaceWrapper::status()
 std::shared_ptr<drivers::HesaiHwInterface> HesaiHwInterfaceWrapper::hw_interface() const
 {
   return hw_interface_;
+}
+
+std::shared_ptr<const HesaiInventoryBase> HesaiHwInterfaceWrapper::inventory() const
+{
+  return inventory_;
 }
 
 }  // namespace nebula::ros

--- a/nebula_ros/src/hesai/hw_interface_wrapper.cpp
+++ b/nebula_ros/src/hesai/hw_interface_wrapper.cpp
@@ -56,8 +56,8 @@ HesaiHwInterfaceWrapper::HesaiHwInterfaceWrapper(
 
   if (status_ == Status::OK) {
     try {
-      auto inventory = hw_interface_->get_inventory();
-      hw_interface_->set_target_model(inventory->model_number());
+      inventory_ = hw_interface_->get_inventory();
+      hw_interface_->set_target_model(inventory_->model_number());
     } catch (...) {
       RCLCPP_ERROR_STREAM(logger_, "Failed to get model from sensor...");
     }


### PR DESCRIPTION
## PR Type

- Improvement

## Related Links



## Description

This PR moves the diagnostic_updater from hw_monitor to ros_wrapper for Hesai.
Since the updater will be used by various diagnostics not just in HW monitor, this change allows for clean implementation of those coming-soon diagnostics.

Other effects:

* The redundant force_update timer has been removed, as diagnostic_updater already has its own timer.
* A get_inventory has been sent to the sensor from 2 places before, this has been reduced to 1.

Confirmed working with a [dummy TCP connection](https://github.com/tier4/pcap_replay) and a real sensor. Publish rate is the same 1 Hz as before.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
