### PR TITLE
build(nebula_ros): use ENABLE_AGNOCAST environment variable to fit in with the Autoware ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ pointcloud and blockage mask outputs.
 >
 > Agnocast support is currently limited to Hesai sensors.
 
-To build with support for Agnocast, add `-DUSE_AGNOCAST=ON` to the `--cmake-args` to the above
-`colcon build` command.
+To build with support for Agnocast, execute the above `colcon build` command with the environment
+variable `ENABLE_AGNOCAST=1` set.
 
 The following apt dependencies are required at run time:
 

--- a/nebula_ros/CMakeLists.txt
+++ b/nebula_ros/CMakeLists.txt
@@ -33,8 +33,8 @@ find_package(sync_tooling_msgs REQUIRED)
 find_package(message_filters REQUIRED)
 find_package(agnocastlib)
 
-if(USE_AGNOCAST AND NOT agnocastlib_FOUND)
-    message(FATAL_ERROR "agnocastlib is required when USE_AGNOCAST is enabled")
+if("$ENV{ENABLE_AGNOCAST}" AND NOT agnocastlib_FOUND)
+    message(FATAL_ERROR "agnocastlib is required when Agnocast is enabled")
 endif()
 
 include_directories(
@@ -81,7 +81,8 @@ target_link_libraries(hesai_ros_wrapper PUBLIC
     nebula_hw_interfaces::nebula_hw_interfaces_hesai
 )
 
-if(USE_AGNOCAST)
+if("$ENV{ENABLE_AGNOCAST}")
+    message("Agnocast support is enabled")
     target_include_directories(hesai_ros_wrapper PUBLIC ${agnocastlib_INCLUDE_DIRS})
     target_link_libraries(hesai_ros_wrapper PUBLIC ${agnocastlib_LIBRARIES})
     add_definitions(-DUSE_AGNOCAST_ENABLED)
@@ -314,7 +315,7 @@ ament_export_dependencies(
     sync_tooling_msgs
 )
 
-if(USE_AGNOCAST)
+if("$ENV{ENABLE_AGNOCAST}")
     ament_export_dependencies(agnocastlib)
 endif()
 


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Improvement

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->
- [TIER IV INTERNAL LINK](https://star4.slack.com/archives/CRUE57C30/p1755828846609449?thread_ts=1755669594.416389&cid=CRUE57C30) -- internal request

## Description

<!-- Describe what this PR changes. -->
This PR removes the `-DUSE_AGNOCAST` CMake option and adds support for the environment variable `ENABLE_AGNOCAST`.

Tested on my local machine with `ENABLE_AGNOCAST=0` and `ENABLE_AGNOCAST=1`.

## Review Procedure

<!-- Explain how to review this PR. -->
Compile with
* `ENABLE_AGNOCAST=0 colcon build` and confirm that Agnocast is disabled
* `ENABLE_AGNOCAST=1 colcon build` and confirm that Agnocast is enabled

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
