### PR TITLE
perf(velodyne): use new UDP socket implementation

### DIFF
--- a/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_velodyne/velodyne_hw_interface.hpp
+++ b/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_velodyne/velodyne_hw_interface.hpp
@@ -53,10 +53,11 @@ namespace nebula::drivers
 class VelodyneHwInterface
 {
 private:
-  std::optional<connections::UdpSocket> udp_socket_;
   std::shared_ptr<const VelodyneSensorConfiguration> sensor_configuration_;
-  std::function<void(const std::vector<uint8_t> &)>
-    cloud_packet_callback_; /**This function pointer is called when the scan is complete*/
+  /**This function pointer is called when the scan is complete*/
+  std::function<void(const std::vector<uint8_t> &)> cloud_packet_callback_;
+  // Calls the above `cloud_packet_callback_` and thus has to be destroyed before it.
+  std::optional<connections::UdpSocket> udp_socket_;
 
   std::shared_ptr<boost::asio::io_context> boost_ctx_;
   std::unique_ptr<::drivers::tcp_driver::HttpClientDriver> http_client_driver_;

--- a/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_velodyne/velodyne_hw_interface.hpp
+++ b/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_velodyne/velodyne_hw_interface.hpp
@@ -19,6 +19,8 @@
 // boost/property_tree/ in some versions of boost.
 // See: https://github.com/boostorg/property_tree/issues/51
 #include <boost/version.hpp>
+
+#include <optional>
 #if (BOOST_VERSION / 100 >= 1073 && BOOST_VERSION / 100 <= 1076)  // Boost 1.73 - 1.76
 #define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #endif
@@ -34,6 +36,7 @@
 #include <nebula_common/loggers/logger.hpp>
 #include <nebula_common/velodyne/velodyne_common.hpp>
 #include <nebula_common/velodyne/velodyne_status.hpp>
+#include <nebula_hw_interfaces/nebula_hw_interfaces_common/connections/udp.hpp>
 
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
@@ -50,10 +53,9 @@ namespace nebula::drivers
 class VelodyneHwInterface
 {
 private:
-  std::unique_ptr<::drivers::common::IoContext> cloud_io_context_;
-  std::unique_ptr<::drivers::udp_driver::UdpDriver> cloud_udp_driver_;
+  std::optional<connections::UdpSocket> udp_socket_;
   std::shared_ptr<const VelodyneSensorConfiguration> sensor_configuration_;
-  std::function<void(std::vector<uint8_t> &)>
+  std::function<void(const std::vector<uint8_t> &)>
     cloud_packet_callback_; /**This function pointer is called when the scan is complete*/
 
   std::shared_ptr<boost::asio::io_context> boost_ctx_;
@@ -148,7 +150,7 @@ public:
 
   /// @brief Callback function to receive the Cloud Packet data from the UDP Driver
   /// @param buffer Buffer containing the data received from the UDP socket
-  void receive_sensor_packet_callback(std::vector<uint8_t> & buffer);
+  void receive_sensor_packet_callback(const std::vector<uint8_t> & buffer);
   /// @brief Starting the interface that handles UDP streams
   /// @return Resulting status
   Status sensor_interface_start();
@@ -177,7 +179,8 @@ public:
   /// @brief Registering callback for PandarScan
   /// @param scan_callback Callback function
   /// @return Resulting status
-  Status register_scan_callback(std::function<void(std::vector<uint8_t> & packet)> scan_callback);
+  Status register_scan_callback(
+    std::function<void(const std::vector<uint8_t> & packet)> scan_callback);
 
   /// @brief Parsing JSON string to property_tree
   /// @param str JSON string

--- a/nebula_ros/config/lidar/velodyne/VLP16.param.yaml
+++ b/nebula_ros/config/lidar/velodyne/VLP16.param.yaml
@@ -1,6 +1,6 @@
 /**:
   ros__parameters:
-    host_ip: 255.255.255.255
+    host_ip: 192.168.1.10
     sensor_ip: 192.168.1.201
     data_port: 2368
     gnss_port: 2369

--- a/nebula_ros/config/lidar/velodyne/VLP32.param.yaml
+++ b/nebula_ros/config/lidar/velodyne/VLP32.param.yaml
@@ -1,6 +1,6 @@
 /**:
   ros__parameters:
-    host_ip: 255.255.255.255
+    host_ip: 192.168.1.10
     sensor_ip: 192.168.1.201
     data_port: 2368
     gnss_port: 2369

--- a/nebula_ros/config/lidar/velodyne/VLS128.param.yaml
+++ b/nebula_ros/config/lidar/velodyne/VLS128.param.yaml
@@ -1,6 +1,6 @@
 /**:
   ros__parameters:
-    host_ip: 255.255.255.255
+    host_ip: 192.168.1.10
     sensor_ip: 192.168.1.201
     data_port: 2368
     gnss_port: 2369

--- a/nebula_ros/include/nebula_ros/velodyne/velodyne_ros_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/velodyne/velodyne_ros_wrapper.hpp
@@ -51,7 +51,6 @@ class VelodyneRosWrapper final : public rclcpp::Node
 {
 public:
   explicit VelodyneRosWrapper(const rclcpp::NodeOptions & options);
-  ~VelodyneRosWrapper() noexcept;
 
   /// @brief Get current status of this driver
   /// @return Current status

--- a/nebula_ros/include/nebula_ros/velodyne/velodyne_ros_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/velodyne/velodyne_ros_wrapper.hpp
@@ -51,7 +51,7 @@ class VelodyneRosWrapper final : public rclcpp::Node
 {
 public:
   explicit VelodyneRosWrapper(const rclcpp::NodeOptions & options);
-  ~VelodyneRosWrapper() noexcept {};
+  ~VelodyneRosWrapper() noexcept;
 
   /// @brief Get current status of this driver
   /// @return Current status
@@ -62,7 +62,7 @@ public:
   Status stream_start();
 
 private:
-  void receive_cloud_packet_callback(std::vector<uint8_t> & packet);
+  void receive_cloud_packet_callback(const std::vector<uint8_t> & packet);
 
   void receive_scan_message_callback(std::unique_ptr<velodyne_msgs::msg::VelodyneScan> scan_msg);
 

--- a/nebula_ros/src/velodyne/velodyne_ros_wrapper.cpp
+++ b/nebula_ros/src/velodyne/velodyne_ros_wrapper.cpp
@@ -71,13 +71,6 @@ VelodyneRosWrapper::VelodyneRosWrapper(const rclcpp::NodeOptions & options)
     std::bind(&VelodyneRosWrapper::on_parameter_change, this, std::placeholders::_1));
 }
 
-VelodyneRosWrapper::~VelodyneRosWrapper() noexcept
-{
-  if (!hw_interface_wrapper_) return;
-  if (!hw_interface_wrapper_->hw_interface()) return;
-  hw_interface_wrapper_->hw_interface()->sensor_interface_stop();
-}
-
 nebula::Status VelodyneRosWrapper::declare_and_get_sensor_config_params()
 {
   nebula::drivers::VelodyneSensorConfiguration config;


### PR DESCRIPTION
## PR Type

- Improvement

## Related Links

- #231 -- using the UDP socket from this PR
- #235 -- equivalent PR for Hesai

## Description

Use the new UDP socket introduced in #231 as a drop-in, ASIO-free, transport-driver-free replacement for the old UdpDriver in HesaiHwInterface.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
