### PR TITLE
fix: update port configurations for ARS548

### DIFF
--- a/src/nebula_continental/nebula_continental/config/ARS548.param.yaml
+++ b/src/nebula_continental/nebula_continental/config/ARS548.param.yaml
@@ -2,15 +2,15 @@
   ros__parameters:
     host_ip: 10.13.1.166
     sensor_ip: 10.13.1.113
-    data_port: 42102
+    data_port: 32102
     frame_id: continental
     base_frame: base_link
     object_frame: base_link
     launch_hw: true
     multicast_ip: 224.0.2.2
     sensor_model: ARS548
-    configuration_host_port: 42401
-    configuration_sensor_port: 42101
+    configuration_host_port: 32401
+    configuration_sensor_port: 32101
     use_sensor_time: false
     radar_info_rate_subsample: 10
     configuration_vehicle_length: 4.89

--- a/src/nebula_continental/nebula_continental_hw_interfaces/test/test_ars548_hw_interface.cpp
+++ b/src/nebula_continental/nebula_continental_hw_interfaces/test/test_ars548_hw_interface.cpp
@@ -117,9 +117,9 @@ protected:
     config_ =
       std::make_shared<nebula::drivers::continental_ars548::ContinentalARS548SensorConfiguration>();
     config_->host_ip = "127.0.0.1";
-    config_->data_port = 42102;
+    config_->data_port = 32102;
     config_->sensor_ip = "127.0.0.1";
-    config_->configuration_sensor_port = 42101;
+    config_->configuration_sensor_port = 32101;
     config_->multicast_ip = "224.0.2.2";
 
     hw_interface_->set_sensor_configuration(config_);

--- a/src/nebula_core/nebula_core_ros/schema/communication.json
+++ b/src/nebula_core/nebula_core_ros/schema/communication.json
@@ -19,7 +19,7 @@
     },
     "data_port": {
       "type": "integer",
-      "default": "32102",
+      "default": "2368",
       "minimum": 0,
       "readOnly": true,
       "description": "Sensor data port."

--- a/src/nebula_core/nebula_core_ros/schema/communication.json
+++ b/src/nebula_core/nebula_core_ros/schema/communication.json
@@ -5,21 +5,21 @@
   "definitions": {
     "configuration_host_port": {
       "type": "integer",
-      "default": "42401",
+      "default": "32401",
       "minimum": 0,
       "readOnly": true,
       "description": "Host configuration port."
     },
     "configuration_sensor_port": {
       "type": "integer",
-      "default": "42101",
+      "default": "32101",
       "minimum": 0,
       "readOnly": true,
       "description": "Sensor configuration port."
     },
     "data_port": {
       "type": "integer",
-      "default": "2368",
+      "default": "32102",
       "minimum": 0,
       "readOnly": true,
       "description": "Sensor data port."


### PR DESCRIPTION
## PR Type
- Improvement

## Related Links
https://star4.slack.com/archives/C076E8EBJTG/p1778655511314399

## Description

Since the port numbers used in ARS548, including `data_port`, are ephemeral ports, communication will fail if they are already occupied on the Host PC side.

Although users can flexibly change these values because they are parameterized, this PR updates the default values to prevent such conflicts and issues.

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
