### PR TITLE
fix(ars548): rename now non-existent ambiguity_flag to raw_ambiguity flag

### DIFF
--- a/nebula_decoders/src/nebula_decoders_continental/decoders/continental_ars548_decoder.cpp
+++ b/nebula_decoders/src/nebula_decoders_continental/decoders/continental_ars548_decoder.cpp
@@ -198,7 +198,7 @@ bool ContinentalARS548Decoder::parse_detections_list_packet(
     assert(detection.raw_positive_predictive_value <= 100);
     assert(detection.classification <= 4 || detection.classification == 255);
     assert(detection.raw_multi_target_probability <= 100);
-    assert(detection.ambiguity_flag <= 100);
+    assert(detection.raw_ambiguity_flag <= 100);
 
     assert(detection.azimuth_angle.value() >= -M_PI && detection.azimuth_angle.value() <= M_PI);
     assert(


### PR DESCRIPTION
## PR Type
- Bug Fix

## Related Links

- #284 -- introduced by this PR

## Description

Fixed a compiler error because of a not yet renamed `ambiguity_flag` reference. It is now renamed to `raw_ambiguity_flag`.

Interesting how it passed CI, possibly CCache is configured too loosely? #270 

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
