### PR TITLE
chore(hesai,ars548): remove watchdog timer in favor of rate bound status

### DIFF
--- a/nebula_ros/include/nebula_ros/continental/continental_ars548_decoder_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/continental/continental_ars548_decoder_wrapper.hpp
@@ -17,7 +17,6 @@
 #include "nebula_ros/common/diagnostics/liveness_monitor.hpp"
 #include "nebula_ros/common/diagnostics/rate_bound_status.hpp"
 #include "nebula_ros/common/parameter_descriptors.hpp"
-#include "nebula_ros/common/watchdog_timer.hpp"
 
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include <nebula_common/continental/continental_ars548.hpp>
@@ -241,7 +240,5 @@ private:
      {{1.0, -1.0}},
      {{0.0, -1.0}},
      {{0.0, 0.0}}}};
-
-  std::shared_ptr<WatchdogTimer> watchdog_;
 };
 }  // namespace nebula::ros

--- a/nebula_ros/include/nebula_ros/hesai/decoder_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/hesai/decoder_wrapper.hpp
@@ -17,7 +17,6 @@
 #include "nebula_decoders/nebula_decoders_hesai/hesai_driver.hpp"
 #include "nebula_ros/common/agnocast_wrapper/nebula_agnocast_wrapper.hpp"
 #include "nebula_ros/common/diagnostics/rate_bound_status.hpp"
-#include "nebula_ros/common/watchdog_timer.hpp"
 #include "nebula_ros/hesai/diagnostics/functional_safety_diagnostic_task.hpp"
 #include "nebula_ros/hesai/diagnostics/packet_loss_diagnostic.hpp"
 
@@ -137,7 +136,5 @@ private:
   custom_diagnostic_tasks::RateBoundStatus publish_diagnostic_;
   std::optional<FunctionalSafetyDiagnosticTask> functional_safety_diagnostic_;
   std::optional<PacketLossDiagnosticTask> packet_loss_diagnostic_;
-
-  std::shared_ptr<WatchdogTimer> cloud_watchdog_;
 };
 }  // namespace nebula::ros

--- a/nebula_ros/src/continental/continental_ars548_decoder_wrapper.cpp
+++ b/nebula_ros/src/continental/continental_ars548_decoder_wrapper.cpp
@@ -114,12 +114,6 @@ ContinentalARS548DecoderWrapper::ContinentalARS548DecoderWrapper(
   detections_diagnostics_updater_.force_update();
   liveness_diagnostics_updater_.force_update();
 
-  watchdog_ =
-    std::make_shared<WatchdogTimer>(*parent_node, 100'000us, [this, parent_node](bool ok) {
-      if (ok) return;
-      RCLCPP_WARN_THROTTLE(logger_, *parent_node->get_clock(), 5000, "Missed output deadline");
-    });
-
   create_radar_info();
 }
 
@@ -161,7 +155,6 @@ void ContinentalARS548DecoderWrapper::process_packet(
   driver_ptr_->process_packet(std::move(packet_msg));
 
   liveness_monitor_.tick();
-  watchdog_->update();
 }
 
 void ContinentalARS548DecoderWrapper::detection_list_callback(

--- a/nebula_ros/src/hesai/decoder_wrapper.cpp
+++ b/nebula_ros/src/hesai/decoder_wrapper.cpp
@@ -81,13 +81,6 @@ HesaiDecoderWrapper::HesaiDecoderWrapper(
   RCLCPP_INFO_STREAM(logger_, ". Wrapper=" << status_);
 
   diagnostic_updater.add(publish_diagnostic_);
-
-  cloud_watchdog_ =
-    std::make_shared<WatchdogTimer>(*parent_node, 100'000us, [this, parent_node](bool ok) {
-      if (ok) return;
-      RCLCPP_WARN_THROTTLE(
-        logger_, *parent_node->get_clock(), 5000, "Missed pointcloud output deadline");
-    });
 }
 
 void HesaiDecoderWrapper::on_config_change(


### PR DESCRIPTION
## PR Type

- Improvement

## Related Links

- #127 -- watchdog timer introduced here for Hesai sensors
- #151 -- watchdog timer introduced here for ARS548
- #326 -- rate bound status introduced here
- #322 -- rate bound status introduced here for Hesai sensors
- #327 -- rate bound status introduced here for ARS548

## Description

This PR removes the `WatchdogTimer` for pointcloud output (Hesai) and packet reception (ARS548) in favor of the already merged rate bound status diagnostics for pointcloud output (Hesai) and detection and object outputs (ARS548).

There have been multiple inquiries about the logging frequency and failure modes of `WatchdogTimer`, so we plan on sunsetting this feature starting with this PR.

## Review Procedure

* confirm that the new diagnostics are at least equivalent in diagnostic quality to `WatchdogTimer`
* confirm there is no unexpected behavior

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
