### PR TITLE
perf(hesai): get rid of copy when replaying `/pandar_packets`

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -28,6 +28,7 @@
     "horiz",
     "Idat",
     "ipaddr",
+    "libmsgsl",
     "manc",
     "mdeg",
     "memcpy",

--- a/nebula_decoders/CMakeLists.txt
+++ b/nebula_decoders/CMakeLists.txt
@@ -26,6 +26,7 @@ find_package(sensor_msgs REQUIRED)
 find_package(velodyne_msgs REQUIRED)
 find_package(yaml-cpp REQUIRED)
 find_package(PNG REQUIRED)
+find_package(Microsoft.GSL REQUIRED)
 
 # Check if pcl_conversions provides modern CMake targets (ROS 2 Jazzy and later)
 # or if we need to use legacy variables (ROS 2 Humble and earlier)
@@ -64,6 +65,7 @@ add_library(nebula_decoders_hesai SHARED
 target_link_libraries(nebula_decoders_hesai PUBLIC
     ${pandar_msgs_TARGETS}
     ${PNG_LIBRARIES}
+    Microsoft.GSL::GSL
 )
 
 target_include_directories(nebula_decoders_hesai PUBLIC
@@ -177,6 +179,7 @@ ament_export_dependencies(
     sensor_msgs
     velodyne_msgs
     yaml-cpp
+    Microsoft.GSL
 )
 
 ament_package()

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/hesai_decoder.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/hesai_decoder.hpp
@@ -23,6 +23,7 @@
 #include "nebula_decoders/nebula_decoders_hesai/decoders/hesai_scan_decoder.hpp"
 #include "nebula_decoders/nebula_decoders_hesai/decoders/packet_loss_detector.hpp"
 
+#include <gsl/span>
 #include <nebula_common/hesai/hesai_common.hpp>
 #include <nebula_common/loggers/logger.hpp>
 #include <nebula_common/nebula_common.hpp>
@@ -106,7 +107,7 @@ private:
   /// @brief Validates and parse PandarPacket. Checks size and, if present, CRC checksums.
   /// @param packet The incoming PandarPacket
   /// @return Whether the packet was parsed successfully
-  bool parse_packet(const std::vector<uint8_t> & packet)
+  bool parse_packet(gsl::span<const uint8_t> packet)
   {
     if (packet.size() < sizeof(typename SensorT::packet_t)) {
       NEBULA_LOG_STREAM(
@@ -350,7 +351,7 @@ public:
     pointcloud_callback_ = std::move(callback);
   }
 
-  PacketDecodeResult unpack(const std::vector<uint8_t> & packet) override
+  PacketDecodeResult unpack(gsl::span<const uint8_t> packet) override
   {
     util::Stopwatch decode_watch;
 

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/hesai_scan_decoder.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/decoders/hesai_scan_decoder.hpp
@@ -15,6 +15,7 @@
 #ifndef NEBULA_WS_HESAI_SCAN_DECODER_HPP
 #define NEBULA_WS_HESAI_SCAN_DECODER_HPP
 
+#include <gsl/span>
 #include <nebula_common/hesai/hesai_common.hpp>
 #include <nebula_common/point_types.hpp>
 #include <nebula_common/util/expected.hpp>
@@ -74,7 +75,7 @@ public:
   /// @param packet The incoming PandarPacket
   /// @return Metadata on success, or decode error on failure. Performance counters are always
   /// returned.
-  virtual PacketDecodeResult unpack(const std::vector<uint8_t> & packet) = 0;
+  virtual PacketDecodeResult unpack(gsl::span<const uint8_t> packet) = 0;
 
   virtual void set_pointcloud_callback(pointcloud_callback_t callback) = 0;
 };

--- a/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/hesai_driver.hpp
+++ b/nebula_decoders/include/nebula_decoders/nebula_decoders_hesai/hesai_driver.hpp
@@ -24,6 +24,7 @@
 #include "nebula_decoders/nebula_decoders_hesai/decoders/hesai_scan_decoder.hpp"
 #include "nebula_decoders/nebula_decoders_hesai/decoders/packet_loss_detector.hpp"
 
+#include <gsl/span>
 #include <nebula_common/loggers/logger.hpp>
 
 #include <pcl_conversions/pcl_conversions.h>
@@ -140,7 +141,7 @@ public:
   /// @param packet Packet to decode
   /// @return Metadata on success, or decode error on failure. Performance counters are always
   /// returned.
-  PacketDecodeResult parse_cloud_packet(const std::vector<uint8_t> & packet);
+  PacketDecodeResult parse_cloud_packet(gsl::span<const uint8_t> packet);
 };
 
 }  // namespace nebula::drivers

--- a/nebula_decoders/package.xml
+++ b/nebula_decoders/package.xml
@@ -21,6 +21,7 @@
   <depend>angles</depend>
   <depend>continental_msgs</depend>
   <depend>diagnostic_msgs</depend>
+  <depend>libmsgsl-dev</depend>
   <depend>nebula_common</depend>
   <depend>nebula_msgs</depend>
   <depend>pandar_msgs</depend>

--- a/nebula_decoders/src/nebula_decoders_hesai/hesai_driver.cpp
+++ b/nebula_decoders/src/nebula_decoders_hesai/hesai_driver.cpp
@@ -16,6 +16,8 @@
 #include "nebula_decoders/nebula_decoders_hesai/decoders/pandar_xt32.hpp"
 #include "nebula_decoders/nebula_decoders_hesai/decoders/pandar_xt32m.hpp"
 
+#include <gsl/span>
+
 #include <cstdint>
 #include <memory>
 #include <utility>
@@ -116,7 +118,7 @@ std::shared_ptr<HesaiScanDecoder> HesaiDriver::initialize_decoder(
     std::move(blockage_mask_plugin));
 }
 
-PacketDecodeResult HesaiDriver::parse_cloud_packet(const std::vector<uint8_t> & packet)
+PacketDecodeResult HesaiDriver::parse_cloud_packet(gsl::span<const uint8_t> packet)
 {
   if (driver_status_ != nebula::Status::OK) {
     logger_->error("Driver not OK.");

--- a/nebula_ros/CMakeLists.txt
+++ b/nebula_ros/CMakeLists.txt
@@ -34,6 +34,7 @@ find_package(message_filters REQUIRED)
 find_package(autoware_utils_debug REQUIRED)
 find_package(autoware_internal_debug_msgs REQUIRED)
 find_package(agnocastlib)
+find_package(Microsoft.GSL REQUIRED)
 
 if("$ENV{ENABLE_AGNOCAST}" AND NOT agnocastlib_FOUND)
     message(FATAL_ERROR "agnocastlib is required when Agnocast is enabled")
@@ -82,6 +83,7 @@ target_link_libraries(hesai_ros_wrapper PUBLIC
     ${autoware_internal_debug_msgs_TARGETS}
     nebula_decoders::nebula_decoders_hesai
     nebula_hw_interfaces::nebula_hw_interfaces_hesai
+    Microsoft.GSL::GSL
 )
 
 if("$ENV{ENABLE_AGNOCAST}")
@@ -331,6 +333,7 @@ ament_export_dependencies(
     sync_tooling_msgs
     autoware_utils_debug
     autoware_internal_debug_msgs
+    Microsoft.GSL
 )
 
 if("$ENV{ENABLE_AGNOCAST}")

--- a/nebula_ros/include/nebula_ros/hesai/decoder_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/hesai/decoder_wrapper.hpp
@@ -25,12 +25,12 @@
 #include <autoware_utils_debug/debug_publisher.hpp>
 #include <diagnostic_updater/publisher.hpp>
 #include <diagnostic_updater/update_functions.hpp>
+#include <gsl/span>
 #include <nebula_common/hesai/hesai_common.hpp>
 #include <nebula_common/nebula_common.hpp>
 #include <rclcpp/node.hpp>
 #include <rclcpp/rclcpp.hpp>
 
-#include <nebula_msgs/msg/nebula_packet.hpp>
 #include <pandar_msgs/msg/pandar_scan.hpp>
 
 #include <limits>
@@ -51,11 +51,12 @@ public:
     diagnostic_updater::Updater & diagnostic_updater, bool publish_packets);
 
   /// @brief Process a cloud packet and return metadata
-  /// @param packet_msg The packet to process
-  /// @param receive_metadata Performance metadata from packet reception
+  /// @param packet_data The raw packet data
+  /// @param packet_stamp_ns Timestamp of the packet in nanoseconds
+  /// @param receive_time_ns Performance metadata from packet reception
   /// @return Expected containing metadata on success, or decode error on failure
   drivers::PacketDecodeResult process_cloud_packet(
-    std::unique_ptr<nebula_msgs::msg::NebulaPacket> packet_msg, uint64_t receive_time_ns);
+    gsl::span<const uint8_t> packet_data, uint64_t packet_stamp_ns, uint64_t receive_time_ns);
 
   void on_pointcloud_decoded(const drivers::NebulaPointCloudPtr & pointcloud, double timestamp_s);
 

--- a/nebula_ros/include/nebula_ros/hesai/hesai_ros_wrapper.hpp
+++ b/nebula_ros/include/nebula_ros/hesai/hesai_ros_wrapper.hpp
@@ -28,7 +28,6 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
 
-#include <nebula_msgs/msg/nebula_packet.hpp>
 #include <pandar_msgs/msg/pandar_scan.hpp>
 
 #include <boost/algorithm/string/join.hpp>

--- a/nebula_ros/package.xml
+++ b/nebula_ros/package.xml
@@ -24,6 +24,7 @@
   <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>geometry_msgs</depend>
+  <depend>libmsgsl-dev</depend>
   <depend>message_filters</depend>
   <depend>nebula_common</depend>
   <depend>nebula_decoders</depend>

--- a/nebula_ros/src/hesai/decoder_wrapper.cpp
+++ b/nebula_ros/src/hesai/decoder_wrapper.cpp
@@ -117,15 +117,12 @@ drivers::PacketDecodeResult HesaiDecoderWrapper::process_cloud_packet(
 {
   current_scan_perf_counters_.receive_time_current_scan_ns += receive_time_ns;
 
-  builtin_interfaces::msg::Time packet_stamp;
-  packet_stamp.sec = static_cast<int32_t>(packet_stamp_ns / 1'000'000'000);
-  packet_stamp.nanosec = static_cast<uint32_t>(packet_stamp_ns % 1'000'000'000);
-
   // Ideally, we would only accumulate packets if someone is subscribed to the packets topic.
   // However, checking for subscriptions in the decode thread (here) causes contention with the
   // publish thread, negating the benefits of multi-threading.
   // Not checking is an okay trade-off for the time being.
   if (packets_pub_) {
+    rclcpp::Time packet_stamp(static_cast<int64_t>(packet_stamp_ns));
     if (current_scan_msg_->packets.size() == 0) {
       current_scan_msg_->header.stamp = packet_stamp;
     }


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Improvement

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->
- [TIER IV INTERNAL](https://star4.slack.com/archives/C05311Y9L2X/p1764149190815289?thread_ts=1763108586.608169&cid=C05311Y9L2X) -- discussion

## Description

<!-- Describe what this PR changes. -->
This PR removes an unnecessary per-packet copy when replaying `/pandar_packets`. Due to the conversion between `PandarScan` and `NebulaPackets`, a copy of the buffer (`std::array` vs. `std::vector`) was necessary before.

Now, we reference the incoming buffer via `gsl::span`, no matter if `std::vector` from UDP or `std::array` from `PandarScan`.

Outgoing packets are still copied.

## Review Procedure

<!-- Explain how to review this PR. -->
* code review
* test record/replay functionality
* confirm memory safety

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
