### PR TITLE
test: increase nebula_core_common unit coverage

### DIFF
--- a/src/nebula_core/nebula_core_common/CMakeLists.txt
+++ b/src/nebula_core/nebula_core_common/CMakeLists.txt
@@ -29,6 +29,9 @@ if(BUILD_TESTING)
   target_link_libraries(test_pcd_io nebula_core_common)
   target_compile_definitions(
     test_pcd_io PRIVATE NEBULA_CORE_COMMON_TEST_RESOURCES_DIR="${CMAKE_CURRENT_SOURCE_DIR}/test_resources")
+
+  ament_add_gtest(test_nebula_common test/test_nebula_common.cpp)
+  target_link_libraries(test_nebula_common nebula_core_common)
 endif()
 
 install(TARGETS nebula_core_common EXPORT export_nebula_core_common)

--- a/src/nebula_core/nebula_core_common/CMakeLists.txt
+++ b/src/nebula_core/nebula_core_common/CMakeLists.txt
@@ -32,6 +32,9 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_nebula_common test/test_nebula_common.cpp)
   target_link_libraries(test_nebula_common nebula_core_common)
+
+  ament_add_gtest(test_ring_buffer test/test_ring_buffer.cpp)
+  target_link_libraries(test_ring_buffer nebula_core_common)
 endif()
 
 install(TARGETS nebula_core_common EXPORT export_nebula_core_common)

--- a/src/nebula_core/nebula_core_common/CMakeLists.txt
+++ b/src/nebula_core/nebula_core_common/CMakeLists.txt
@@ -35,6 +35,9 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_ring_buffer test/test_ring_buffer.cpp)
   target_link_libraries(test_ring_buffer nebula_core_common)
+
+  ament_add_gtest(test_utility_helpers test/test_utility_helpers.cpp)
+  target_link_libraries(test_utility_helpers nebula_core_common)
 endif()
 
 install(TARGETS nebula_core_common EXPORT export_nebula_core_common)

--- a/src/nebula_core/nebula_core_common/include/nebula_core_common/nebula_common.hpp
+++ b/src/nebula_core/nebula_core_common/include/nebula_core_common/nebula_common.hpp
@@ -408,6 +408,7 @@ inline SensorModel sensor_model_from_string(const std::string & sensor_model)
   if (sensor_model == "PandarAT128") return SensorModel::HESAI_PANDARAT128;
   if (sensor_model == "PandarQT64") return SensorModel::HESAI_PANDARQT64;
   if (sensor_model == "PandarQT128") return SensorModel::HESAI_PANDARQT128;
+  if (sensor_model == "Pandar128E3X") return SensorModel::HESAI_PANDAR128_E3X;
   if (sensor_model == "Pandar128E4X") return SensorModel::HESAI_PANDAR128_E4X;
   // Velodyne
   if (sensor_model == "VLS128") return SensorModel::VELODYNE_VLS128;
@@ -449,6 +450,8 @@ inline std::string sensor_model_to_string(const SensorModel & sensor_model)
       return "PandarQT64";
     case SensorModel::HESAI_PANDARQT128:
       return "PandarQT128";
+    case SensorModel::HESAI_PANDAR128_E3X:
+      return "Pandar128E3X";
     case SensorModel::HESAI_PANDAR128_E4X:
       return "Pandar128E4X";
     // Velodyne

--- a/src/nebula_core/nebula_core_common/include/nebula_core_common/nebula_status.hpp
+++ b/src/nebula_core/nebula_core_common/include/nebula_core_common/nebula_status.hpp
@@ -60,6 +60,9 @@ struct Status
       case Status::UDP_CONNECTION_ERROR:
         os << "Udp Connection Error";
         break;
+      case Status::CAN_CONNECTION_ERROR:
+        os << "Can Connection Error";
+        break;
       case Status::SENSOR_CONFIG_ERROR:
         os << "Could not set SensorConfiguration";
         break;

--- a/src/nebula_core/nebula_core_common/include/nebula_core_common/util/bitfield.hpp
+++ b/src/nebula_core/nebula_core_common/include/nebula_core_common/util/bitfield.hpp
@@ -49,8 +49,7 @@ constexpr OutT get_bitfield(const InT & storage)
   static_assert(HighBit < storage_bits, "HighBit must be within the width of InT");
   constexpr uint8_t n_bits = HighBit - LowBit + 1;
   constexpr InT all_ones = ~static_cast<InT>(0);
-  constexpr InT mask =
-    n_bits == storage_bits ? all_ones : static_cast<InT>(~static_cast<InT>(all_ones << n_bits));
+  constexpr InT mask = static_cast<InT>(all_ones >> (storage_bits - n_bits));
 
   InT raw_value = (storage >> LowBit) & mask;
   return static_cast<OutT>(raw_value);

--- a/src/nebula_core/nebula_core_common/include/nebula_core_common/util/bitfield.hpp
+++ b/src/nebula_core/nebula_core_common/include/nebula_core_common/util/bitfield.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <cstdint>
+#include <type_traits>
 namespace nebula::util
 {
 
@@ -41,9 +42,15 @@ namespace nebula::util
 template <typename OutT, uint8_t LowBit, uint8_t HighBit, typename InT>
 constexpr OutT get_bitfield(const InT & storage)
 {
+  static_assert(std::is_integral_v<InT>, "InT must be an integral type");
+  static_assert(std::is_unsigned_v<InT>, "InT must be an unsigned integral type");
+  constexpr auto storage_bits = static_cast<uint8_t>(sizeof(InT) * 8U);
+  static_assert(LowBit <= HighBit, "LowBit must not exceed HighBit");
+  static_assert(HighBit < storage_bits, "HighBit must be within the width of InT");
   constexpr uint8_t n_bits = HighBit - LowBit + 1;
   constexpr InT all_ones = ~static_cast<InT>(0);
-  constexpr InT mask = static_cast<InT>(~static_cast<InT>(all_ones << n_bits));
+  constexpr InT mask =
+    n_bits == storage_bits ? all_ones : static_cast<InT>(~static_cast<InT>(all_ones << n_bits));
 
   InT raw_value = (storage >> LowBit) & mask;
   return static_cast<OutT>(raw_value);

--- a/src/nebula_core/nebula_core_common/include/nebula_core_common/util/bitfield.hpp
+++ b/src/nebula_core/nebula_core_common/include/nebula_core_common/util/bitfield.hpp
@@ -43,7 +43,7 @@ constexpr OutT get_bitfield(const InT & storage)
 {
   constexpr uint8_t n_bits = HighBit - LowBit + 1;
   constexpr InT all_ones = ~static_cast<InT>(0);
-  constexpr InT mask = ~(all_ones << n_bits);
+  constexpr InT mask = static_cast<InT>(~static_cast<InT>(all_ones << n_bits));
 
   InT raw_value = (storage >> LowBit) & mask;
   return static_cast<OutT>(raw_value);

--- a/src/nebula_core/nebula_core_common/include/nebula_core_common/util/bitfield.hpp
+++ b/src/nebula_core/nebula_core_common/include/nebula_core_common/util/bitfield.hpp
@@ -49,6 +49,7 @@ constexpr OutT get_bitfield(const InT & storage)
   static_assert(HighBit < storage_bits, "HighBit must be within the width of InT");
   constexpr uint8_t n_bits = HighBit - LowBit + 1;
   constexpr InT all_ones = ~static_cast<InT>(0);
+  // This low-bit mask relies on InT being unsigned so the right shift zero-fills.
   constexpr InT mask = static_cast<InT>(all_ones >> (storage_bits - n_bits));
 
   InT raw_value = (storage >> LowBit) & mask;

--- a/src/nebula_core/nebula_core_common/include/nebula_core_common/util/errno.hpp
+++ b/src/nebula_core/nebula_core_common/include/nebula_core_common/util/errno.hpp
@@ -24,7 +24,7 @@ namespace nebula::util
 inline std::string errno_to_string(int err_no)
 {
   static constexpr size_t gnu_max_strerror_length = 1024;
-  std::array<char, gnu_max_strerror_length> msg_buf;  // NOLINT
+  std::array<char, gnu_max_strerror_length> msg_buf{};  // NOLINT
   std::string_view msg = strerror_r(err_no, msg_buf.data(), msg_buf.size());
   return std::string{msg};
 }

--- a/src/nebula_core/nebula_core_common/test/test_nebula_common.cpp
+++ b/src/nebula_core/nebula_core_common/test/test_nebula_common.cpp
@@ -1,0 +1,336 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "nebula_core_common/nebula_common.hpp"
+#include "nebula_core_common/nebula_status.hpp"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <initializer_list>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace
+{
+
+using nebula::Status;
+using nebula::drivers::CANSensorConfigurationBase;
+using nebula::drivers::EthernetSensorConfigurationBase;
+using nebula::drivers::LidarConfigurationBase;
+using nebula::drivers::PointCloud;
+using nebula::drivers::PointXYZ;
+using nebula::drivers::PointXYZIR;
+using nebula::drivers::PointXYZIRADT;
+using nebula::drivers::PointXYZIRCAEDT;
+using nebula::drivers::ReturnMode;
+using nebula::drivers::ReturnType;
+using nebula::drivers::SensorConfigurationBase;
+using nebula::drivers::SensorModel;
+
+template <typename T>
+std::string stream_to_string(const T & value)
+{
+  std::ostringstream stream;
+  stream << value;
+  return stream.str();
+}
+
+void expect_contains_all(
+  const std::string & output, std::initializer_list<std::string_view> expected_substrings)
+{
+  for (const auto expected_substring : expected_substrings) {
+    EXPECT_NE(output.find(expected_substring), std::string::npos) << output;
+  }
+}
+
+TEST(NebulaCommonTest, ReturnTypeStreamingCoversAllEnumerators)
+{
+  constexpr std::array<std::pair<ReturnType, std::string_view>, 11> expected_values{{
+    {ReturnType::UNKNOWN, "Unknown"},
+    {ReturnType::LAST, "Last"},
+    {ReturnType::FIRST, "First"},
+    {ReturnType::STRONGEST, "Strongest"},
+    {ReturnType::FIRST_WEAK, "FirstWeak"},
+    {ReturnType::LAST_WEAK, "LastWeak"},
+    {ReturnType::IDENTICAL, "Identical"},
+    {ReturnType::SECOND, "Second"},
+    {ReturnType::SECONDSTRONGEST, "SecondStrongest"},
+    {ReturnType::FIRST_STRONGEST, "FirstStrongest"},
+    {ReturnType::LAST_STRONGEST, "LastStrongest"},
+  }};
+
+  for (const auto & [value, expected_string] : expected_values) {
+    EXPECT_EQ(stream_to_string(value), expected_string);
+  }
+}
+
+TEST(NebulaCommonTest, ReturnModeStreamingAndParsingCoversSupportedValues)
+{
+  constexpr std::array<std::pair<ReturnMode, std::string_view>, 19> expected_values{{
+    {ReturnMode::SINGLE_FIRST, "SingleFirst"},
+    {ReturnMode::SINGLE_STRONGEST, "SingleStrongest"},
+    {ReturnMode::SINGLE_LAST, "SingleLast"},
+    {ReturnMode::DUAL_ONLY, "Dual"},
+    {ReturnMode::DUAL_FIRST, "DualFirst"},
+    {ReturnMode::DUAL_LAST, "DualLast"},
+    {ReturnMode::DUAL_WEAK_FIRST, "WeakFirst"},
+    {ReturnMode::DUAL_WEAK_LAST, "WeakLast"},
+    {ReturnMode::DUAL_STRONGEST_LAST, "StrongLast"},
+    {ReturnMode::DUAL_STRONGEST_FIRST, "StrongFirst"},
+    {ReturnMode::TRIPLE, "Triple"},
+    {ReturnMode::LAST, "Last"},
+    {ReturnMode::STRONGEST, "Strongest"},
+    {ReturnMode::DUAL_LAST_STRONGEST, "LastStrongest"},
+    {ReturnMode::FIRST, "First"},
+    {ReturnMode::DUAL_LAST_FIRST, "LastFirst"},
+    {ReturnMode::DUAL_FIRST_STRONGEST, "FirstStrongest"},
+    {ReturnMode::DUAL, "Dual"},
+    {ReturnMode::UNKNOWN, "Unknown"},
+  }};
+
+  for (const auto & [value, expected_string] : expected_values) {
+    EXPECT_EQ(stream_to_string(value), expected_string);
+  }
+
+  constexpr std::array<std::pair<std::string_view, ReturnMode>, 4> supported_round_trips{{
+    {"SingleFirst", ReturnMode::SINGLE_FIRST},
+    {"SingleStrongest", ReturnMode::SINGLE_STRONGEST},
+    {"SingleLast", ReturnMode::SINGLE_LAST},
+    {"Dual", ReturnMode::DUAL_ONLY},
+  }};
+
+  for (const auto & [string_value, expected_mode] : supported_round_trips) {
+    EXPECT_EQ(nebula::drivers::return_mode_from_string(std::string(string_value)), expected_mode);
+    EXPECT_EQ(
+      nebula::drivers::return_mode_from_string(stream_to_string(expected_mode)), expected_mode);
+  }
+
+  EXPECT_EQ(nebula::drivers::return_mode_from_string("NotAReturnMode"), ReturnMode::UNKNOWN);
+}
+
+TEST(NebulaCommonTest, SensorModelStreamingAndStringConversionsRoundTrip)
+{
+  constexpr std::array<std::pair<SensorModel, std::string_view>, 23> streamed_values{{
+    {SensorModel::HESAI_PANDAR64, "Pandar64"},
+    {SensorModel::HESAI_PANDAR40P, "Pandar40P"},
+    {SensorModel::HESAI_PANDAR40M, "Pandar40M"},
+    {SensorModel::HESAI_PANDARQT64, "PandarQT64"},
+    {SensorModel::HESAI_PANDARQT128, "PandarQT128"},
+    {SensorModel::HESAI_PANDARXT16, "PandarXT16"},
+    {SensorModel::HESAI_PANDARXT32, "PandarXT32"},
+    {SensorModel::HESAI_PANDARXT32M, "PandarXT32M"},
+    {SensorModel::HESAI_PANDARAT128, "PandarAT128"},
+    {SensorModel::HESAI_PANDAR128_E3X, "Pandar128_E3X"},
+    {SensorModel::HESAI_PANDAR128_E4X, "Pandar128_E4X_OT"},
+    {SensorModel::VELODYNE_VLS128, "VLS128"},
+    {SensorModel::VELODYNE_HDL64, "HDL64"},
+    {SensorModel::VELODYNE_VLP32, "VLP32"},
+    {SensorModel::VELODYNE_VLP32MR, "VLP32MR"},
+    {SensorModel::VELODYNE_HDL32, "HDL32"},
+    {SensorModel::VELODYNE_VLP16, "VLP16"},
+    {SensorModel::ROBOSENSE_HELIOS, "HELIOS"},
+    {SensorModel::ROBOSENSE_BPEARL_V3, "BPEARL V3.0"},
+    {SensorModel::ROBOSENSE_BPEARL_V4, "BPEARL V4.0"},
+    {SensorModel::CONTINENTAL_ARS548, "ARS548"},
+    {SensorModel::CONTINENTAL_SRR520, "SRR520"},
+    {SensorModel::UNKNOWN, "Sensor Unknown"},
+  }};
+
+  for (const auto & [value, expected_string] : streamed_values) {
+    EXPECT_EQ(stream_to_string(value), expected_string);
+  }
+
+  constexpr std::array<std::pair<std::string_view, SensorModel>, 22> canonical_round_trips{{
+    {"Pandar64", SensorModel::HESAI_PANDAR64},
+    {"Pandar40P", SensorModel::HESAI_PANDAR40P},
+    {"Pandar40M", SensorModel::HESAI_PANDAR40M},
+    {"PandarXT16", SensorModel::HESAI_PANDARXT16},
+    {"PandarXT32", SensorModel::HESAI_PANDARXT32},
+    {"PandarXT32M", SensorModel::HESAI_PANDARXT32M},
+    {"PandarAT128", SensorModel::HESAI_PANDARAT128},
+    {"PandarQT64", SensorModel::HESAI_PANDARQT64},
+    {"PandarQT128", SensorModel::HESAI_PANDARQT128},
+    {"Pandar128E3X", SensorModel::HESAI_PANDAR128_E3X},
+    {"Pandar128E4X", SensorModel::HESAI_PANDAR128_E4X},
+    {"VLS128", SensorModel::VELODYNE_VLS128},
+    {"HDL64", SensorModel::VELODYNE_HDL64},
+    {"VLP32", SensorModel::VELODYNE_VLP32},
+    {"VLP32MR", SensorModel::VELODYNE_VLP32MR},
+    {"HDL32", SensorModel::VELODYNE_HDL32},
+    {"VLP16", SensorModel::VELODYNE_VLP16},
+    {"Helios", SensorModel::ROBOSENSE_HELIOS},
+    {"Bpearl_V3", SensorModel::ROBOSENSE_BPEARL_V3},
+    {"Bpearl_V4", SensorModel::ROBOSENSE_BPEARL_V4},
+    {"ARS548", SensorModel::CONTINENTAL_ARS548},
+    {"SRR520", SensorModel::CONTINENTAL_SRR520},
+  }};
+
+  for (const auto & [string_value, expected_model] : canonical_round_trips) {
+    EXPECT_EQ(nebula::drivers::sensor_model_from_string(std::string(string_value)), expected_model);
+    EXPECT_EQ(nebula::drivers::sensor_model_to_string(expected_model), string_value);
+  }
+
+  EXPECT_EQ(
+    nebula::drivers::sensor_model_from_string("Bpearl"), SensorModel::ROBOSENSE_BPEARL_V4);
+  EXPECT_EQ(nebula::drivers::sensor_model_from_string("NotASensor"), SensorModel::UNKNOWN);
+  EXPECT_EQ(nebula::drivers::sensor_model_to_string(SensorModel::UNKNOWN), "UNKNOWN");
+}
+
+TEST(NebulaCommonTest, StatusStreamingHandlesKnownAndFallbackValues)
+{
+  const std::array<std::pair<Status, std::string_view>, 12> expected_values{{
+    {Status::OK, "OK"},
+    {Status::UDP_CONNECTION_ERROR, "Udp Connection Error"},
+    {Status::CAN_CONNECTION_ERROR, "Can Connection Error"},
+    {Status::SENSOR_CONFIG_ERROR, "Could not set SensorConfiguration"},
+    {Status::INVALID_SENSOR_MODEL, "Invalid sensor model provided"},
+    {Status::INVALID_ECHO_MODE, "Invalid echo model provided"},
+    {Status::NOT_IMPLEMENTED, "Not Implemented"},
+    {Status::NOT_INITIALIZED, "Not Initialized"},
+    {Status::INVALID_CALIBRATION_FILE, "Invalid Calibration File"},
+    {Status::CANNOT_SAVE_FILE, "Cannot Save File"},
+    {Status::HTTP_CONNECTION_ERROR, "Http Connection Error"},
+    {Status::WAITING_FOR_SENSOR_RESPONSE, "Waiting for Sensor Response"},
+  }};
+
+  for (const auto & [status, expected_string] : expected_values) {
+    EXPECT_EQ(stream_to_string(status), expected_string);
+  }
+
+  EXPECT_EQ(stream_to_string(Status{Status::ERROR_1}), "Generic Error");
+  EXPECT_EQ(stream_to_string(Status{999}), "Generic Error");
+  EXPECT_EQ(Status(Status::OK), Status(Status::OK));
+  EXPECT_NE(Status(Status::OK), Status(Status::ERROR_1));
+}
+
+TEST(NebulaCommonTest, ConfigurationStreamOperatorsReflectFieldValues)
+{
+  SensorConfigurationBase sensor_config{};
+  sensor_config.sensor_model = SensorModel::VELODYNE_VLP16;
+  sensor_config.frame_id = "sensor_frame";
+  expect_contains_all(stream_to_string(sensor_config), {"VLP16", "sensor_frame"});
+
+  EthernetSensorConfigurationBase ethernet_config{};
+  ethernet_config.sensor_model = SensorModel::HESAI_PANDAR64;
+  ethernet_config.frame_id = "ethernet_frame";
+  ethernet_config.host_ip = "192.168.1.10";
+  ethernet_config.sensor_ip = "192.168.1.20";
+  ethernet_config.data_port = 2368;
+  expect_contains_all(
+    stream_to_string(ethernet_config),
+    {"Pandar64", "ethernet_frame", "192.168.1.10", "192.168.1.20", "2368"});
+
+  CANSensorConfigurationBase can_config{};
+  can_config.sensor_model = SensorModel::CONTINENTAL_SRR520;
+  can_config.frame_id = "can_frame";
+  can_config.interface = "can0";
+  can_config.receiver_timeout_sec = 0.25F;
+  can_config.sender_timeout_sec = 0.5F;
+  can_config.filters = "100:7FF";
+  can_config.use_bus_time = true;
+  expect_contains_all(
+    stream_to_string(can_config), {"SRR520", "can_frame", "can0", "0.25", "0.5", "100:7FF", "1"});
+
+  LidarConfigurationBase lidar_config{};
+  lidar_config.sensor_model = SensorModel::ROBOSENSE_HELIOS;
+  lidar_config.frame_id = "lidar_frame";
+  lidar_config.host_ip = "10.0.0.1";
+  lidar_config.sensor_ip = "10.0.0.2";
+  lidar_config.data_port = 6699;
+  lidar_config.return_mode = ReturnMode::SINGLE_STRONGEST;
+  lidar_config.packet_mtu_size = 1500;
+  lidar_config.use_sensor_time = true;
+  expect_contains_all(
+    stream_to_string(lidar_config),
+    {"HELIOS", "lidar_frame", "10.0.0.1", "10.0.0.2", "6699", "SingleStrongest", "1500", "1"});
+}
+
+TEST(NebulaCommonTest, PointConversionsPreserveRelevantFields)
+{
+  PointCloud<PointXYZIRCAEDT> input_cloud;
+
+  PointXYZIRCAEDT first{};
+  first.x = 1.0F;
+  first.y = -2.0F;
+  first.z = 3.5F;
+  first.intensity = 7U;
+  first.return_type = static_cast<std::uint8_t>(ReturnType::SECOND);
+  first.channel = 12U;
+  first.azimuth = nebula::drivers::deg2rad(45.0F);
+  first.distance = 9.5F;
+  first.time_stamp = 250000000U;
+  input_cloud.push_back(first);
+
+  PointXYZIRCAEDT second{};
+  second.x = -4.0F;
+  second.y = 5.0F;
+  second.z = -6.0F;
+  second.intensity = 200U;
+  second.return_type = static_cast<std::uint8_t>(ReturnType::LAST_STRONGEST);
+  second.channel = 99U;
+  second.azimuth = nebula::drivers::deg2rad(180.0F);
+  second.distance = 42.0F;
+  second.time_stamp = 999U;
+  input_cloud.push_back(second);
+
+  const PointCloud<PointXYZIR> xyzir_cloud =
+    nebula::drivers::convert_point_xyzircaedt_to_point_xyzir(input_cloud);
+  ASSERT_EQ(xyzir_cloud.size(), input_cloud.size());
+  EXPECT_FLOAT_EQ(xyzir_cloud[0].x, first.x);
+  EXPECT_FLOAT_EQ(xyzir_cloud[0].y, first.y);
+  EXPECT_FLOAT_EQ(xyzir_cloud[0].z, first.z);
+  EXPECT_FLOAT_EQ(xyzir_cloud[0].intensity, static_cast<float>(first.intensity));
+  EXPECT_EQ(xyzir_cloud[0].ring, first.channel);
+  EXPECT_EQ(xyzir_cloud[1].ring, second.channel);
+
+  constexpr double stamp = 1000.5;
+  const PointCloud<PointXYZIRADT> xyziradt_cloud =
+    nebula::drivers::convert_point_xyzircaedt_to_point_xyziradt(input_cloud, stamp);
+  ASSERT_EQ(xyziradt_cloud.size(), input_cloud.size());
+  EXPECT_FLOAT_EQ(xyziradt_cloud[0].azimuth, 4500.0F);
+  EXPECT_FLOAT_EQ(xyziradt_cloud[1].azimuth, 18000.0F);
+  EXPECT_FLOAT_EQ(xyziradt_cloud[0].distance, first.distance);
+  EXPECT_EQ(xyziradt_cloud[0].return_type, first.return_type);
+  EXPECT_DOUBLE_EQ(xyziradt_cloud[0].time_stamp, stamp + 0.25);
+  EXPECT_DOUBLE_EQ(xyziradt_cloud[1].time_stamp, stamp + 999.0e-9);
+
+  const PointCloud<PointXYZ> xyz_cloud =
+    nebula::drivers::convert_point_xyzircaedt_to_point_xyz(input_cloud);
+  ASSERT_EQ(xyz_cloud.size(), input_cloud.size());
+  EXPECT_FLOAT_EQ(xyz_cloud[1].x, second.x);
+  EXPECT_FLOAT_EQ(xyz_cloud[1].y, second.y);
+  EXPECT_FLOAT_EQ(xyz_cloud[1].z, second.z);
+}
+
+TEST(NebulaCommonTest, AngleAndSpeedHelpersConvertUnits)
+{
+  constexpr double pi = 3.14159265358979323846;
+
+  EXPECT_NEAR(nebula::drivers::deg2rad(180.0), pi, 1.0e-12);
+  EXPECT_NEAR(nebula::drivers::deg2rad(180), pi, 1.0e-12);
+  EXPECT_NEAR(nebula::drivers::rad2deg(pi / 2.0), 90.0, 1.0e-12);
+  EXPECT_DOUBLE_EQ(nebula::drivers::rpm2hz(600.0), 10.0);
+}
+
+}  // namespace
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/nebula_core/nebula_core_common/test/test_nebula_common.cpp
+++ b/src/nebula_core/nebula_core_common/test/test_nebula_common.cpp
@@ -185,8 +185,7 @@ TEST(NebulaCommonTest, SensorModelStreamingAndStringConversionsRoundTrip)
     EXPECT_EQ(nebula::drivers::sensor_model_to_string(expected_model), string_value);
   }
 
-  EXPECT_EQ(
-    nebula::drivers::sensor_model_from_string("Bpearl"), SensorModel::ROBOSENSE_BPEARL_V4);
+  EXPECT_EQ(nebula::drivers::sensor_model_from_string("Bpearl"), SensorModel::ROBOSENSE_BPEARL_V4);
   EXPECT_EQ(nebula::drivers::sensor_model_from_string("NotASensor"), SensorModel::UNKNOWN);
   EXPECT_EQ(nebula::drivers::sensor_model_to_string(SensorModel::UNKNOWN), "UNKNOWN");
 }

--- a/src/nebula_core/nebula_core_common/test/test_nebula_common.cpp
+++ b/src/nebula_core/nebula_core_common/test/test_nebula_common.cpp
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <cmath>
 #include <cstdint>
 #include <initializer_list>
 #include <sstream>
@@ -318,11 +319,9 @@ TEST(NebulaCommonTest, PointConversionsPreserveRelevantFields)
 
 TEST(NebulaCommonTest, AngleAndSpeedHelpersConvertUnits)
 {
-  constexpr double pi = 3.14159265358979323846;
-
-  EXPECT_NEAR(nebula::drivers::deg2rad(180.0), pi, 1.0e-12);
-  EXPECT_NEAR(nebula::drivers::deg2rad(180), pi, 1.0e-12);
-  EXPECT_NEAR(nebula::drivers::rad2deg(pi / 2.0), 90.0, 1.0e-12);
+  EXPECT_NEAR(nebula::drivers::deg2rad(180.0), M_PI, 1.0e-12);
+  EXPECT_NEAR(nebula::drivers::deg2rad(180), M_PI, 1.0e-12);
+  EXPECT_NEAR(nebula::drivers::rad2deg(M_PI / 2.0), 90.0, 1.0e-12);
   EXPECT_DOUBLE_EQ(nebula::drivers::rpm2hz(600.0), 10.0);
 }
 

--- a/src/nebula_core/nebula_core_common/test/test_ring_buffer.cpp
+++ b/src/nebula_core/nebula_core_common/test/test_ring_buffer.cpp
@@ -1,0 +1,87 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "nebula_core_common/util/ring_buffer.hpp"
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+
+TEST(RingBufferTest, EmptyBufferThrowsAndSizeStartsAtZero)
+{
+  nebula::util::RingBuffer<int> buffer(3);
+
+  EXPECT_EQ(buffer.size(), 0U);
+  EXPECT_FALSE(buffer.is_full());
+  EXPECT_THROW(static_cast<void>(buffer.get_average()), std::runtime_error);
+}
+
+TEST(RingBufferTest, AverageTracksValuesBeforeBufferIsFull)
+{
+  nebula::util::RingBuffer<int> buffer(3);
+
+  buffer.push_back(2);
+  EXPECT_EQ(buffer.size(), 1U);
+  EXPECT_EQ(buffer.get_average(), 2);
+  EXPECT_FALSE(buffer.is_full());
+
+  buffer.push_back(4);
+  EXPECT_EQ(buffer.size(), 2U);
+  EXPECT_EQ(buffer.get_average(), 3);
+  EXPECT_FALSE(buffer.is_full());
+
+  buffer.push_back(6);
+  EXPECT_EQ(buffer.size(), 3U);
+  EXPECT_EQ(buffer.get_average(), 4);
+  EXPECT_TRUE(buffer.is_full());
+}
+
+TEST(RingBufferTest, AverageUsesNewestValuesAfterWrapAround)
+{
+  nebula::util::RingBuffer<int> buffer(3);
+
+  buffer.push_back(3);
+  buffer.push_back(6);
+  buffer.push_back(9);
+  EXPECT_EQ(buffer.get_average(), 6);
+
+  buffer.push_back(12);
+  EXPECT_EQ(buffer.size(), 3U);
+  EXPECT_TRUE(buffer.is_full());
+  EXPECT_EQ(buffer.get_average(), 9);
+
+  buffer.push_back(15);
+  EXPECT_EQ(buffer.get_average(), 12);
+
+  buffer.push_back(18);
+  EXPECT_EQ(buffer.get_average(), 15);
+}
+
+TEST(RingBufferTest, SupportsNonIntegralAverages)
+{
+  nebula::util::RingBuffer<double> buffer(2);
+
+  buffer.push_back(0.5);
+  buffer.push_back(1.5);
+  EXPECT_DOUBLE_EQ(buffer.get_average(), 1.0);
+
+  buffer.push_back(3.5);
+  EXPECT_DOUBLE_EQ(buffer.get_average(), 2.5);
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/nebula_core/nebula_core_common/test/test_utility_helpers.cpp
+++ b/src/nebula_core/nebula_core_common/test/test_utility_helpers.cpp
@@ -56,6 +56,24 @@ TEST(UtilityHelpersTest, BitfieldExtractionSupportsRawAndAccessorUsage)
   EXPECT_EQ(packet.counter(), 10U);
 }
 
+TEST(UtilityHelpersTest, BitfieldExtractionHandlesUnsignedStorageEdgeCases)
+{
+  constexpr std::uint8_t byte_storage = 0x81U;
+  EXPECT_EQ((nebula::util::get_bitfield<std::uint8_t, 0, 0>(byte_storage)), 1U);
+  EXPECT_EQ((nebula::util::get_bitfield<std::uint8_t, 7, 7>(byte_storage)), 1U);
+  EXPECT_EQ((nebula::util::get_bitfield<std::uint8_t, 0, 7>(byte_storage)), byte_storage);
+
+  constexpr std::uint16_t word_storage = 0x8001U;
+  EXPECT_EQ((nebula::util::get_bitfield<std::uint8_t, 0, 0>(word_storage)), 1U);
+  EXPECT_EQ((nebula::util::get_bitfield<std::uint8_t, 15, 15>(word_storage)), 1U);
+  EXPECT_EQ((nebula::util::get_bitfield<std::uint16_t, 0, 15>(word_storage)), word_storage);
+
+  constexpr std::uint32_t dword_storage = 0xF0000001U;
+  EXPECT_EQ((nebula::util::get_bitfield<std::uint8_t, 0, 0>(dword_storage)), 1U);
+  EXPECT_EQ((nebula::util::get_bitfield<std::uint8_t, 28, 31>(dword_storage)), 0x0FU);
+  EXPECT_EQ((nebula::util::get_bitfield<std::uint32_t, 0, 31>(dword_storage)), dword_storage);
+}
+
 TEST(UtilityHelpersTest, ExpectedProvidesValueAndErrorAccessors)
 {
   const nebula::util::expected<int, std::string> value{42};

--- a/src/nebula_core/nebula_core_common/test/test_utility_helpers.cpp
+++ b/src/nebula_core/nebula_core_common/test/test_utility_helpers.cpp
@@ -1,0 +1,172 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "nebula_core_common/util/bitfield.hpp"
+#include "nebula_core_common/util/errno.hpp"
+#include "nebula_core_common/util/expected.hpp"
+#include "nebula_core_common/util/rate_limiter.hpp"
+#include "nebula_core_common/util/stopwatch.hpp"
+#include "nebula_core_common/util/string_conversions.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <thread>
+
+namespace
+{
+
+enum class BitfieldMode : std::uint8_t { Zero = 0, One = 1, Two = 2, Three = 3 };
+
+struct BitfieldPacket
+{
+  std::uint16_t storage{};
+  BITFIELD_ACCESSOR(BitfieldMode, mode, 0, 1, storage)
+  BITFIELD_ACCESSOR(std::uint8_t, counter, 8, 11, storage)
+};
+
+TEST(UtilityHelpersTest, BitfieldExtractionSupportsRawAndAccessorUsage)
+{
+  constexpr std::uint16_t storage = 0x0A03U;
+  const auto low_nibble = nebula::util::get_bitfield<std::uint8_t, 0, 3>(storage);
+  const auto high_nibble = nebula::util::get_bitfield<std::uint8_t, 8, 11>(storage);
+  const auto mode = nebula::util::get_bitfield<BitfieldMode, 0, 1>(storage);
+
+  EXPECT_EQ(low_nibble, 3U);
+  EXPECT_EQ(high_nibble, 10U);
+  EXPECT_EQ(mode, BitfieldMode::Three);
+
+  const BitfieldPacket packet{storage};
+  EXPECT_EQ(packet.mode(), BitfieldMode::Three);
+  EXPECT_EQ(packet.counter(), 10U);
+}
+
+TEST(UtilityHelpersTest, ExpectedProvidesValueAndErrorAccessors)
+{
+  const nebula::util::expected<int, std::string> value{42};
+  EXPECT_TRUE(value.has_value());
+  EXPECT_EQ(value.value(), 42);
+  EXPECT_EQ(value.value_or(7), 42);
+  EXPECT_EQ(value.value_or_throw("unused"), 42);
+  EXPECT_EQ(value.error_or("fallback"), "fallback");
+  EXPECT_THROW(static_cast<void>(value.error()), nebula::util::bad_expected_access);
+
+  const nebula::util::expected<int, std::string> error{std::string("bad")};
+  EXPECT_FALSE(error.has_value());
+  EXPECT_EQ(error.error(), "bad");
+  EXPECT_EQ(error.value_or(7), 7);
+  EXPECT_EQ(error.error_or("fallback"), "bad");
+
+  try {
+    static_cast<void>(error.value());
+    FAIL() << "Expected bad_expected_access";
+  } catch (const nebula::util::bad_expected_access & exception) {
+    EXPECT_STREQ(exception.what(), "value() called but containing error");
+  }
+
+  try {
+    static_cast<void>(value.error());
+    FAIL() << "Expected bad_expected_access";
+  } catch (const nebula::util::bad_expected_access & exception) {
+    EXPECT_STREQ(exception.what(), "error() called but containing value");
+  }
+
+  try {
+    static_cast<void>(error.value_or_throw("custom failure"));
+    FAIL() << "Expected runtime_error";
+  } catch (const std::runtime_error & exception) {
+    EXPECT_STREQ(exception.what(), "custom failure");
+  }
+}
+
+TEST(UtilityHelpersTest, ExpectedCanThrowStoredErrorType)
+{
+  const nebula::util::expected<int, std::runtime_error> error{std::runtime_error("stored error")};
+
+  try {
+    static_cast<void>(error.value_or_throw());
+    FAIL() << "Expected runtime_error";
+  } catch (const std::runtime_error & exception) {
+    EXPECT_STREQ(exception.what(), "stored error");
+  }
+}
+
+TEST(UtilityHelpersTest, RateLimiterSuppressesCallsInsideWindow)
+{
+  nebula::util::RateLimiter limiter(std::chrono::milliseconds(100));
+  int invocations = 0;
+
+  auto action = [&]() { ++invocations; };
+
+  limiter.with_rate_limit(100000000ULL, action);
+  limiter.with_rate_limit(150000000ULL, action);
+  limiter.with_rate_limit(199999999ULL, action);
+  limiter.with_rate_limit(200000000ULL, action);
+
+  EXPECT_EQ(invocations, 2);
+}
+
+TEST(UtilityHelpersTest, StopwatchResetRestartsElapsedTime)
+{
+  nebula::util::Stopwatch stopwatch;
+  std::this_thread::sleep_for(std::chrono::milliseconds(2));
+  const auto elapsed_before_reset = stopwatch.elapsed_ns();
+
+  EXPECT_GT(elapsed_before_reset, 0U);
+
+  stopwatch.reset();
+  const auto elapsed_after_reset = stopwatch.elapsed_ns();
+
+  EXPECT_LT(elapsed_after_reset, elapsed_before_reset);
+}
+
+TEST(UtilityHelpersTest, ErrnoToStringReturnsDistinctMessages)
+{
+  const auto success_message = nebula::util::errno_to_string(0);
+  const auto invalid_argument_message = nebula::util::errno_to_string(EINVAL);
+
+  EXPECT_FALSE(success_message.empty());
+  EXPECT_FALSE(invalid_argument_message.empty());
+  EXPECT_NE(success_message, invalid_argument_message);
+}
+
+TEST(UtilityHelpersTest, StringConversionsHandleStreamableTypesAndJson)
+{
+  EXPECT_EQ(nebula::util::to_string(123), "123");
+
+  constexpr char truncated_string[] = {'a', 'b', '\0', 'c', '\0'};
+  EXPECT_EQ(nebula::util::to_string(truncated_string), "ab");
+
+  const nlohmann::ordered_json ordered_string = "hello";
+  EXPECT_EQ(nebula::util::to_string(ordered_string), "hello");
+
+  const nlohmann::ordered_json ordered_object = {{"answer", 42}};
+  EXPECT_EQ(nebula::util::to_string(ordered_object), "{\"answer\":42}");
+
+  const nlohmann::json array = {1, 2, 3};
+  EXPECT_EQ(nebula::util::to_string(array), "[1,2,3]");
+  EXPECT_EQ(nebula::util::format_timestamp(12U, 34U), "12.000000034");
+}
+
+}  // namespace
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/nebula_core/nebula_core_common/test/test_utility_helpers.cpp
+++ b/src/nebula_core/nebula_core_common/test/test_utility_helpers.cpp
@@ -113,10 +113,10 @@ TEST(UtilityHelpersTest, RateLimiterSuppressesCallsInsideWindow)
 
   auto action = [&]() { ++invocations; };
 
-  limiter.with_rate_limit(100000000ULL, action);
-  limiter.with_rate_limit(150000000ULL, action);
-  limiter.with_rate_limit(199999999ULL, action);
-  limiter.with_rate_limit(200000000ULL, action);
+  limiter.with_rate_limit(100'000'000ULL, action);
+  limiter.with_rate_limit(150'000'000ULL, action);
+  limiter.with_rate_limit(199'999'999ULL, action);
+  limiter.with_rate_limit(200'000'000ULL, action);
 
   EXPECT_EQ(invocations, 2);
 }


### PR DESCRIPTION
## PR Type

- Improvement

## Related Links

- Follow-up vendor-specific coverage PRs:
  - #427
  - #428
  - #429

## Description

This PR increases coverage of `nebula_core_common` and adds focused unit tests for vendor-independent helpers.

Main additions:
- enum/string conversion coverage for `ReturnType`, `ReturnMode`, `SensorModel`, and `Status`
- stream-operator coverage for the core configuration structs and representative point-conversion helpers
- direct coverage for `ring_buffer`, `bitfield`, `expected`, `rate_limiter`, `stopwatch`, `errno`, and string conversion utilities
- unsigned edge-case coverage for `get_bitfield()` across `uint8_t`, `uint16_t`, and `uint32_t`

Small code fixes discovered while adding coverage:
- add missing `Pandar128E3X` handling in core sensor-model conversion helpers
- add the missing `CAN_CONNECTION_ERROR` branch in status streaming
- make `bitfield` explicitly require unsigned integral storage and simplify mask construction
- initialize the `errno` buffer to avoid the compiler warning treated as an error

## Review Procedure

1. Review the PR commit-by-commit; the core coverage work is intentionally split into small commits.
2. In `nebula_common` tests, check that round-trip/default-case coverage reflects the public conversion helpers without overfitting stream formatting.
3. In the utility-helper tests, focus on the new unsigned-only `bitfield` contract and the added edge-case coverage for full-width extraction.
4. Sanity-check the small production fixes in `nebula_common.hpp`, `nebula_status.hpp`, `bitfield.hpp`, and `errno.hpp` that were exposed by the added tests.

## Remarks

Verification used while preparing this PR:
- `source /opt/ros/humble/setup.bash && colcon build --packages-select nebula_core_common --symlink-install --mixin debug compile-commands coverage-gcc`
- `source /opt/ros/humble/setup.bash && colcon test --packages-select nebula_core_common --event-handlers console_direct+`

The repo-wide `build-test-cov.sh` run succeeds through coverage generation after splitting the vendor-specific work into follow-up PRs, but there is still an unrelated existing failure in `nebula_core_hw_interfaces` (`TestTcp.TestConnectTimeout`) that is not addressed here.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
