### PR TITLE
fix: deprecation of .h files in message_filters

### DIFF
--- a/nebula_ros/include/nebula_ros/continental/continental_srr520_hw_interface_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/continental/continental_srr520_hw_interface_wrapper.hpp
@@ -16,6 +16,9 @@
 
 #include "nebula_ros/common/parameter_descriptors.hpp"
 
+#include <message_filters/subscriber.hpp>
+#include <message_filters/sync_policies/exact_time.hpp>
+#include <message_filters/synchronizer.hpp>
 #include <nebula_common/continental/continental_srr520.hpp>
 #include <nebula_hw_interfaces/nebula_hw_interfaces_continental/continental_srr520_hw_interface.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -23,10 +26,6 @@
 #include <continental_srvs/srv/continental_srr520_set_radar_parameters.hpp>
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 #include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
-
-#include <message_filters/subscriber.h>
-#include <message_filters/sync_policies/exact_time.h>
-#include <message_filters/synchronizer.h>
 
 #include <memory>
 

--- a/nebula_ros/package.xml
+++ b/nebula_ros/package.xml
@@ -21,6 +21,7 @@
   <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>geometry_msgs</depend>
+  <depend>message_filters</depend>
   <depend>nebula_common</depend>
   <depend>nebula_decoders</depend>
   <depend>nebula_hw_interfaces</depend>


### PR DESCRIPTION
## PR Type

- Bug Fix

## Related Links

## Description

```
/opt/ros/rolling/include/message_filters/message_filters/synchronizer.h:18:2: warning: #warning This header is obsolete, please include message_filters/synchronizer.hpp instead [-Wcpp]
   18 | #warning This header is obsolete, please include message_filters/synchronizer.hpp instead
      |  ^~~~~~~
```

These headers are backported to humble so this works.

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
