### PR TITLE
chore: revert "fix(ci): temporary workaround for expired ROS signing key (#331)"

### DIFF
--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -27,17 +27,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: ROS signing key workaround
-        run: |
-          sudo rm /etc/apt/sources.list.d/ros2-latest.list
-          sudo rm /usr/share/keyrings/ros2-latest-archive-keyring.gpg
-          sudo apt update && sudo apt install -y curl ca-certificates
-          export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}') ;\
-              curl -L -s -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" \
-              && sudo apt-get update \
-              && sudo apt-get install /tmp/ros2-apt-source.deb \
-              && sudo rm -f /tmp/ros2-apt-source.deb
-
       - name: Remove exec_depend
         uses: autowarefoundation/autoware-github-actions/remove-exec-depend@v1
 

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -38,17 +38,6 @@ jobs:
           swap-storage: false
           large-packages: false
 
-      - name: ROS signing key workaround
-        run: |
-          sudo rm /etc/apt/sources.list.d/ros2-latest.list
-          sudo rm /usr/share/keyrings/ros2-latest-archive-keyring.gpg
-          sudo apt update && sudo apt install -y curl ca-certificates
-          export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}') ;\
-              curl -L -s -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" \
-              && sudo apt-get update \
-              && sudo apt-get install /tmp/ros2-apt-source.deb \
-              && sudo rm -f /tmp/ros2-apt-source.deb
-
       - name: Remove exec_depend
         uses: autowarefoundation/autoware-github-actions/remove-exec-depend@v1
 


### PR DESCRIPTION
The upstream issue is cleared, removing the workaround:

https://github.com/docker-library/official-images/pull/19162#issuecomment-2936730894