### PR TITLE
ci: distribute lint-autoware-system-design-format via sync-files

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -6,6 +6,7 @@
     - source: .github/workflows/semantic-pull-request.yaml
     - source: .github/workflows/spell-check-differential.yaml
     - source: .github/workflows/sync-files.yaml
+    - source: .github/workflows/lint-autoware-system-design-format.yaml
     - source: .clang-format
     - source: .markdown-link-check.json
     - source: .markdownlint.yaml

--- a/.github/workflows/lint-autoware-system-design-format.yaml
+++ b/.github/workflows/lint-autoware-system-design-format.yaml
@@ -25,6 +25,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Lint system design format files
-        uses: autowarefoundation/autoware_system_designer@v0.3.0
+        uses: autowarefoundation/autoware_system_designer@v0.4.1
         with:
           design_files_path: .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,7 +95,7 @@ repos:
         exclude: .cu
 
   - repo: https://github.com/autowarefoundation/autoware_system_designer
-    rev: v0.3.2
+    rev: v0.4.1
     hooks:
       - id: lint-system-design-format
         args: [--format=github-actions]


### PR DESCRIPTION
## PR Type

- Improvement

## Related Links

- autowarefoundation/sync-file-templates#91

## Description

Bring the Autoware system design format lint workflow under `sync-files` management. Nebula carries `*.node.yaml` design files, so the workflow lints them on PRs.

- Rename `.github/workflows/lint-autoware-system-design-format.yml` to `.yaml` to match the [sync-file-templates](https://github.com/autowarefoundation/sync-file-templates) source path, and register it in `.github/sync-files.yaml` so it stays managed by `sync-files`.
- Bump the workflow's `autoware_system_designer` action from `v0.3.0` to `v0.4.1`, and the `autoware_system_designer` pre-commit hook from `v0.3.2` to `v0.4.1`, matching the current template.

## Review Procedure

Confirm the added mapping line matches the sync-file-templates source. No behavioral change until the workflow file is synced in.

## Remarks

None.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.