### PR TITLE
chore: change reliable QoS settings 

### DIFF
--- a/src/nebula_continental/nebula_continental/src/continental_ars548_decoder_wrapper.cpp
+++ b/src/nebula_continental/nebula_continental/src/continental_ars548_decoder_wrapper.cpp
@@ -74,7 +74,7 @@ ContinentalARS548DecoderWrapper::ContinentalARS548DecoderWrapper(
   // Publish packets only if HW interface is connected
   if (launch_hw) {
     packets_pub_ = parent_node->create_publisher<nebula_msgs::msg::NebulaPackets>(
-      "nebula_packets", rclcpp::SensorDataQoS());
+      "nebula_packets", rclcpp::SensorDataQoS().reliable());
   }
 
   detection_list_pub_ =

--- a/src/nebula_continental/nebula_continental/src/continental_srr520_decoder_wrapper.cpp
+++ b/src/nebula_continental/nebula_continental/src/continental_srr520_decoder_wrapper.cpp
@@ -52,7 +52,7 @@ ContinentalSRR520DecoderWrapper::ContinentalSRR520DecoderWrapper(
   // Publish packets only if HW interface is connected
   if (hw_interface_ptr_) {
     packets_pub_ = parent_node->create_publisher<nebula_msgs::msg::NebulaPackets>(
-      "nebula_packets", rclcpp::SensorDataQoS());
+      "nebula_packets", rclcpp::SensorDataQoS().reliable());
   }
 
   auto qos_profile = rmw_qos_profile_sensor_data;

--- a/src/nebula_hesai/nebula_hesai/src/decoder_wrapper.cpp
+++ b/src/nebula_hesai/nebula_hesai/src/decoder_wrapper.cpp
@@ -73,7 +73,7 @@ HesaiDecoderWrapper::HesaiDecoderWrapper(
   if (publish_packets) {
     current_scan_msg_ = std::make_unique<pandar_msgs::msg::PandarScan>();
     packets_pub_ = parent_node->create_publisher<pandar_msgs::msg::PandarScan>(
-      "pandar_packets", rclcpp::SensorDataQoS());
+      "pandar_packets", rclcpp::SensorDataQoS().reliable());
     packets_pub_thread_.emplace(
       [this](pandar_msgs::msg::PandarScan::UniquePtr && msg) {
         if (packets_pub_) {


### PR DESCRIPTION

## PR Type

- Improvement


## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description

<!-- Describe what this PR changes. -->

This pull request updates the quality of service (QoS) settings for packet publishers in multiple decoder wrappers to ensure reliable message delivery. The main change is switching the QoS from the default sensor data profile to a reliable mode, which can help prevent packet loss in scenarios where message reliability is critical.

**QoS reliability improvements:**

* Changed the QoS profile for the `nebula_packets` publisher in `ContinentalARS548DecoderWrapper` to use `.reliable()` for reliable message delivery.
* Changed the QoS profile for the `nebula_packets` publisher in `ContinentalSRR520DecoderWrapper` to use `.reliable()` for reliable message delivery.
* Changed the QoS profile for the `pandar_packets` publisher in `HesaiDecoderWrapper` to use `.reliable()` for reliable message delivery.

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
