### PR TITLE
feat(nebula_core_ros): templatize NodeT of `nebula_core_ros`

### DIFF
--- a/src/nebula_core/nebula_core_ros/include/nebula_core_ros/diagnostics/liveness_monitor.hpp
+++ b/src/nebula_core/nebula_core_ros/include/nebula_core_ros/diagnostics/liveness_monitor.hpp
@@ -52,8 +52,9 @@ public:
    * @param parent_node The node from which clock type and parameters are read.
    * @param timeout The time after the last call to `tick()` where the routine is declared dead
    */
+  template <typename NodeT>
   LivenessMonitor(
-    const std::string & name, const rclcpp::Node * parent_node, const rclcpp::Duration & timeout)
+    const std::string & name, const NodeT * parent_node, const rclcpp::Duration & timeout)
   : DiagnosticTask(name), timeout_(timeout)
   {
     // select clock according to the use_sim_time paramter set to the parent

--- a/src/nebula_core/nebula_core_ros/include/nebula_core_ros/diagnostics/rate_bound_status.hpp
+++ b/src/nebula_core/nebula_core_ros/include/nebula_core_ros/diagnostics/rate_bound_status.hpp
@@ -79,8 +79,9 @@ public:
    * \param name The arbitrary string to be assigned for this diagnostic task.
    * This name will not be exposed in the actual published topics.
    */
+  template <typename NodeT>
   RateBoundStatus(
-    const rclcpp::Node * parent_node, const RateBoundStatusParam & ok_params,
+    const NodeT * parent_node, const RateBoundStatusParam & ok_params,
     const RateBoundStatusParam & warn_params, const size_t num_frame_transition = 1,
     const bool immediate_error_report = false, const bool immediate_relax_state = true,
     const std::string & name = "rate bound check")

--- a/src/nebula_core/nebula_core_ros/include/nebula_core_ros/sync_tooling/sync_tooling_worker.hpp
+++ b/src/nebula_core/nebula_core_ros/include/nebula_core_ros/sync_tooling/sync_tooling_worker.hpp
@@ -67,8 +67,9 @@ public:
   SyncToolingWorker(
     NodeT * const parent_node, const std::string & topic, const std::string & frame_id,
     uint8_t ptp_domain_id)
-  : publisher_(rclcpp::create_publisher<std_msgs::msg::UInt8MultiArray>(
-      *parent_node, topic, rclcpp::QoS(10))),
+  : publisher_(
+      rclcpp::create_publisher<std_msgs::msg::UInt8MultiArray>(
+        *parent_node, topic, rclcpp::QoS(10))),
     hostname_(get_hostname()),
     sensor_id_(make_sensor_clock_id(frame_id)),
     ptp_domain_id_(ptp_domain_id)

--- a/src/nebula_core/nebula_core_ros/include/nebula_core_ros/sync_tooling/sync_tooling_worker.hpp
+++ b/src/nebula_core/nebula_core_ros/include/nebula_core_ros/sync_tooling/sync_tooling_worker.hpp
@@ -63,10 +63,12 @@ inline ClockId make_sensor_clock_id(const std::string & frame_id)
 class SyncToolingWorker
 {
 public:
+  template <typename NodeT>
   SyncToolingWorker(
-    rclcpp::Node * const parent_node, const std::string & topic, const std::string & frame_id,
+    NodeT * const parent_node, const std::string & topic, const std::string & frame_id,
     uint8_t ptp_domain_id)
-  : publisher_(parent_node->create_publisher<std_msgs::msg::UInt8MultiArray>(topic, 10)),
+  : publisher_(rclcpp::create_publisher<std_msgs::msg::UInt8MultiArray>(
+      *parent_node, topic, rclcpp::QoS(10))),
     hostname_(get_hostname()),
     sensor_id_(make_sensor_clock_id(frame_id)),
     ptp_domain_id_(ptp_domain_id)


### PR DESCRIPTION
## PR Type

- Improvement

## Related Links

<!-- 必要であれば追加してください -->

## Description

Templatize the `NodeT` parameter of `LivenessMonitor`, `RateBoundStatus`, and `SyncToolingWorker` in `nebula_core_ros`, so they can work with node types other than `rclcpp::Node`.

We plan to migrate Nebula nodes to `agnocast_wrapper::Node` in the future, so these helpers need to support node types other than `rclcpp::Node`. This is a preparatory, non-functional change — behavior for existing `rclcpp::Node` usages is unchanged.

## Review Procedure

- Confirm the templatized constructors behave identically for existing `rclcpp::Node` call sites

## Remarks

Preparatory change for future `agnocast::Node` adoption.

## Pre-Review Checklist for the PR Author

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.