### PR TITLE
fix(hesai): increase UDP buffer size to reduce receive buffer error

### DIFF
--- a/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_hesai/hesai_hw_interface.hpp
+++ b/nebula_hw_interfaces/include/nebula_hw_interfaces/nebula_hw_interfaces_hesai/hesai_hw_interface.hpp
@@ -102,9 +102,9 @@ const uint16_t g_mtu_size = 1500;
 
 /// @brief The kernel buffer size in bytes to use for receiving UDP packets. If the buffer is too
 /// small to bridge scheduling and processing delays, packets will be dropped. This corresponds to
-/// the net.core.rmem_default setting in Linux. The current value is hardcoded to accommodate one
+/// the net.core.rmem_default setting in Linux. The current value is hardcoded to accommodate two
 /// pointcloud worth of OT128 packets (currently the highest data rate sensor supported).
-const size_t g_udp_socket_buffer_size = g_mtu_size * 3600;
+const size_t g_udp_socket_buffer_size = g_mtu_size * 3600 * 2;
 
 // Time interval between Announce messages, in units of log seconds (default: 1)
 const int g_ptp_log_announce_interval = 1;


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Improvement

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

[private link: JIRA RT2-2324](https://tier4.atlassian.net/browse/RT2-2324)

## Description

<!-- Describe what this PR changes. -->

- Doubled UDP receive buffer size.

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

When using the OT128 LiDAR in high-resolution mode with two subscribers to the /pandar_packets topic, a UDP receive buffer error occurs. This error causes a loss of point data in the pointcloud topic, as shown in the figure below.

![image](https://github.com/user-attachments/assets/4e197fb3-a440-4310-b0d7-0bf94718710f)

I confirmed that this issue is caused by the number of received buffer packets reaching the buffer size limit. I used the following command for monitoring:
```
$ while true; do ss -lunp | grep 192.168.1.11:2368 | cut -c 1-120; sleep 1; done
```

Therefore, I am proposing to double the receive buffer size. With this change, I have verified that the received queue size no longer reaches the limit.

(Left: Before Change, Right: After Change)
![image](https://github.com/user-attachments/assets/40e82494-742b-4884-ba53-7633079f1e63)


## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
