### PR TITLE
ci: add GitHub Actions workflow for linting Autoware system design format

### DIFF
--- a/.github/workflows/lint-autoware-system-design-format.yml
+++ b/.github/workflows/lint-autoware-system-design-format.yml
@@ -1,0 +1,30 @@
+name: Lint Autoware System Design Format
+
+on:
+  pull_request:
+    paths:
+      - "**/*.node.yaml"
+      - "**/*.module.yaml"
+      - "**/*.system.yaml"
+      - "**/*.parameter_set.yaml"
+  push:
+    branches:
+      - main
+    paths:
+      - "**/*.node.yaml"
+      - "**/*.module.yaml"
+      - "**/*.system.yaml"
+      - "**/*.parameter_set.yaml"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Lint system design format files
+        uses: autowarefoundation/autoware_system_designer@v0.3.0
+        with:
+          design_files_path: .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,4 +94,10 @@ repos:
         args: [--quiet, '--filter=-runtime/arrays,-build/c++17,-readability/casting']
         exclude: .cu
 
+  - repo: https://github.com/autowarefoundation/autoware_system_designer
+    rev: v0.3.0
+    hooks:
+      - id: lint-system-design-format
+        args: [--format=github-actions]
+
 exclude: .svg


### PR DESCRIPTION



## PR Type


- Improvement

## Related Links

https://github.com/autowarefoundation/autoware_system_designer/issues/6
https://github.com/tier4/nebula/pull/403

## Description
- Introduced a new workflow to lint system design format files on pull requests and pushes to the main branch.
- Updated pre-commit configuration to include a new hook for linting with autoware_system_designer.


## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
