### PR TITLE
ci: fix Agnocast CI

### DIFF
--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -13,11 +13,6 @@ jobs:
       matrix:
         rosdistro: [humble, jazzy]
         enable_agnocast: [0, 1]
-        exclude:
-          - rosdistro: jazzy
-            # ros-jazzy-agnocastlib is not yet available on Apt
-            # (but has already been released to rosdistro)
-            enable_agnocast: 1
     env:
       CCACHE_DIR: /root/.ccache
       CC: /usr/lib/ccache/gcc

--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -70,6 +70,8 @@ jobs:
         id: test
         if: steps.build.outcome == 'success'
         uses: autowarefoundation/autoware-github-actions/colcon-test@v1
+        env:
+          ENABLE_AGNOCAST: 0
         with:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}

--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -12,15 +12,17 @@ jobs:
       fail-fast: false
       matrix:
         rosdistro: [humble, jazzy]
-        agnocast_enabled: [0, 1]
+        enable_agnocast: [0, 1]
         exclude:
           - rosdistro: jazzy
-            agnocast_enabled: 1  # Agnocast does not yet support Jazzy
+            # ros-jazzy-agnocastlib is not yet available on Apt
+            # (but has already been released to rosdistro)
+            enable_agnocast: 1
     env:
       CCACHE_DIR: /root/.ccache
       CC: /usr/lib/ccache/gcc
       CXX: /usr/lib/ccache/g++
-      AGNOCAST_ENABLED: ${{ matrix.agnocast_enabled }}
+      ENABLE_AGNOCAST: ${{ matrix.enable_agnocast }}
 
     steps:
       - name: Check out repository

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -45,15 +45,8 @@ jobs:
         id: get-self-packages
         uses: autowarefoundation/autoware-github-actions/get-self-packages@v1
 
-      - name: Install ccache
-        run: sudo apt-get update && sudo apt-get install -y ccache
-        shell: bash
-
-      - name: Create ccache directory
-        run: |
-          mkdir -p ${CCACHE_DIR}
-          du -sh ${CCACHE_DIR} && ccache -s
-        shell: bash
+      - run: ./.github/workflows/scripts/ensure-apt-up-to-date.sh
+      - run: ./.github/workflows/scripts/setup-ccache.sh
 
       - name: Limit ccache size
         run: |

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -93,6 +93,8 @@ jobs:
         if: ${{ steps.get-self-packages.outputs.self-packages != '' }}
         id: test
         uses: autowarefoundation/autoware-github-actions/colcon-test@v1
+        env:
+          ENABLE_AGNOCAST: 0
         with:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -16,11 +16,6 @@ jobs:
       matrix:
         rosdistro: [humble, jazzy]
         enable_agnocast: [0, 1]
-        exclude:
-          - rosdistro: jazzy
-            # ros-jazzy-agnocastlib is not yet available on Apt
-            # (but has already been released to rosdistro)
-            enable_agnocast: 1
     env:
       CCACHE_DIR: /root/.ccache
       CCACHE_SIZE: 1G  # The GitHub cache action allows for 10G but the runners' disk space is limited

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -15,16 +15,18 @@ jobs:
       fail-fast: false
       matrix:
         rosdistro: [humble, jazzy]
-        agnocast_enabled: [0, 1]
+        enable_agnocast: [0, 1]
         exclude:
           - rosdistro: jazzy
-            agnocast_enabled: 1  # Agnocast does not yet support Jazzy
+            # ros-jazzy-agnocastlib is not yet available on Apt
+            # (but has already been released to rosdistro)
+            enable_agnocast: 1
     env:
       CCACHE_DIR: /root/.ccache
       CCACHE_SIZE: 1G  # The GitHub cache action allows for 10G but the runners' disk space is limited
       CC: /usr/lib/ccache/gcc
       CXX: /usr/lib/ccache/g++
-      AGNOCAST_ENABLED: ${{ matrix.agnocast_enabled }}
+      ENABLE_AGNOCAST: ${{ matrix.enable_agnocast }}
 
     steps:
       - name: Check out repository
@@ -97,7 +99,7 @@ jobs:
           build-depends-repos: build_depends-${{ matrix.rosdistro }}.repos
 
       - name: Upload coverage to CodeCov
-        if: ${{ steps.test.outputs.coverage-report-files != '' && matrix.agnocast_enabled == 0 }}
+        if: ${{ steps.test.outputs.coverage-report-files != '' && matrix.enable_agnocast == 0 }}
         uses: codecov/codecov-action@v4
         with:
           files: ${{ steps.test.outputs.coverage-report-files }}

--- a/build_depends-humble.repos
+++ b/build_depends-humble.repos
@@ -3,12 +3,3 @@ repositories:
     type: git
     url: https://github.com/tier4/sync_tooling_msgs.git
     version: main
-
-  # TODO(TIER IV): During the transition period of Agnocast introduction,
-  # the Agnocast ROS packages are provided as a source build.
-  # Once the transition stabilizes, use the packages released from the official ROS repository.
-  # Issue: https://github.com/autowarefoundation/autoware/issues/5968
-  agnocast:
-    type: git
-    url: https://github.com/tier4/agnocast
-    version: 2.3.1

--- a/src/nebula_continental/nebula_continental/src/continental_ars548_ros_wrapper.cpp
+++ b/src/nebula_continental/nebula_continental/src/continental_ars548_ros_wrapper.cpp
@@ -33,6 +33,7 @@ ContinentalARS548RosWrapper::ContinentalARS548RosWrapper(const rclcpp::NodeOptio
     "continental_ars548_ros_wrapper", rclcpp::NodeOptions(options).use_intra_process_comms(true)),
   wrapper_status_(Status::NOT_INITIALIZED)
 {
+  // CI trigger
   setvbuf(stdout, NULL, _IONBF, BUFSIZ);
 
   wrapper_status_ = declare_and_get_sensor_config_params();

--- a/src/nebula_hesai/nebula_hesai/src/hesai_ros_wrapper.cpp
+++ b/src/nebula_hesai/nebula_hesai/src/hesai_ros_wrapper.cpp
@@ -37,6 +37,7 @@ HesaiRosWrapper::HesaiRosWrapper(const rclcpp::NodeOptions & options)
   diagnostic_updater_general_((declare_parameter<bool>("diagnostic_updater.use_fqn", true), this)),
   diagnostic_updater_functional_safety_(this)
 {
+  // CI trigger
   setvbuf(stdout, nullptr, _IONBF, BUFSIZ);
 
   wrapper_status_ = declare_and_get_sensor_config_params();


### PR DESCRIPTION
## PR Type

- Improvement

## Related Links

- #422 - original PR, merged too early before ROS distro sync

## Description

<!-- Describe what this PR changes. -->
This PR is a new incarnation of #422, fixing the Agnocast env var name in CI. Previously it was wrong and completely ignored by colcon/Nebula, resulting in a non-Agnocast build being labeled with Agnocast.

CI now tests compilation with/without Agnocast for Hubmle/Jazzy. Since Agnocast kmod is not available in CI, Agnocast is disabled during the test step, resulting in the Agnocast lib falling back to ROS2 comms internally.

ROS distro sync finished for both Hubmle and Jazzy, so agnocastlib and agnocast_components are both available, making CI pass now.

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
