### PR TITLE
fix(hesai): fusa reports as stuck in non-360 deg FoVs

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -16,6 +16,7 @@
     "ccit",
     "centi",
     "ddeg",
+    "demarked",
     "DHAVE",
     "Difop",
     "extrinsics",

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/functional_safety.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/functional_safety.hpp
@@ -134,7 +134,10 @@ private:
 
   [[nodiscard]] bool is_overdue(uint64_t timestamp_ns) const
   {
-    return (timestamp_ns - last_changed_timestamp_ns_) >= functional_safety_t::update_cycle_ns * 2;
+    // While the data shall change every N ms, in non-360 deg FoVs, there is a phase where no
+    // packets are sent by the sensor. To comply with any FoV, we have to allow for 100 ms (assuming
+    // a 10 Hz scan rate) before  reporting the system as stuck.
+    return (timestamp_ns - last_changed_timestamp_ns_) >= 100'000'000;
   }
 
   std::optional<FunctionalSafetyErrorCodes> try_accumulate_error_codes(

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/functional_safety.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/functional_safety.hpp
@@ -68,6 +68,11 @@ class FunctionalSafetyDecoder : public FunctionalSafetyDecoderTypedBase<PacketT>
   using status_cb_t = typename FunctionalSafetyDecoderBase::status_cb_t;
 
 public:
+  explicit FunctionalSafetyDecoder(uint16_t sensor_rpm)
+  : scan_period_ns_(rpm_to_scan_period_ns(sensor_rpm))
+  {
+  }
+
   void update(const PacketT & packet) override
   {
     uint64_t timestamp_ns = hesai_packet::get_timestamp_ns(packet);
@@ -117,6 +122,8 @@ public:
   void set_status_callback(status_cb_t on_status) override { on_status_ = std::move(on_status); }
 
 private:
+  static uint64_t rpm_to_scan_period_ns(uint16_t rpm) { return 60ULL * 1'000'000'000ULL / rpm; }
+
   bool has_changed(const functional_safety_t & current_value)
   {
     // From Hesai's safety manuals:
@@ -135,9 +142,9 @@ private:
   [[nodiscard]] bool is_overdue(uint64_t timestamp_ns) const
   {
     // While the data shall change every N ms, in non-360 deg FoVs, there is a phase where no
-    // packets are sent by the sensor. To comply with any FoV, we have to allow for 100 ms (assuming
-    // a 10 Hz scan rate) before  reporting the system as stuck.
-    return (timestamp_ns - last_changed_timestamp_ns_) >= 100'000'000;
+    // packets are sent by the sensor. To comply with any FoV, we have to allow for one scan
+    // period to pass before reporting the system as stuck.
+    return (timestamp_ns - last_changed_timestamp_ns_) >= scan_period_ns_;
   }
 
   std::optional<FunctionalSafetyErrorCodes> try_accumulate_error_codes(
@@ -182,6 +189,9 @@ private:
 
     return std::nullopt;
   }
+
+  //! The duration of one scan in nanoseconds.
+  uint64_t scan_period_ns_;
 
   uint64_t last_changed_timestamp_ns_{};
   functional_safety_t last_value_;

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/functional_safety.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/functional_safety.hpp
@@ -33,7 +33,7 @@ class FunctionalSafetyDecoderBase
 {
 public:
   using alive_cb_t = std::function<void()>;
-  using stuck_cb_t = std::function<void()>;
+  using stuck_cb_t = std::function<void(bool is_stuck)>;
   using status_cb_t = std::function<void(FunctionalSafetySeverity, FunctionalSafetyErrorCodes)>;
 
   virtual ~FunctionalSafetyDecoderBase() = default;
@@ -84,11 +84,10 @@ public:
     // but it only changes at a fixed rate e.g. every 5 ms.
     bool changed = has_changed(fs);
 
-    // Data not changing at that fixed rate signals the sensor's fault reporting system being
-    // stuck.
-    if (!changed && is_overdue(timestamp_ns)) {
-      if (on_stuck_) on_stuck_();
-      return;
+    // Data not changing at that fixed rate signals the sensor's fault reporting system being stuck.
+    bool is_stuck = !changed && is_overdue(timestamp_ns);
+    if (on_stuck_) {
+      on_stuck_(is_stuck);
     }
 
     // If there is no update, the data is ignored.

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/hesai_driver.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/hesai_driver.hpp
@@ -28,6 +28,7 @@
 
 #include <pcl_conversions/pcl_conversions.h>
 
+#include <cstdint>
 #include <memory>
 #include <tuple>
 #include <type_traits>
@@ -63,10 +64,10 @@ private:
   initialize_functional_safety_decoder(
     FunctionalSafetyDecoderBase::alive_cb_t alive_cb,
     FunctionalSafetyDecoderBase::stuck_cb_t stuck_cb,
-    FunctionalSafetyDecoderBase::status_cb_t status_cb)
+    FunctionalSafetyDecoderBase::status_cb_t status_cb, uint16_t sensor_rpm)
   {
     auto functional_safety_decoder =
-      std::make_shared<FunctionalSafetyDecoder<typename SensorT::packet_t>>();
+      std::make_shared<FunctionalSafetyDecoder<typename SensorT::packet_t>>(sensor_rpm);
     functional_safety_decoder->set_alive_callback(std::move(alive_cb));
     functional_safety_decoder->set_stuck_callback(std::move(stuck_cb));
     functional_safety_decoder->set_status_callback(std::move(status_cb));
@@ -80,7 +81,7 @@ private:
   initialize_functional_safety_decoder(
     FunctionalSafetyDecoderBase::alive_cb_t /* alive_cb */,
     FunctionalSafetyDecoderBase::stuck_cb_t /* stuck_cb */,
-    FunctionalSafetyDecoderBase::status_cb_t /* status_cb */)
+    FunctionalSafetyDecoderBase::status_cb_t /* status_cb */, uint16_t /* sensor_rpm */)
   {
     return nullptr;
   }

--- a/nebula_decoders/src/nebula_decoders_hesai/hesai_driver.cpp
+++ b/nebula_decoders/src/nebula_decoders_hesai/hesai_driver.cpp
@@ -17,6 +17,7 @@
 #include "nebula_decoders/nebula_decoders_hesai/decoders/pandar_xt32.hpp"
 #include "nebula_decoders/nebula_decoders_hesai/decoders/pandar_xt32m.hpp"
 
+#include <cstdint>
 #include <memory>
 #include <tuple>
 #include <type_traits>
@@ -106,8 +107,9 @@ std::shared_ptr<HesaiScanDecoder> HesaiDriver::initialize_decoder(
   FunctionalSafetyDecoderBase::status_cb_t status_cb, PacketLossDetectorBase::lost_cb_t lost_cb,
   std::shared_ptr<point_filters::BlockageMaskPlugin> blockage_mask_plugin)
 {
+  uint16_t sensor_rpm = sensor_configuration->rotation_speed;
   auto functional_safety_decoder =
-    initialize_functional_safety_decoder<SensorT>(alive_cb, stuck_cb, status_cb);
+    initialize_functional_safety_decoder<SensorT>(alive_cb, stuck_cb, status_cb, sensor_rpm);
   auto packet_loss_detector = initialize_packet_loss_detector<SensorT>(lost_cb);
 
   using CalibT = typename SensorT::angle_corrector_t::correction_data_t;

--- a/nebula_ros/include/nebula_ros/common/diagnostics/severity_latch.hpp
+++ b/nebula_ros/include/nebula_ros/common/diagnostics/severity_latch.hpp
@@ -36,14 +36,16 @@ public:
     std::lock_guard lock(mutex_);
 
     if (!current_status_) {
-      status.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "No status available");
+      status.summary(diagnostic_msgs::msg::DiagnosticStatus::STALE, "No status available");
       return;
     }
 
     status.values.insert(
       status.values.end(), current_status_->values.begin(), current_status_->values.end());
     status.summary(current_status_->level, current_status_->message);
-    current_status_ = std::nullopt;
+
+    // Reported the status, allow it to be reset in the next `submit()`.
+    should_reset_ = true;
   }
 
   void submit(diagnostic_msgs::msg::DiagnosticStatus status)
@@ -57,13 +59,19 @@ public:
 
     // Only the highest severity status in between two `run()`s is reported.
     // If multiple statuses with the same severity are submitted, only the last one is reported.
-    if (status.level >= current_status_->level) {
+    // If the `current_status_` is from a previous cycle (demarked by `should_reset_`), it is
+    // replaced with the new status, even if that new status has a lower severity.
+    if (status.level >= current_status_->level || should_reset_) {
       current_status_ = status;
     }
   }
 
 private:
   std::mutex mutex_;
+  //! Indicates that `current_status_` has been reported at least once via `run()`. In order to
+  //! have something to report in the next `run()` the status is kept until the next one is
+  //! `submit()`-ed. This member signals that the status has been reported and can be reset.
+  bool should_reset_ RCPPUTILS_TSA_GUARDED_BY(mutex_) = false;
   std::optional<diagnostic_msgs::msg::DiagnosticStatus> current_status_
     RCPPUTILS_TSA_GUARDED_BY(mutex_);
 };

--- a/nebula_ros/include/nebula_ros/hesai/diagnostics/functional_safety_diagnostic_task.hpp
+++ b/nebula_ros/include/nebula_ros/hesai/diagnostics/functional_safety_diagnostic_task.hpp
@@ -25,7 +25,6 @@
 #include <boost/algorithm/string.hpp>
 
 #include <string>
-#include <utility>
 
 namespace nebula::ros
 {
@@ -48,6 +47,10 @@ inline uint8_t severity_to_diagnostic_status_level(drivers::FunctionalSafetySeve
 
 inline std::string error_codes_to_string(const drivers::FunctionalSafetyErrorCodes & error_codes)
 {
+  if (error_codes.empty()) {
+    return "No error codes";
+  }
+
   std::stringstream ss;
   for (auto it = error_codes.begin(); it != error_codes.end(); ++it) {
     if (it != error_codes.begin()) {

--- a/nebula_ros/include/nebula_ros/hesai/diagnostics/functional_safety_diagnostic_task.hpp
+++ b/nebula_ros/include/nebula_ros/hesai/diagnostics/functional_safety_diagnostic_task.hpp
@@ -95,10 +95,12 @@ public:
   explicit FunctionalSafetyDiagnosticTask(rclcpp::Node * const parent_node)
   : CompositeDiagnosticTask("Functional safety status"),
     liveness_monitor_("Liveness", parent_node, 100ms),
-    severity_latch_("Status")
+    status_latch_("Status"),
+    stuck_latch_("Sensor functional safety system operation status")
   {
     addTask(&liveness_monitor_);
-    addTask(&severity_latch_);
+    addTask(&status_latch_);
+    addTask(&stuck_latch_);
   }
 
   void on_status(
@@ -114,22 +116,30 @@ public:
     kv.value = detail::error_codes_to_string(error_codes);
     status.values.push_back(kv);
 
-    severity_latch_.submit(status);
+    status_latch_.submit(status);
   }
 
   void on_alive() { liveness_monitor_.tick(); }
 
-  void on_stuck()
+  void on_stuck(bool is_stuck)
   {
     diagnostic_msgs::msg::DiagnosticStatus status;
-    status.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-    status.message = "Sensor diagnostics system is stuck";
-    severity_latch_.submit(status);
+
+    if (is_stuck) {
+      status.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+      status.message = "Sensor functional safety system is stuck";
+    } else {
+      status.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+      status.message = "Sensor functional safety system is running";
+    }
+
+    stuck_latch_.submit(status);
   }
 
 private:
   LivenessMonitor liveness_monitor_;
-  SeverityLatch severity_latch_;
+  SeverityLatch status_latch_;
+  SeverityLatch stuck_latch_;
 };
 
 }  // namespace nebula::ros

--- a/nebula_ros/src/hesai/decoder_wrapper.cpp
+++ b/nebula_ros/src/hesai/decoder_wrapper.cpp
@@ -255,7 +255,7 @@ std::shared_ptr<drivers::HesaiDriver> HesaiDecoderWrapper::initialize_driver(
 
   if (functional_safety_diagnostic_) {
     alive_cb = [this]() { functional_safety_diagnostic_->on_alive(); };
-    stuck_cb = [this]() { functional_safety_diagnostic_->on_stuck(); };
+    stuck_cb = [this](bool is_stuck) { functional_safety_diagnostic_->on_stuck(is_stuck); };
     status_cb = [this](
                   drivers::FunctionalSafetySeverity severity,
                   const drivers::FunctionalSafetyErrorCodes & codes) {

--- a/nebula_tests/hesai/hesai_ros_decoder_test.cpp
+++ b/nebula_tests/hesai/hesai_ros_decoder_test.cpp
@@ -89,6 +89,7 @@ Status HesaiRosDecoderTest::GetParameters(
   std::filesystem::path bag_root_dir = _SRC_RESOURCES_DIR_PATH;
   bag_root_dir /= "hesai";
 
+  sensor_configuration.rotation_speed = 600;
   sensor_configuration.sensor_model =
     nebula::drivers::sensor_model_from_string(params_.sensor_model);
   sensor_configuration.return_mode = nebula::drivers::return_mode_from_string_hesai(


### PR DESCRIPTION
## PR Type

- Bug Fix

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description

In non-360 deg FoVs, Nebula was reporting the functional safety status as stuck. The reasons:
* outside the FoV, no packets are sent (e.g. 50 ms for 180 deg FoV), but Nebula expects FuSa to update every 5 ms
* reported error codes and stuck reports were aggregated together, with the more severe status winning

The solutions this PR implements are:
* to handle error code aggregation and stuck status aggregation separately
* allow up to 100ms until FuSa updates, instead of 5ms

<table>
<tr>
<th> Before </th>
<th> After </th>
</tr>
<tr>
<td>

[Screencast from 2025年08月08日 19時35分40秒.webm](https://github.com/user-attachments/assets/ca9d4d67-c328-46bb-9079-bfdc325f3a21)

</td>
<td>

[Screencast from 2025年08月08日 19時34分43秒.webm](https://github.com/user-attachments/assets/6592793d-998b-47b9-bd4f-5ef9af6a2b85)

</td>
</tr>
</table>


## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
