### PR TITLE
refactor(hesai): fuse pointcloud and blockage mask callbacks into one

### DIFF
--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/hesai_scan_decoder.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/hesai_scan_decoder.hpp
@@ -15,6 +15,8 @@
 #ifndef NEBULA_WS_HESAI_SCAN_DECODER_HPP
 #define NEBULA_WS_HESAI_SCAN_DECODER_HPP
 
+#include "nebula_decoders/nebula_decoders_common/point_filters/blockage_mask.hpp"
+
 #include <nebula_common/hesai/hesai_common.hpp>
 #include <nebula_common/point_types.hpp>
 #include <nebula_common/util/expected.hpp>
@@ -40,12 +42,18 @@ struct PacketMetadata
   uint32_t last_azimuth;
 };
 
+struct DecodeFrame
+{
+  uint64_t timestamp_ns{0};
+  NebulaPointCloudPtr pointcloud;
+  std::optional<point_filters::BlockageMask> blockage_mask;
+};
+
 /// @brief Base class for Hesai LiDAR decoder
 class HesaiScanDecoder
 {
 public:
-  using pointcloud_callback_t =
-    std::function<void(const NebulaPointCloudPtr & pointcloud, double timestamp_s)>;
+  using frame_callback_t = std::function<void(const DecodeFrame & pointcloud)>;
 
   HesaiScanDecoder(HesaiScanDecoder && c) = delete;
   HesaiScanDecoder & operator=(HesaiScanDecoder && c) = delete;
@@ -61,7 +69,7 @@ public:
   virtual nebula::util::expected<PacketMetadata, DecodeError> unpack(
     const std::vector<uint8_t> & packet) = 0;
 
-  virtual void set_pointcloud_callback(pointcloud_callback_t callback) = 0;
+  virtual void set_frame_callback(frame_callback_t callback) = 0;
 };
 }  // namespace nebula::drivers
 

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/hesai_driver.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/hesai_driver.hpp
@@ -54,7 +54,7 @@ private:
     FunctionalSafetyDecoderBase::alive_cb_t alive_cb,
     FunctionalSafetyDecoderBase::stuck_cb_t stuck_cb,
     FunctionalSafetyDecoderBase::status_cb_t status_cb, PacketLossDetectorBase::lost_cb_t lost_cb,
-    std::shared_ptr<point_filters::BlockageMaskPlugin> blockage_mask_plugin = nullptr);
+    std::shared_ptr<point_filters::BlockageMaskParams> blockage_mask_params = nullptr);
 
   template <typename SensorT>
   std::enable_if_t<
@@ -115,13 +115,12 @@ public:
     const std::shared_ptr<const drivers::HesaiSensorConfiguration> & sensor_configuration,
     const std::shared_ptr<const drivers::HesaiCalibrationConfigurationBase> &
       calibration_configuration,
-    const std::shared_ptr<loggers::Logger> & logger,
-    HesaiScanDecoder::pointcloud_callback_t pointcloud_cb,
+    const std::shared_ptr<loggers::Logger> & logger, HesaiScanDecoder::frame_callback_t frame_cb,
     FunctionalSafetyDecoderBase::alive_cb_t alive_cb = nullptr,
     FunctionalSafetyDecoderBase::stuck_cb_t stuck_cb = nullptr,
     FunctionalSafetyDecoderBase::status_cb_t status_cb = nullptr,
     PacketLossDetectorBase::lost_cb_t lost_cb = nullptr,
-    std::shared_ptr<point_filters::BlockageMaskPlugin> blockage_mask_plugin = nullptr);
+    std::shared_ptr<point_filters::BlockageMaskParams> blockage_mask_params = nullptr);
 
   /// @brief Get current status of this driver
   /// @return Current status
@@ -133,7 +132,7 @@ public:
   Status set_calibration_configuration(
     const HesaiCalibrationConfigurationBase & calibration_configuration);
 
-  void set_pointcloud_callback(HesaiScanDecoder::pointcloud_callback_t pointcloud_cb);
+  void set_frame_callback(HesaiScanDecoder::frame_callback_t frame_cb);
 
   /// @brief Decode a pointcloud packet. If a pointcloud is produced, `pointcloud_cb` is called.
   /// @param packet Packet to decode

--- a/nebula_decoders/src/nebula_decoders_hesai/hesai_driver.cpp
+++ b/nebula_decoders/src/nebula_decoders_hesai/hesai_driver.cpp
@@ -28,12 +28,11 @@ namespace nebula::drivers
 HesaiDriver::HesaiDriver(
   const std::shared_ptr<const HesaiSensorConfiguration> & sensor_configuration,
   const std::shared_ptr<const HesaiCalibrationConfigurationBase> & calibration_data,
-  const std::shared_ptr<loggers::Logger> & logger,
-  HesaiScanDecoder::pointcloud_callback_t pointcloud_cb,
+  const std::shared_ptr<loggers::Logger> & logger, HesaiScanDecoder::frame_callback_t frame_cb,
   FunctionalSafetyDecoderBase::alive_cb_t alive_cb,
   FunctionalSafetyDecoderBase::stuck_cb_t stuck_cb,
   FunctionalSafetyDecoderBase::status_cb_t status_cb, PacketLossDetectorBase::lost_cb_t lost_cb,
-  std::shared_ptr<point_filters::BlockageMaskPlugin> blockage_mask_plugin)
+  std::shared_ptr<point_filters::BlockageMaskParams> blockage_mask_plugin)
 : logger_(logger)
 {
   // initialize proper parser from cloud config's model and echo mode
@@ -93,7 +92,7 @@ HesaiDriver::HesaiDriver(
       throw std::runtime_error("Driver not Implemented for selected sensor.");
   }
 
-  scan_decoder_->set_pointcloud_callback(std::move(pointcloud_cb));
+  scan_decoder_->set_frame_callback(std::move(frame_cb));
 }
 
 template <typename SensorT>
@@ -104,7 +103,7 @@ std::shared_ptr<HesaiScanDecoder> HesaiDriver::initialize_decoder(
   FunctionalSafetyDecoderBase::alive_cb_t alive_cb,
   FunctionalSafetyDecoderBase::stuck_cb_t stuck_cb,
   FunctionalSafetyDecoderBase::status_cb_t status_cb, PacketLossDetectorBase::lost_cb_t lost_cb,
-  std::shared_ptr<point_filters::BlockageMaskPlugin> blockage_mask_plugin)
+  std::shared_ptr<point_filters::BlockageMaskParams> blockage_mask_plugin)
 {
   auto functional_safety_decoder =
     initialize_functional_safety_decoder<SensorT>(alive_cb, stuck_cb, status_cb);
@@ -136,9 +135,9 @@ Status HesaiDriver::set_calibration_configuration(
     calibration_configuration.calibration_file + ")");
 }
 
-void HesaiDriver::set_pointcloud_callback(HesaiScanDecoder::pointcloud_callback_t pointcloud_cb)
+void HesaiDriver::set_frame_callback(HesaiScanDecoder::frame_callback_t frame_cb)
 {
-  scan_decoder_->set_pointcloud_callback(std::move(pointcloud_cb));
+  scan_decoder_->set_frame_callback(std::move(frame_cb));
 }
 
 Status HesaiDriver::get_status()

--- a/nebula_examples/src/hesai/hesai_ros_offline_extract_bag_pcd.cpp
+++ b/nebula_examples/src/hesai/hesai_ros_offline_extract_bag_pcd.cpp
@@ -15,6 +15,7 @@
 #include "hesai/hesai_ros_offline_extract_bag_pcd.hpp"
 
 #include <nebula_common/hesai/hesai_common.hpp>
+#include <nebula_decoders/nebula_decoders_hesai/decoders/hesai_scan_decoder.hpp>
 #include <nebula_ros/common/rclcpp_logger.hpp>
 #include <rclcpp/serialization.hpp>
 #include <rclcpp/serialized_message.hpp>
@@ -269,56 +270,56 @@ Status HesaiRosOfflineExtractBag::read_bag()
       bag_writer->write(bag_message);
     }
 
-    drivers::HesaiScanDecoder::pointcloud_callback_t pointcloud_cb =
-      [&](const drivers::NebulaPointCloudPtr & pointcloud, double /* timestamp_s */) {
-        auto fn = std::to_string(bag_message->time_stamp) + ".pcd";
+    drivers::HesaiScanDecoder::frame_callback_t frame_cb = [&](const drivers::DecodeFrame & frame) {
+      const auto & pointcloud = *frame.pointcloud;
+      auto fn = std::to_string(bag_message->time_stamp) + ".pcd";
 
-        cnt++;
-        if (skip_num_ < cnt) {
-          out_cnt++;
+      cnt++;
+      if (skip_num_ < cnt) {
+        out_cnt++;
 
-          if (output_pcd_) {
-            if (only_xyz_) {
-              pcl::PointCloud<pcl::PointXYZ> cloud_xyz;
-              pcl::copyPointCloud(*pointcloud, cloud_xyz);
-              pcd_writer.writeBinary((o_dir / fn).string(), cloud_xyz);
-            } else {
-              pcd_writer.writeBinary((o_dir / fn).string(), *pointcloud);
-            }
-          }
-
-          if (output_rosbag_) {
-            // Create ROS Pointcloud from PCL pointcloud
-            sensor_msgs::msg::PointCloud2 cloud_msg;
-            pcl::toROSMsg(*pointcloud, cloud_msg);
-            cloud_msg.header = extracted_msg.header;
-            cloud_msg.header.frame_id = frame_id_;
-
-            // Create a serialized message for the pointcloud
-            rclcpp::SerializedMessage cloud_serialized_msg;
-            rclcpp::Serialization<sensor_msgs::msg::PointCloud2> cloud_serialization;
-            cloud_serialization.serialize_message(&cloud_msg, &cloud_serialized_msg);
-
-            // Create a bag message for the pointcloud
-            auto cloud_bag_msg = std::make_shared<rosbag2_storage::SerializedBagMessage>();
-            cloud_bag_msg->topic_name = output_pointcloud_topic_;
-            cloud_bag_msg->time_stamp = bag_message->time_stamp;
-
-            // Create a new shared_ptr for the serialized data
-            cloud_bag_msg->serialized_data = std::make_shared<rcutils_uint8_array_t>(
-              cloud_serialized_msg.get_rcl_serialized_message());
-
-            // Write both messages to the bag
-            bag_writer->write(cloud_bag_msg);
+        if (output_pcd_) {
+          if (only_xyz_) {
+            pcl::PointCloud<pcl::PointXYZ> cloud_xyz;
+            pcl::copyPointCloud(pointcloud, cloud_xyz);
+            pcd_writer.writeBinary((o_dir / fn).string(), cloud_xyz);
+          } else {
+            pcd_writer.writeBinary((o_dir / fn).string(), pointcloud);
           }
         }
 
-        if (out_num_ != 0 && out_num_ <= out_cnt) {
-          output_limit_reached = true;
-        }
-      };
+        if (output_rosbag_) {
+          // Create ROS Pointcloud from PCL pointcloud
+          sensor_msgs::msg::PointCloud2 cloud_msg;
+          pcl::toROSMsg(pointcloud, cloud_msg);
+          cloud_msg.header = extracted_msg.header;
+          cloud_msg.header.frame_id = frame_id_;
 
-    driver_ptr_->set_pointcloud_callback(pointcloud_cb);
+          // Create a serialized message for the pointcloud
+          rclcpp::SerializedMessage cloud_serialized_msg;
+          rclcpp::Serialization<sensor_msgs::msg::PointCloud2> cloud_serialization;
+          cloud_serialization.serialize_message(&cloud_msg, &cloud_serialized_msg);
+
+          // Create a bag message for the pointcloud
+          auto cloud_bag_msg = std::make_shared<rosbag2_storage::SerializedBagMessage>();
+          cloud_bag_msg->topic_name = output_pointcloud_topic_;
+          cloud_bag_msg->time_stamp = bag_message->time_stamp;
+
+          // Create a new shared_ptr for the serialized data
+          cloud_bag_msg->serialized_data = std::make_shared<rcutils_uint8_array_t>(
+            cloud_serialized_msg.get_rcl_serialized_message());
+
+          // Write both messages to the bag
+          bag_writer->write(cloud_bag_msg);
+        }
+      }
+
+      if (out_num_ != 0 && out_num_ <= out_cnt) {
+        output_limit_reached = true;
+      }
+    };
+
+    driver_ptr_->set_frame_callback(frame_cb);
 
     nebula_msgs::msg::NebulaPackets nebula_msg;
     nebula_msg.header = extracted_msg.header;

--- a/nebula_ros/include/nebula_ros/hesai/decoder_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/hesai/decoder_wrapper.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "nebula_decoders/nebula_decoders_hesai/decoders/hesai_scan_decoder.hpp"
 #include "nebula_decoders/nebula_decoders_hesai/hesai_driver.hpp"
 #include "nebula_ros/common/agnocast_wrapper/nebula_agnocast_wrapper.hpp"
 #include "nebula_ros/common/diagnostics/rate_bound_status.hpp"
@@ -52,7 +53,7 @@ public:
   nebula::util::expected<drivers::PacketMetadata, drivers::DecodeError> process_cloud_packet(
     std::unique_ptr<nebula_msgs::msg::NebulaPacket> packet_msg);
 
-  void on_pointcloud_decoded(const drivers::NebulaPointCloudPtr & pointcloud, double timestamp_s);
+  void on_frame_decoded(const drivers::DecodeFrame & frame);
 
   void on_config_change(
     const std::shared_ptr<const nebula::drivers::HesaiSensorConfiguration> & new_config);
@@ -71,7 +72,7 @@ private:
   /// @brief Convert seconds to chrono::nanoseconds
   /// @param seconds
   /// @return chrono::nanoseconds
-  static inline std::chrono::nanoseconds seconds_to_chrono_nano_seconds(const double seconds)
+  static std::chrono::nanoseconds seconds_to_chrono_nano_seconds(const double seconds)
   {
     return std::chrono::duration_cast<std::chrono::nanoseconds>(
       std::chrono::duration<double>(seconds));
@@ -110,7 +111,7 @@ private:
   void initialize_packet_loss_diagnostic(diagnostic_updater::Updater & diagnostic_updater);
 
   std::pair<
-    std::shared_ptr<drivers::point_filters::BlockageMaskPlugin>,
+    std::shared_ptr<drivers::point_filters::BlockageMaskParams>,
     NEBULA_PUBLISHER_PTR(sensor_msgs::msg::Image)>
   initialize_blockage_mask_plugin();
 

--- a/nebula_tests/hesai/hesai_ros_decoder_test.cpp
+++ b/nebula_tests/hesai/hesai_ros_decoder_test.cpp
@@ -2,6 +2,8 @@
 
 #include "hesai_ros_decoder_test.hpp"
 
+#include "nebula_decoders/nebula_decoders_hesai/decoders/hesai_scan_decoder.hpp"
+
 #include <nebula_common/hesai/hesai_common.hpp>
 #include <nebula_common/nebula_common.hpp>
 #include <nebula_ros/common/rclcpp_logger.hpp>
@@ -189,13 +191,12 @@ void HesaiRosDecoderTest::read_bag(
 
       auto extracted_msg_ptr = std::make_shared<pandar_msgs::msg::PandarScan>(extracted_msg);
 
-      drivers::HesaiScanDecoder::pointcloud_callback_t pointcloud_cb =
-        [&](const drivers::NebulaPointCloudPtr & pointcloud, double timestamp_s) {
-          auto timestamp_ns = static_cast<uint64_t>(timestamp_s * 1e9);
-          scan_callback(bag_message->time_stamp, timestamp_ns, pointcloud);
+      drivers::HesaiScanDecoder::frame_callback_t frame_cb =
+        [&](const drivers::DecodeFrame & frame) {
+          scan_callback(bag_message->time_stamp, frame.timestamp_ns, frame.pointcloud);
         };
 
-      driver_ptr_->set_pointcloud_callback(pointcloud_cb);
+      driver_ptr_->set_frame_callback(frame_cb);
 
       for (const auto & pkt : extracted_msg_ptr->packets) {
         std::vector<uint8_t> packet_data(pkt.data.begin(), std::next(pkt.data.begin(), pkt.size));


### PR DESCRIPTION
## PR Type

- Improvement

## Related Links

* #329 -- introduced blockage mask here
* #330 -- introduced callback-based pointcloud pipeline here

## Description

Combine the callbacks for pointclouds and blockage masks into one callback `on_frame` which takes a `DecodeFrame` constref containing the time stamp, pointcloud and optional blockage mask.

This is a preparatory PR for the upcoming publisher thread optimization.

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
