### PR TITLE
feat(ars548): implemented autoware specific diagnostic criteria

### DIFF
--- a/nebula_common/include/nebula_common/continental/continental_ars548.hpp
+++ b/nebula_common/include/nebula_common/continental/continental_ars548.hpp
@@ -50,6 +50,10 @@ struct ContinentalARS548SensorConfiguration : EthernetSensorConfigurationBase
   float configuration_vehicle_width{};
   float configuration_vehicle_height{};
   float configuration_vehicle_wheelbase{};
+  float min_expected_detections_rate_hz{};
+  float max_expected_detections_rate_hz{};
+  float min_expected_object_rate_hz{};
+  float max_expected_object_rate_hz{};
 };
 
 /// @brief Convert ContinentalARS548SensorConfiguration to string (Overloading the <<

--- a/nebula_decoders/src/nebula_decoders_continental/decoders/continental_ars548_decoder.cpp
+++ b/nebula_decoders/src/nebula_decoders_continental/decoders/continental_ars548_decoder.cpp
@@ -639,7 +639,7 @@ bool ContinentalARS548Decoder::parse_sensor_status_packet(
   }
 
   radar_status_.status_total_count++;
-  radar_status_.radar_invalid_count += sensor_status_packet.radar_status == 2 ? 1 : 0;
+  radar_status_.radar_invalid_count += sensor_status_packet.radar_status == state_invalid ? 1 : 0;
 
   if (sensor_status_callback_) {
     sensor_status_callback_(radar_status_);

--- a/nebula_ros/config/radar/continental/ARS548.param.yaml
+++ b/nebula_ros/config/radar/continental/ARS548.param.yaml
@@ -16,3 +16,7 @@
     configuration_vehicle_width: 1.896
     configuration_vehicle_height: 2.5
     configuration_vehicle_wheelbase: 2.79
+    min_expected_detections_rate_hz: 9.0
+    max_expected_detections_rate_hz: 11.0
+    min_expected_object_rate_hz: 9.0
+    max_expected_object_rate_hz: 11.0

--- a/nebula_ros/src/continental/continental_ars548_ros_wrapper.cpp
+++ b/nebula_ros/src/continental/continental_ars548_ros_wrapper.cpp
@@ -90,14 +90,22 @@ nebula::Status ContinentalARS548RosWrapper::declare_and_get_sensor_config_params
   config.configuration_sensor_port =
     static_cast<uint16_t>(declare_parameter<int>("configuration_sensor_port", param_read_only()));
   config.use_sensor_time = declare_parameter<bool>("use_sensor_time", param_read_write());
-  config.configuration_vehicle_length = static_cast<float>(
-    declare_parameter<double>("configuration_vehicle_length", param_read_write()));
-  config.configuration_vehicle_width = static_cast<float>(
-    declare_parameter<double>("configuration_vehicle_width", param_read_write()));
-  config.configuration_vehicle_height = static_cast<float>(
-    declare_parameter<double>("configuration_vehicle_height", param_read_write()));
-  config.configuration_vehicle_wheelbase = static_cast<float>(
-    declare_parameter<double>("configuration_vehicle_wheelbase", param_read_write()));
+  config.configuration_vehicle_length =
+    declare_parameter<float>("configuration_vehicle_length", param_read_write());
+  config.configuration_vehicle_width =
+    declare_parameter<float>("configuration_vehicle_width", param_read_write());
+  config.configuration_vehicle_height =
+    declare_parameter<float>("configuration_vehicle_height", param_read_write());
+  config.configuration_vehicle_wheelbase =
+    declare_parameter<float>("configuration_vehicle_wheelbase", param_read_write());
+  config.min_expected_detections_rate_hz =
+    declare_parameter<float>("min_expected_detections_rate_hz", param_read_only());
+  config.max_expected_detections_rate_hz =
+    declare_parameter<float>("max_expected_detections_rate_hz", param_read_only());
+  config.min_expected_object_rate_hz =
+    declare_parameter<float>("min_expected_object_rate_hz", param_read_only());
+  config.max_expected_object_rate_hz =
+    declare_parameter<float>("max_expected_object_rate_hz", param_read_only());
 
   if (config.sensor_model == nebula::drivers::SensorModel::UNKNOWN) {
     return Status::INVALID_SENSOR_MODEL;


### PR DESCRIPTION
## PR Type

- New Feature

## Related Links

[TIER IV INTERNAL LINK](https://tier4.atlassian.net/wiki/spaces/~69616678/pages/3648553031/Continental+ARS8+Radar+diagnostics)

## Description

This PR implements the diagnostics discussed with @manato 
For now, instead of modifying the current messages I opted to add another (it can be changed).
Added the data rate parameters as ROS parameters as requested, since the thresholds are project specific.

If this PR is to be merged, the following concerns must be addressed:
 - topic names change, so launchers and stakeholders need to be handled
 - the new parameters need to be added to aip_launcher

<!-- Describe what this PR changes. -->

## Review Procedure

Use a project that used the sensor or launch the driver independently:

```bash
ros2 launch nebula_ros continental_launch_all_hw.xml sensor_model:=ARS548 launch_hw:=false
```

The output is as follows (one message):

```text
---
header:
  stamp:
    sec: 1740468096
    nanosec: 917767979
  frame_id: continental
status:
- level: "\0"
  name: continental_dynamics
  message: ARS548 dynamics status
  hardware_id: continental_dynamics
  values:
  - key: longitudinal_velocity_status
    value: 0:VDY_OK
  - key: longitudinal_acceleration_status
    value: 0:VDY_OK
  - key: lateral_acceleration_status
    value: 0:VDY_OK
  - key: yaw_rate_status
    value: 0:VDY_OK
  - key: steering_angle_status
    value: 0:VDY_OK
  - key: driving_direction_status
    value: 0:VDY_OK
- level: "\0"
  name: continental_internal
  message: ARS548 internal signals
  hardware_id: continental_internal
  values:
  - key: radar_status
    value: 1:STATE_OK
  - key: voltage_status
    value: Ok
  - key: temperature_status
    value: Ok
- level: "\0"
  name: continental_blockage
  message: ARS548 blockage status
  hardware_id: continental_blockage
  values:
  - key: blockage_status
    value: 4:None. 1:Self test passed
- level: "\0"
  name: continental_rate
  message: ''
  hardware_id: continental_rate
  values:
  - key: detections_rate
    value: 9.993293 Hz
  - key: objects_rate
    value: 9.993425 Hz
---

```

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
