### PR TITLE
fix(ars548): re-introduce correct UDP MTU and sender filter

### DIFF
--- a/nebula_hw_interfaces/src/nebula_continental_hw_interfaces/continental_ars548_hw_interface.cpp
+++ b/nebula_hw_interfaces/src/nebula_continental_hw_interfaces/continental_ars548_hw_interface.cpp
@@ -49,7 +49,8 @@ Status ContinentalARS548HwInterface::sensor_interface_start()
       UdpSocket::Builder(config_ptr_->host_ip, config_ptr_->data_port)
         .join_multicast_group(config_ptr_->multicast_ip)
         .set_send_destination(config_ptr_->sensor_ip, config_ptr_->configuration_sensor_port)
-        .limit_to_sender(config_ptr_->sensor_ip, config_ptr_->configuration_sensor_port)
+        .limit_to_sender(config_ptr_->sensor_ip, config_ptr_->data_port)
+        .set_mtu(2 << 16)
         .bind();
 
     udp_socket_.emplace(std::move(udp_socket));


### PR DESCRIPTION
## PR Type

- Bug Fix

## Related Links

- #273 -- introduced the bug here :bow: 

## Description

This PR re-introduces the sender filter for ARS548. As the sensor is using IP multicast, if there are multiple ARS548s in the same IP subnet, this leads to Nebula receiving data from each of them without this filter, which is unwanted behavior. 

The PR also re-introduces the MTU of `2^16 B` without which the large detection list / object list datagrams cannot be received by Nebula.

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
