### PR TITLE
feat(nebula_hesai): soft-reset Hesai sensor on FuSa errors

### DIFF
--- a/src/nebula_hesai/nebula_hesai/include/nebula_hesai/decoder_wrapper.hpp
+++ b/src/nebula_hesai/nebula_hesai/include/nebula_hesai/decoder_wrapper.hpp
@@ -35,6 +35,7 @@
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
+#include <functional>
 #include <limits>
 #include <memory>
 #include <mutex>
@@ -46,11 +47,22 @@ namespace nebula::ros
 class HesaiDecoderWrapper
 {
 public:
+  using functional_safety_evaluation_cb_t = std::function<void(const FunctionalSafetyEvaluation &)>;
+
+  /// @brief Construct the Hesai decoder wrapper.
+  /// @param parent_node Parent ROS node.
+  /// @param config Active sensor configuration.
+  /// @param calibration Loaded calibration data.
+  /// @param diagnostic_updater Diagnostic updater to register tasks on.
+  /// @param publish_packets Whether raw packet scans should be republished.
+  /// @param functional_safety_evaluation_cb Optional callback invoked for completed FuSa
+  /// evaluations.
   HesaiDecoderWrapper(
     rclcpp::Node * parent_node,
     const std::shared_ptr<const nebula::drivers::HesaiSensorConfiguration> & config,
     const std::shared_ptr<const nebula::drivers::HesaiCalibrationConfigurationBase> & calibration,
-    diagnostic_updater::Updater & diagnostic_updater, bool publish_packets);
+    diagnostic_updater::Updater & diagnostic_updater, bool publish_packets,
+    functional_safety_evaluation_cb_t functional_safety_evaluation_cb = nullptr);
 
   /// @brief Process a cloud packet and return metadata
   /// @param packet_msg The packet to process
@@ -162,6 +174,7 @@ private:
   custom_diagnostic_tasks::RateBoundStatus publish_diagnostic_;
   std::optional<FunctionalSafetyDiagnosticTask> functional_safety_diagnostic_;
   std::optional<PacketLossDiagnosticTask> packet_loss_diagnostic_;
+  functional_safety_evaluation_cb_t functional_safety_evaluation_cb_;
 
   autoware_utils_debug::DebugPublisher debug_publisher_;
 

--- a/src/nebula_hesai/nebula_hesai/include/nebula_hesai/diagnostics/functional_safety_advanced.hpp
+++ b/src/nebula_hesai/nebula_hesai/include/nebula_hesai/diagnostics/functional_safety_advanced.hpp
@@ -20,8 +20,6 @@
 #include <diagnostic_msgs/msg/detail/key_value__struct.hpp>
 
 #include <boost/algorithm/string.hpp>
-#include <boost/range/algorithm/find.hpp>
-#include <boost/range/algorithm/find_if.hpp>
 #include <boost/tokenizer.hpp>
 
 #include <algorithm>
@@ -174,6 +172,24 @@ inline std::vector<ErrorDefinition> read_error_definitions_from_csv(const std::s
   return error_definitions;
 }
 
+/// Partition error codes into non-exempted and exempted subsets.
+inline std::tuple<drivers::FunctionalSafetyErrorCodes, drivers::FunctionalSafetyErrorCodes>
+split_error_codes(
+  const drivers::FunctionalSafetyErrorCodes & error_codes,
+  const std::unordered_set<uint16_t> & exempted_codes)
+{
+  drivers::FunctionalSafetyErrorCodes non_exempted_error_codes;
+  drivers::FunctionalSafetyErrorCodes exempted_error_codes;
+  for (const auto & error_code : error_codes) {
+    if (exempted_codes.find(error_code) == exempted_codes.end()) {
+      non_exempted_error_codes.push_back(error_code);
+    } else {
+      exempted_error_codes.push_back(error_code);
+    }
+  }
+  return std::make_tuple(non_exempted_error_codes, exempted_error_codes);
+}
+
 class FunctionalSafetyAdvanced : public FunctionalSafetyStatusProcessor
 {
 public:
@@ -187,28 +203,30 @@ public:
     }
   }
 
-  void populate_status(
+  FunctionalSafetyEvaluation evaluate_status(
     drivers::FunctionalSafetySeverity severity,
-    const drivers::FunctionalSafetyErrorCodes & error_codes,
-    diagnostic_msgs::msg::DiagnosticStatus & inout_status) override
+    const drivers::FunctionalSafetyErrorCodes & error_codes) override
   {
+    FunctionalSafetyEvaluation evaluation;
+    evaluation.received_error_codes = error_codes;
+
     diagnostic_msgs::msg::KeyValue kv;
     kv.key = "Diagnostic codes";
     kv.value = detail::error_codes_to_string(error_codes);
-    inout_status.values.push_back(kv);
+    evaluation.diagnostic_status.values.push_back(kv);
 
     if (error_codes.empty()) {
       // If there are no error codes, report the severity reported by the sensor
-      inout_status.level = detail::severity_to_diagnostic_status_level(severity);
-      inout_status.message = detail::status_to_string(severity, 0);
-      return;
+      evaluation.diagnostic_status.level = detail::severity_to_diagnostic_status_level(severity);
+      evaluation.diagnostic_status.message = detail::status_to_string(severity, 0);
+      return evaluation;
     }
 
-    auto [non_exempted_error_codes, exempted_error_codes] =
+    std::tie(evaluation.non_exempted_error_codes, evaluation.exempted_error_codes) =
       split_error_codes(error_codes, exempted_codes_);
 
     drivers::FunctionalSafetySeverity max_severity = drivers::FunctionalSafetySeverity::OK;
-    for (const auto & error_code : non_exempted_error_codes) {
+    for (const auto & error_code : evaluation.non_exempted_error_codes) {
       // If the error code is not found in the definitions, use the severity reported by the
       // sensor as the worst-case assumption.
       const auto error_definition =
@@ -217,44 +235,33 @@ public:
 
       max_severity = std::max(max_severity, error_definition.severity);
       auto error_kv = to_key_value(error_definition);
-      inout_status.values.push_back(error_kv);
+      evaluation.diagnostic_status.values.push_back(error_kv);
+      if (error_definition.severity == drivers::FunctionalSafetySeverity::ERROR) {
+        evaluation.triggering_error_codes.push_back(error_code);
+      }
     }
 
-    for (const auto & error_code : exempted_error_codes) {
+    for (const auto & error_code : evaluation.exempted_error_codes) {
       const auto error_definition =
         get_error_definition(error_code)
           .value_or(ErrorDefinition{error_code, "Unknown error", severity});
       auto error_kv = to_key_value(error_definition);
       error_kv.value = "[Exempted] " + error_kv.value;
-      inout_status.values.push_back(error_kv);
+      evaluation.diagnostic_status.values.push_back(error_kv);
     }
 
-    inout_status.level = detail::severity_to_diagnostic_status_level(max_severity);
+    evaluation.diagnostic_status.level = detail::severity_to_diagnostic_status_level(max_severity);
 
     // When the effective severity is OK, report nominal operation regardless of code count
-    const size_t n_errors_for_message =
-      (max_severity == drivers::FunctionalSafetySeverity::OK) ? 0 : non_exempted_error_codes.size();
-    inout_status.message = detail::status_to_string(max_severity, n_errors_for_message);
+    const size_t n_errors_for_message = (max_severity == drivers::FunctionalSafetySeverity::OK)
+                                          ? 0
+                                          : evaluation.non_exempted_error_codes.size();
+    evaluation.diagnostic_status.message =
+      detail::status_to_string(max_severity, n_errors_for_message);
+    return evaluation;
   }
 
 private:
-  static std::tuple<drivers::FunctionalSafetyErrorCodes, drivers::FunctionalSafetyErrorCodes>
-  split_error_codes(
-    const drivers::FunctionalSafetyErrorCodes & error_codes,
-    const std::unordered_set<uint16_t> & exempted_codes)
-  {
-    drivers::FunctionalSafetyErrorCodes non_exempted_error_codes;
-    drivers::FunctionalSafetyErrorCodes exempted_error_codes;
-    for (const auto & error_code : error_codes) {
-      if (boost::range::find(exempted_codes, error_code) == exempted_codes.end()) {
-        non_exempted_error_codes.push_back(error_code);
-      } else {
-        exempted_error_codes.push_back(error_code);
-      }
-    }
-    return std::make_tuple(non_exempted_error_codes, exempted_error_codes);
-  }
-
   [[nodiscard]] std::optional<ErrorDefinition> get_error_definition(uint16_t error_code) const
   {
     auto it = error_definitions_.find(error_code);

--- a/src/nebula_hesai/nebula_hesai/include/nebula_hesai/diagnostics/functional_safety_basic.hpp
+++ b/src/nebula_hesai/nebula_hesai/include/nebula_hesai/diagnostics/functional_safety_basic.hpp
@@ -29,18 +29,26 @@ namespace nebula::ros
 class FunctionalSafetyBasic : public FunctionalSafetyStatusProcessor
 {
 public:
-  void populate_status(
+  FunctionalSafetyEvaluation evaluate_status(
     drivers::FunctionalSafetySeverity severity,
-    const drivers::FunctionalSafetyErrorCodes & error_codes,
-    diagnostic_msgs::msg::DiagnosticStatus & inout_status) override
+    const drivers::FunctionalSafetyErrorCodes & error_codes) override
   {
-    inout_status.level = detail::severity_to_diagnostic_status_level(severity);
-    inout_status.message = detail::status_to_string(severity, error_codes.size());
+    FunctionalSafetyEvaluation evaluation;
+    evaluation.received_error_codes = error_codes;
+    evaluation.non_exempted_error_codes = error_codes;
+    evaluation.diagnostic_status.level = detail::severity_to_diagnostic_status_level(severity);
+    evaluation.diagnostic_status.message = detail::status_to_string(severity, error_codes.size());
 
     diagnostic_msgs::msg::KeyValue kv;
     kv.key = "Diagnostic codes";
     kv.value = detail::error_codes_to_string(error_codes);
-    inout_status.values.push_back(kv);
+    evaluation.diagnostic_status.values.push_back(kv);
+
+    if (severity == drivers::FunctionalSafetySeverity::ERROR) {
+      evaluation.triggering_error_codes = error_codes;
+    }
+
+    return evaluation;
   }
 };
 

--- a/src/nebula_hesai/nebula_hesai/include/nebula_hesai/diagnostics/functional_safety_diagnostic_task.hpp
+++ b/src/nebula_hesai/nebula_hesai/include/nebula_hesai/diagnostics/functional_safety_diagnostic_task.hpp
@@ -94,19 +94,36 @@ inline std::string status_to_string(drivers::FunctionalSafetySeverity severity, 
 
 using std::chrono_literals::operator""ms;
 
+/// @brief Result of evaluating a FuSa status update.
+struct FunctionalSafetyEvaluation
+{
+  diagnostic_msgs::msg::DiagnosticStatus diagnostic_status;
+  drivers::FunctionalSafetyErrorCodes received_error_codes;
+  drivers::FunctionalSafetyErrorCodes non_exempted_error_codes;
+  drivers::FunctionalSafetyErrorCodes exempted_error_codes;
+  drivers::FunctionalSafetyErrorCodes triggering_error_codes;
+};
+
 class FunctionalSafetyStatusProcessor
 {
 public:
   virtual ~FunctionalSafetyStatusProcessor() = default;
-  virtual void populate_status(
+
+  /// @brief Evaluate a FuSa status update into a diagnostic status and actionable code groups.
+  /// @param severity Severity reported by the sensor.
+  /// @param error_codes Aggregated FuSa error codes for the current update.
+  /// @return Evaluation result containing the diagnostic status and filtered code groups.
+  virtual FunctionalSafetyEvaluation evaluate_status(
     drivers::FunctionalSafetySeverity severity,
-    const drivers::FunctionalSafetyErrorCodes & error_codes,
-    diagnostic_msgs::msg::DiagnosticStatus & inout_status) = 0;
+    const drivers::FunctionalSafetyErrorCodes & error_codes) = 0;
 };
 
 class FunctionalSafetyDiagnosticTask : public diagnostic_updater::CompositeDiagnosticTask
 {
 public:
+  /// @brief Construct a FuSa diagnostic task.
+  /// @param parent_node ROS node used for liveness timing.
+  /// @param status_processor Processor that evaluates incoming FuSa statuses.
   explicit FunctionalSafetyDiagnosticTask(
     rclcpp::Node * const parent_node,
     std::unique_ptr<FunctionalSafetyStatusProcessor> status_processor)
@@ -121,13 +138,17 @@ public:
     addTask(&stuck_latch_);
   }
 
-  void on_status(
+  /// @brief Submit a FuSa status update.
+  /// @param severity Severity reported by the sensor.
+  /// @param error_codes Aggregated FuSa error codes for the current update.
+  /// @return Evaluated FuSa result after diagnostic status generation.
+  FunctionalSafetyEvaluation on_status(
     drivers::FunctionalSafetySeverity severity,
     const drivers::FunctionalSafetyErrorCodes & error_codes)
   {
-    diagnostic_msgs::msg::DiagnosticStatus status;
-    status_processor_->populate_status(severity, error_codes, status);
-    status_latch_.submit(status);
+    auto evaluation = status_processor_->evaluate_status(severity, error_codes);
+    status_latch_.submit(evaluation.diagnostic_status);
+    return evaluation;
   }
 
   void on_alive() { liveness_monitor_.tick(); }

--- a/src/nebula_hesai/nebula_hesai/include/nebula_hesai/hesai_ros_wrapper.hpp
+++ b/src/nebula_hesai/nebula_hesai/include/nebula_hesai/hesai_ros_wrapper.hpp
@@ -17,6 +17,7 @@
 #include "nebula_core_common/nebula_common.hpp"
 #include "nebula_core_common/nebula_status.hpp"
 #include "nebula_core_hw_interfaces/connections/udp.hpp"
+#include "nebula_core_ros/single_consumer_processor.hpp"
 #include "nebula_core_ros/sync_tooling/sync_tooling_worker.hpp"
 #include "nebula_hesai/decoder_wrapper.hpp"
 #include "nebula_hesai/hw_interface_wrapper.hpp"
@@ -34,6 +35,7 @@
 #include <boost/asio.hpp>
 #include <boost/lexical_cast.hpp>
 
+#include <atomic>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -58,6 +60,13 @@ class HesaiRosWrapper final : public rclcpp::Node
   struct ReplayState
   {
     rclcpp::Time last_scan_timestamp_;
+  };
+
+  /// @brief Reset debounce state for FuSa-triggered soft-resets.
+  enum class FunctionalSafetyResetState {
+    Healthy,
+    ResetPendingOrInFlight,
+    WaitingForRecovery,
   };
 
 public:
@@ -92,6 +101,14 @@ private:
   Status declare_and_get_sensor_config_params();
 
   void initialize_sync_tooling(const drivers::HesaiSensorConfiguration & config);
+
+  /// @brief Handle an evaluated FuSa status update and trigger a soft-reset on matching errors.
+  /// @param evaluation Evaluated FuSa result from the diagnostic task.
+  void on_functional_safety_evaluation(const FunctionalSafetyEvaluation & evaluation);
+
+  /// @brief Send the queued FuSa-triggered soft-reset command on a worker thread.
+  /// @param evaluation Evaluated FuSa result that triggered the reset.
+  void send_functional_safety_reset(FunctionalSafetyEvaluation && evaluation);
 
   /// @brief rclcpp parameter callback
   /// @param parameters Received parameters
@@ -135,6 +152,10 @@ private:
   std::optional<HesaiHwInterfaceWrapper> hw_interface_wrapper_;
   std::optional<HesaiHwMonitorWrapper> hw_monitor_wrapper_;
   std::optional<HesaiDecoderWrapper> decoder_wrapper_;
+  /// @brief Latch state used to suppress repeat soft-resets until recovery is observed.
+  std::atomic<FunctionalSafetyResetState> functional_safety_reset_state_{
+    FunctionalSafetyResetState::Healthy};
+  SingleConsumerProcessor<FunctionalSafetyEvaluation> functional_safety_reset_processor_;
 
   /// @brief Diagnostics that are not time or safety-critical
   diagnostic_updater::Updater diagnostic_updater_general_;

--- a/src/nebula_hesai/nebula_hesai/src/decoder_wrapper.cpp
+++ b/src/nebula_hesai/nebula_hesai/src/decoder_wrapper.cpp
@@ -37,13 +37,15 @@ HesaiDecoderWrapper::HesaiDecoderWrapper(
   rclcpp::Node * parent_node,
   const std::shared_ptr<const nebula::drivers::HesaiSensorConfiguration> & config,
   const std::shared_ptr<const drivers::HesaiCalibrationConfigurationBase> & calibration,
-  diagnostic_updater::Updater & diagnostic_updater, bool publish_packets)
+  diagnostic_updater::Updater & diagnostic_updater, bool publish_packets,
+  functional_safety_evaluation_cb_t functional_safety_evaluation_cb)
 : status_(nebula::Status::NOT_INITIALIZED),
   logger_(parent_node->get_logger().get_child("HesaiDecoder")),
   parent_node_(*parent_node),
   sensor_cfg_(config),
   calibration_cfg_ptr_(calibration),
   publish_diagnostic_(make_rate_bound_status(sensor_cfg_->rotation_speed, *parent_node)),
+  functional_safety_evaluation_cb_(std::move(functional_safety_evaluation_cb)),
   debug_publisher_(parent_node, "nebula")
 {
   if (!sensor_cfg_) {
@@ -325,7 +327,10 @@ std::shared_ptr<drivers::HesaiDriver> HesaiDecoderWrapper::initialize_driver(
     status_cb = [this](
                   drivers::FunctionalSafetySeverity severity,
                   const drivers::FunctionalSafetyErrorCodes & codes) {
-      functional_safety_diagnostic_->on_status(severity, codes);
+      const auto evaluation = functional_safety_diagnostic_->on_status(severity, codes);
+      if (functional_safety_evaluation_cb_) {
+        functional_safety_evaluation_cb_(evaluation);
+      }
     };
   }
 

--- a/src/nebula_hesai/nebula_hesai/src/hesai_ros_wrapper.cpp
+++ b/src/nebula_hesai/nebula_hesai/src/hesai_ros_wrapper.cpp
@@ -239,7 +239,7 @@ void HesaiRosWrapper::send_functional_safety_reset(FunctionalSafetyEvaluation &&
                     << format_functional_safety_evaluation(evaluation));
 
   try {
-    hw_interface_wrapper_->hw_interface()->send_reset();
+    hw_interface_wrapper_->hw_interface()->send_restart();
     RCLCPP_ERROR_STREAM(
       get_logger(), "FuSa-triggered Hesai PTC soft-reset command completed for codes "
                       << detail::error_codes_to_string(evaluation.triggering_error_codes));

--- a/src/nebula_hesai/nebula_hesai/src/hesai_ros_wrapper.cpp
+++ b/src/nebula_hesai/nebula_hesai/src/hesai_ros_wrapper.cpp
@@ -30,10 +30,51 @@
 
 namespace nebula::ros
 {
+namespace
+{
+
+const char * diagnostic_level_to_string(const uint8_t level)
+{
+  switch (level) {
+    case diagnostic_msgs::msg::DiagnosticStatus::OK:
+      return "OK";
+    case diagnostic_msgs::msg::DiagnosticStatus::WARN:
+      return "WARN";
+    case diagnostic_msgs::msg::DiagnosticStatus::ERROR:
+      return "ERROR";
+    case diagnostic_msgs::msg::DiagnosticStatus::STALE:
+      return "STALE";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+std::string format_functional_safety_evaluation(const FunctionalSafetyEvaluation & evaluation)
+{
+  std::stringstream ss;
+  ss << "level=" << diagnostic_level_to_string(evaluation.diagnostic_status.level) << " ("
+     << evaluation.diagnostic_status.message << ")"
+     << ", received codes=" << detail::error_codes_to_string(evaluation.received_error_codes)
+     << ", non-ignored codes=" << detail::error_codes_to_string(evaluation.non_exempted_error_codes)
+     << ", reset-triggering codes="
+     << detail::error_codes_to_string(evaluation.triggering_error_codes);
+  if (!evaluation.exempted_error_codes.empty()) {
+    ss << ", ignored codes=" << detail::error_codes_to_string(evaluation.exempted_error_codes);
+  }
+  return ss.str();
+}
+
+}  // namespace
+
 HesaiRosWrapper::HesaiRosWrapper(const rclcpp::NodeOptions & options)
 : rclcpp::Node("hesai_ros_wrapper", rclcpp::NodeOptions(options).use_intra_process_comms(true)),
   wrapper_status_(Status::NOT_INITIALIZED),
   sensor_cfg_ptr_(nullptr),
+  functional_safety_reset_processor_(
+    [this](FunctionalSafetyEvaluation && evaluation) {
+      send_functional_safety_reset(std::move(evaluation));
+    },
+    1),
   diagnostic_updater_general_((declare_parameter<bool>("diagnostic_updater.use_fqn", true), this)),
   diagnostic_updater_functional_safety_(this)
 {
@@ -97,9 +138,16 @@ HesaiRosWrapper::HesaiRosWrapper(const rclcpp::NodeOptions & options)
     }
   }
 
+  HesaiDecoderWrapper::functional_safety_evaluation_cb_t functional_safety_evaluation_cb;
+  if (launch_hw_ && !use_udp_only) {
+    functional_safety_evaluation_cb = [this](const FunctionalSafetyEvaluation & evaluation) {
+      on_functional_safety_evaluation(evaluation);
+    };
+  }
+
   decoder_wrapper_.emplace(
     this, sensor_cfg_ptr_, calibration_result.value(), diagnostic_updater_functional_safety_,
-    launch_hw_);
+    launch_hw_, std::move(functional_safety_evaluation_cb));
 
   RCLCPP_DEBUG(get_logger(), "Starting stream");
 
@@ -134,6 +182,73 @@ void HesaiRosWrapper::initialize_sync_tooling(const drivers::HesaiSensorConfigur
     this, *config.sync_diagnostics_topic, config.frame_id, config.ptp_domain);
 
   sync_tooling_plugin_.emplace(SyncToolingPlugin{sync_tooling_worker, util::RateLimiter(100ms)});
+}
+
+void HesaiRosWrapper::on_functional_safety_evaluation(const FunctionalSafetyEvaluation & evaluation)
+{
+  const bool has_reset_trigger =
+    hw_interface_wrapper_ &&
+    evaluation.diagnostic_status.level == diagnostic_msgs::msg::DiagnosticStatus::ERROR &&
+    !evaluation.triggering_error_codes.empty();
+
+  if (!has_reset_trigger) {
+    auto expected_state = FunctionalSafetyResetState::WaitingForRecovery;
+    if (
+      functional_safety_reset_state_.compare_exchange_strong(
+        expected_state, FunctionalSafetyResetState::Healthy)) {
+      RCLCPP_INFO_STREAM(
+        get_logger(),
+        "FuSa error state cleared. Sensor recovered to a non-error state and automatic Hesai "
+        "soft-reset is re-armed. "
+          << format_functional_safety_evaluation(evaluation));
+    }
+    return;
+  }
+
+  auto expected_state = FunctionalSafetyResetState::Healthy;
+  if (!functional_safety_reset_state_.compare_exchange_strong(
+        expected_state, FunctionalSafetyResetState::ResetPendingOrInFlight)) {
+    return;
+  }
+
+  if (!functional_safety_reset_processor_.try_push(FunctionalSafetyEvaluation{evaluation})) {
+    functional_safety_reset_state_.store(FunctionalSafetyResetState::Healthy);
+    RCLCPP_WARN_STREAM(
+      get_logger(), "FuSa-triggered Hesai soft-reset could not be queued. "
+                      << format_functional_safety_evaluation(evaluation));
+    return;
+  }
+
+  RCLCPP_ERROR_STREAM(
+    get_logger(),
+    "FuSa entered a latched error state and is now waiting for recovery before another automatic "
+    "Hesai soft-reset can be requested. "
+      << format_functional_safety_evaluation(evaluation));
+}
+
+void HesaiRosWrapper::send_functional_safety_reset(FunctionalSafetyEvaluation && evaluation)
+{
+  struct ResetStateGuard
+  {
+    std::atomic<FunctionalSafetyResetState> & state;
+    ~ResetStateGuard() { state.store(FunctionalSafetyResetState::WaitingForRecovery); }
+  } guard{functional_safety_reset_state_};
+
+  RCLCPP_ERROR_STREAM(
+    get_logger(), "Sending Hesai PTC soft-reset command for the latched FuSa error state. "
+                    << format_functional_safety_evaluation(evaluation));
+
+  try {
+    hw_interface_wrapper_->hw_interface()->send_reset();
+    RCLCPP_ERROR_STREAM(
+      get_logger(), "FuSa-triggered Hesai PTC soft-reset command completed for codes "
+                      << detail::error_codes_to_string(evaluation.triggering_error_codes));
+  } catch (const std::exception & ex) {
+    RCLCPP_ERROR_STREAM(
+      get_logger(), "FuSa-triggered Hesai PTC soft-reset command failed for codes "
+                      << detail::error_codes_to_string(evaluation.triggering_error_codes) << ": "
+                      << ex.what());
+  }
 }
 
 nebula::Status HesaiRosWrapper::declare_and_get_sensor_config_params()

--- a/src/nebula_hesai/nebula_hesai/tests/test_hesai_functional_safety.cpp
+++ b/src/nebula_hesai/nebula_hesai/tests/test_hesai_functional_safety.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "nebula_hesai/diagnostics/functional_safety_advanced.hpp"
+#include "nebula_hesai/diagnostics/functional_safety_basic.hpp"
 #include "nebula_hesai_decoders/decoders/functional_safety.hpp"
 
 #include <boost/range/algorithm/sort.hpp>
@@ -22,6 +23,7 @@
 
 #include <filesystem>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #ifndef _TEST_RESOURCES_PATH
@@ -180,10 +182,9 @@ TEST_P(PopulateStatusTest, PopulateStatus)
   const auto & test_case = GetParam();
   nebula::ros::FunctionalSafetyAdvanced functional_safety_advanced(
     error_definitions(), test_case.exempted_error_codes);
-  diagnostic_msgs::msg::DiagnosticStatus status;
-  functional_safety_advanced.populate_status(
-    test_case.arg_severity, test_case.arg_error_codes, status);
-  EXPECT_EQ(status.level, test_case.expected_status_level);
+  const auto evaluation =
+    functional_safety_advanced.evaluate_status(test_case.arg_severity, test_case.arg_error_codes);
+  EXPECT_EQ(evaluation.diagnostic_status.level, test_case.expected_status_level);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -193,8 +194,60 @@ INSTANTIATE_TEST_SUITE_P(
 TEST(FunctionalSafetyAdvanced, PopulateStatus)
 {
   nebula::ros::FunctionalSafetyAdvanced functional_safety_advanced(error_definitions(), {});
-  diagnostic_msgs::msg::DiagnosticStatus status;
-  functional_safety_advanced.populate_status(Severity::OK, {0x1111}, status);
-  EXPECT_EQ(status.level, diagnostic_msgs::msg::DiagnosticStatus::OK);
-  EXPECT_EQ(status.message, "Operating nominally");
+  const auto evaluation = functional_safety_advanced.evaluate_status(Severity::OK, {0x1111});
+  EXPECT_EQ(evaluation.diagnostic_status.level, diagnostic_msgs::msg::DiagnosticStatus::OK);
+  EXPECT_EQ(evaluation.diagnostic_status.message, "Operating nominally");
+}
+
+TEST(FunctionalSafetyAdvanced, EvaluateStatusCollectsTriggeringErrorCodes)
+{
+  nebula::ros::FunctionalSafetyAdvanced functional_safety_advanced(error_definitions(), {});
+  const auto evaluation =
+    functional_safety_advanced.evaluate_status(Severity::ERROR, {0x1111, 0x2222, 0x3333});
+  ASSERT_EQ(evaluation.triggering_error_codes.size(), 1U);
+  EXPECT_EQ(evaluation.triggering_error_codes.front(), 0x3333);
+}
+
+TEST(FunctionalSafetyAdvanced, EvaluateStatusRespectsExemptions)
+{
+  nebula::ros::FunctionalSafetyAdvanced functional_safety_advanced(error_definitions(), {0x3333});
+  const auto evaluation =
+    functional_safety_advanced.evaluate_status(Severity::ERROR, {0x2222, 0x3333});
+  EXPECT_TRUE(evaluation.triggering_error_codes.empty());
+  ASSERT_EQ(evaluation.exempted_error_codes.size(), 1U);
+  EXPECT_EQ(evaluation.exempted_error_codes.front(), 0x3333);
+}
+
+TEST(FunctionalSafetyAdvanced, EvaluateStatusFallsBackToReportedSeverity)
+{
+  nebula::ros::FunctionalSafetyAdvanced functional_safety_advanced(error_definitions(), {});
+  const auto evaluation = functional_safety_advanced.evaluate_status(Severity::ERROR, {0x4444});
+  ASSERT_EQ(evaluation.triggering_error_codes.size(), 1U);
+  EXPECT_EQ(evaluation.triggering_error_codes.front(), 0x4444);
+}
+
+TEST(FunctionalSafetyAdvanced, EvaluateStatusDoesNotPromoteWarnings)
+{
+  nebula::ros::FunctionalSafetyAdvanced functional_safety_advanced(error_definitions(), {});
+  const auto evaluation = functional_safety_advanced.evaluate_status(Severity::WARNING, {0x4444});
+  EXPECT_TRUE(evaluation.triggering_error_codes.empty());
+}
+
+TEST(FunctionalSafetyBasic, EvaluateStatusTriggersOnReportedErrors)
+{
+  nebula::ros::FunctionalSafetyBasic functional_safety_basic;
+  const auto evaluation =
+    functional_safety_basic.evaluate_status(Severity::ERROR, {0x1111, 0x2222});
+  EXPECT_EQ(evaluation.diagnostic_status.level, diagnostic_msgs::msg::DiagnosticStatus::ERROR);
+  EXPECT_EQ(
+    evaluation.triggering_error_codes,
+    (nebula::drivers::FunctionalSafetyErrorCodes{0x1111, 0x2222}));
+}
+
+TEST(FunctionalSafetyBasic, EvaluateStatusDoesNotTriggerOnWarnings)
+{
+  nebula::ros::FunctionalSafetyBasic functional_safety_basic;
+  const auto evaluation = functional_safety_basic.evaluate_status(Severity::WARNING, {0x1111});
+  EXPECT_EQ(evaluation.diagnostic_status.level, diagnostic_msgs::msg::DiagnosticStatus::WARN);
+  EXPECT_TRUE(evaluation.triggering_error_codes.empty());
 }

--- a/src/nebula_hesai/nebula_hesai_hw_interfaces/include/nebula_hesai_hw_interfaces/hesai_hw_interface.hpp
+++ b/src/nebula_hesai/nebula_hesai_hw_interfaces/include/nebula_hesai_hw_interfaces/hesai_hw_interface.hpp
@@ -81,6 +81,7 @@ const uint8_t g_ptc_command_get_high_resolution_mode = 0x28;
 const uint8_t g_ptp_command_set_ptp_lock_offset = 0x39;
 const uint8_t g_ptp_command_get_ptp_lock_offset = 0x3a;
 const uint8_t g_ptc_command_reset = 0x25;
+const uint8_t g_ptc_command_restart = 0x10;
 const uint8_t g_ptc_command_set_rotate_direction = 0x2a;
 const uint8_t g_ptc_command_lidar_monitor = 0x27;
 const uint8_t g_ptc_command_set_up_close_blockage_detection = 0x58;
@@ -352,6 +353,9 @@ public:
   /// @brief Sending command with PTC_COMMAND_RESET
   /// @return Resulting status
   Status send_reset();
+  /// @brief Sending command with PTC_COMMAND_RESTART
+  /// @return Resulting status
+  Status send_restart();
   /// @brief Setting values with PTC_COMMAND_SET_ROTATE_DIRECTION
   /// @param mode Rotation of the motor
   /// @return Resulting status

--- a/src/nebula_hesai/nebula_hesai_hw_interfaces/src/hesai_hw_interface.cpp
+++ b/src/nebula_hesai/nebula_hesai_hw_interfaces/src/hesai_hw_interface.cpp
@@ -859,6 +859,13 @@ Status HesaiHwInterface::send_reset()
   return Status::OK;
 }
 
+ Status HesaiHwInterface::send_restart()
+{
+  auto response_or_err = send_receive(g_ptc_command_restart);
+  response_or_err.value_or_throw(pretty_print_ptc_error(response_or_err.error_or({})));
+  return Status::OK;
+}
+
 Status HesaiHwInterface::set_rot_dir(int mode)
 {
   std::vector<unsigned char> request_payload;

--- a/src/nebula_hesai/nebula_hesai_hw_interfaces/src/hesai_hw_interface.cpp
+++ b/src/nebula_hesai/nebula_hesai_hw_interfaces/src/hesai_hw_interface.cpp
@@ -859,7 +859,7 @@ Status HesaiHwInterface::send_reset()
   return Status::OK;
 }
 
- Status HesaiHwInterface::send_restart()
+Status HesaiHwInterface::send_restart()
 {
   auto response_or_err = send_receive(g_ptc_command_restart);
   response_or_err.value_or_throw(pretty_print_ptc_error(response_or_err.error_or({})));


### PR DESCRIPTION
## Summary
- trigger a Hesai PTC soft-reset when a non-ignored FuSa error (not a warning) is observed
- move the reset command off the UDP receive thread and latch the error state until recovery is observed
- log the latched error/recovery state transitions and extend FuSa unit coverage for basic and advanced paths

## Testing
- source /opt/ros/humble/setup.bash && colcon build --packages-select nebula_hesai --mixin rel-with-deb-info compile-commands
- source /opt/ros/humble/setup.bash && colcon test --packages-select nebula_hesai