### PR TITLE
fix: update message_filters includes for compatibility with old environments

### DIFF
--- a/nebula_ros/include/nebula_ros/continental/continental_srr520_hw_interface_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/continental/continental_srr520_hw_interface_wrapper.hpp
@@ -16,9 +16,16 @@
 
 #include "nebula_ros/common/parameter_descriptors.hpp"
 
+#if __has_include(<message_filters/subscriber.hpp>)
 #include <message_filters/subscriber.hpp>
 #include <message_filters/sync_policies/exact_time.hpp>
 #include <message_filters/synchronizer.hpp>
+#else
+#include <message_filters/subscriber.h>
+#include <message_filters/sync_policies/exact_time.h>
+#include <message_filters/synchronizer.h>
+#endif
+
 #include <nebula_common/continental/continental_srr520.hpp>
 #include <nebula_hw_interfaces/nebula_hw_interfaces_continental/continental_srr520_hw_interface.hpp>
 #include <rclcpp/rclcpp.hpp>


### PR DESCRIPTION
## PR Type
- Bug Fix

## Related Links
https://github.com/autowarefoundation/autoware_core/pull/467

## Description
In some old environment, the build is failed.
Similar to the related link, resolve the issue by macro.


## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
