### PR TITLE
fix(hesai_hw_interfaces): slightly widen FoV

### DIFF
--- a/nebula_common/include/nebula_common/hesai/hesai_common.hpp
+++ b/nebula_common/include/nebula_common/hesai/hesai_common.hpp
@@ -202,6 +202,12 @@ struct HesaiCalibrationConfiguration : public HesaiCalibrationConfigurationBase
       max = std::max(max, item.second);
     }
 
+    // NOTE: Slightly widen the FOV padding because some LiDARs do not transmit blocks near the end
+    // of the FOV. If these blocks are missing, the point cloud may not be published at the desired
+    // timing.
+    min -= 0.1f;
+    max += 0.1f;
+
     return {-max, -min};
   }
 };

--- a/nebula_common/include/nebula_common/hesai/hesai_common.hpp
+++ b/nebula_common/include/nebula_common/hesai/hesai_common.hpp
@@ -205,8 +205,8 @@ struct HesaiCalibrationConfiguration : public HesaiCalibrationConfigurationBase
     // NOTE: Slightly widen the FOV padding because some LiDARs do not transmit blocks near the end
     // of the FOV. If these blocks are missing, the point cloud may not be published at the desired
     // timing.
-    min -= 0.1f;
-    max += 0.1f;
+    min -= 1.0f;
+    max += 1.0f;
 
     return {-max, -min};
   }


### PR DESCRIPTION
## PR Type

- Bug Fix

## Related Links

* https://github.com/tier4/nebula/issues/339

## Description

Based on my experience, the Hesai XT32 occasionally does not publish packets near the boundary of the FOV.
When that happens, Nebula cannot publish the point cloud at the correct timing. :cry: 

Currently, Nebula uses a calibration file downloaded to set the minimum FOV for the LiDAR, but this seems to be not sufficient. **Therefore, I added a fix that adjusts the FOV by ~~0.1~~ `1.0 degrees` .**

> [!NOTE]
> At least for all the “problematic” LiDARs I have encountered, this fix has been sufficient.

### My Experiments

Here is a video of one of the “problematic” LiDARs I encountered.

https://github.com/user-attachments/assets/ef7b711b-031f-4551-858b-668d7660c1f3


When running nebula (v0.2.6.1), only a single line of point clouds is published.
However, if I configure the LiDAR via the web interface to use an FoV that is wider by just 0.1 degrees, the expected point clouds are displayed.

When Nebula is restarted, the LiDAR is reset to the minimum FoV, and once again only a strange point cloud is published.
With my PR applied, this issue is resolved.

## Review Procedure

~~I have confirmed that the FOV of the XT32 expands by 0.1 degrees.~~
I have confirmed that the FOV of the XT32 expands by 1.0 degrees.

## Remarks

Nothing

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
