### PR TITLE
fix(nebula_hesai): guard sensor setup with try/catch and retry

### DIFF
--- a/src/nebula_hesai/nebula_hesai/include/nebula_hesai/hw_interface_wrapper.hpp
+++ b/src/nebula_hesai/nebula_hesai/include/nebula_hesai/hw_interface_wrapper.hpp
@@ -42,6 +42,14 @@ public:
   [[nodiscard]] std::shared_ptr<const HesaiInventoryBase> inventory() const;
 
 private:
+  /// @brief Apply the sensor configuration via the HW interface, retrying on transient comms
+  /// faults. Retries are bounded by g_hw_config_max_attempts when retry_hw is enabled (a single
+  /// attempt otherwise).
+  /// @throws std::runtime_error if the configuration cannot be applied after all attempts. Callers
+  /// decide whether that is fatal: the constructor lets it propagate (aborting startup), while
+  /// on_config_change catches it to keep a running node alive.
+  void configure_sensor();
+
   std::shared_ptr<drivers::HesaiHwInterface> hw_interface_;
   std::shared_ptr<const HesaiInventoryBase> inventory_;
 
@@ -49,5 +57,6 @@ private:
   nebula::Status status_;
   bool setup_sensor_;
   bool use_udp_only_;
+  bool retry_hw_;
 };
 }  // namespace nebula::ros

--- a/src/nebula_hesai/nebula_hesai/src/hw_interface_wrapper.cpp
+++ b/src/nebula_hesai/nebula_hesai/src/hw_interface_wrapper.cpp
@@ -9,10 +9,24 @@
 #include <nebula_core_common/util/string_conversions.hpp>
 #include <nebula_hesai_hw_interfaces/hesai_hw_interface.hpp>
 
+#include <chrono>
+#include <exception>
 #include <memory>
+#include <stdexcept>
+#include <string>
+#include <thread>
 
 namespace nebula::ros
 {
+
+namespace
+{
+/// @brief Back-off between hardware bring-up attempts (TCP connect and sensor configuration).
+/// The sensor can take more than 5s to become responsive after power-on, so this is generous.
+constexpr auto g_hw_retry_delay = std::chrono::milliseconds(8000);
+/// @brief Maximum number of sensor-configuration attempts when retry_hw is enabled.
+constexpr int g_hw_config_max_attempts = 5;
+}  // namespace
 
 HesaiHwInterfaceWrapper::HesaiHwInterfaceWrapper(
   rclcpp::Node * const parent_node,
@@ -25,7 +39,7 @@ HesaiHwInterfaceWrapper::HesaiHwInterfaceWrapper(
   use_udp_only_(use_udp_only)
 {
   setup_sensor_ = parent_node->declare_parameter<bool>("setup_sensor", param_read_only());
-  bool retry_connect = parent_node->declare_parameter<bool>("retry_hw", param_read_only());
+  retry_hw_ = parent_node->declare_parameter<bool>("retry_hw", param_read_only());
 
   status_ = hw_interface_->set_sensor_configuration(
     std::static_pointer_cast<const drivers::SensorConfigurationBase>(config));
@@ -45,12 +59,12 @@ HesaiHwInterfaceWrapper::HesaiHwInterfaceWrapper(
 
   while (true) {
     status_ = hw_interface_->initialize_tcp_socket();
-    if (status_ == Status::OK || !retry_connect) {
+    if (status_ == Status::OK || !retry_hw_) {
       break;
     }
 
     retry_count++;
-    std::this_thread::sleep_for(std::chrono::milliseconds(8000));  // >5000
+    std::this_thread::sleep_for(g_hw_retry_delay);
     RCLCPP_WARN_STREAM(logger_, status_ << ". Retry #" << retry_count);
   }
 
@@ -62,7 +76,7 @@ HesaiHwInterfaceWrapper::HesaiHwInterfaceWrapper(
       RCLCPP_ERROR_STREAM(logger_, "Failed to get model from sensor...");
     }
     if (setup_sensor_) {
-      hw_interface_->check_and_set_config();
+      configure_sensor();
     }
   } else {
     RCLCPP_ERROR_STREAM(
@@ -78,8 +92,45 @@ void HesaiHwInterfaceWrapper::on_config_change(
   hw_interface_->set_sensor_configuration(
     std::static_pointer_cast<const nebula::drivers::SensorConfigurationBase>(new_config));
   if (!use_udp_only_ && setup_sensor_) {
-    hw_interface_->check_and_set_config();
+    // Unlike startup, a runtime reconfiguration failure must not bring down a running node (this
+    // runs inside a set-parameters callback), so the node is kept alive. Note that
+    // check_and_set_config applies settings incrementally, so a mid-sequence failure can leave the
+    // sensor partially reconfigured rather than at either the old or the new configuration.
+    try {
+      configure_sensor();
+    } catch (const std::exception & e) {
+      RCLCPP_ERROR_STREAM(
+        logger_,
+        "Could not apply new configuration; the sensor may be left in a partially applied, "
+        "undefined state: "
+          << e.what());
+    }
   }
+}
+
+void HesaiHwInterfaceWrapper::configure_sensor()
+{
+  // A transient comms fault (e.g. a slow sensor timing out a single PTC command) should not fail
+  // setup outright, so attempts are retried. When retry_hw is set, a bounded number of retries
+  // gives a slow-to-respond sensor time to become ready. If configuration still cannot be applied,
+  // we throw rather than run a misconfigured sensor; the caller decides whether that is fatal.
+  const int attempts = retry_hw_ ? g_hw_config_max_attempts : 1;
+  for (int attempt = 1; attempt <= attempts; ++attempt) {
+    try {
+      hw_interface_->check_and_set_config();
+      return;
+    } catch (const std::exception & e) {
+      RCLCPP_ERROR_STREAM(
+        logger_,
+        "Could not configure sensor (attempt " << attempt << "/" << attempts << "): " << e.what());
+    }
+    if (attempt < attempts) {
+      std::this_thread::sleep_for(g_hw_retry_delay);
+    }
+  }
+
+  throw std::runtime_error(
+    "Could not configure sensor after " + std::to_string(attempts) + " attempt(s)");
 }
 
 Status HesaiHwInterfaceWrapper::status()

--- a/src/nebula_hesai/nebula_hesai/src/hw_interface_wrapper.cpp
+++ b/src/nebula_hesai/nebula_hesai/src/hw_interface_wrapper.cpp
@@ -101,8 +101,8 @@ void HesaiHwInterfaceWrapper::on_config_change(
     } catch (const std::exception & e) {
       RCLCPP_ERROR_STREAM(
         logger_,
-        "Could not apply new configuration; the sensor may be left in a partially applied, "
-        "undefined state: "
+        "Could not apply new configuration; the sensor may be left in a partially reconfigured "
+        "state: "
           << e.what());
     }
   }

--- a/src/nebula_hesai/nebula_hesai_hw_interfaces/src/hesai_hw_interface.cpp
+++ b/src/nebula_hesai/nebula_hesai_hw_interfaces/src/hesai_hw_interface.cpp
@@ -1021,18 +1021,15 @@ HesaiStatus HesaiHwInterface::check_and_set_config(
     std::stringstream ss2;
     ss2 << sensor_configuration->return_mode;
     logger_->info("Current Configuration return_mode: " + ss2.str());
-    std::thread t([this, sensor_configuration] {
-      auto return_mode_int = nebula::drivers::int_from_return_mode_hesai(
-        sensor_configuration->return_mode, sensor_configuration->sensor_model);
-      if (return_mode_int < 0) {
-        logger_->error(
-          "Invalid Return Mode for this sensor. Please check your settings. Falling back to Dual "
-          "mode.");
-        return_mode_int = 2;
-      }
-      set_return_mode(return_mode_int);
-    });
-    t.join();
+    auto return_mode_int = nebula::drivers::int_from_return_mode_hesai(
+      sensor_configuration->return_mode, sensor_configuration->sensor_model);
+    if (return_mode_int < 0) {
+      logger_->error(
+        "Invalid Return Mode for this sensor. Please check your settings. Falling back to Dual "
+        "mode.");
+      return_mode_int = 2;
+    }
+    set_return_mode(return_mode_int);
     std::this_thread::sleep_for(wait_time);
   }
 
@@ -1049,9 +1046,7 @@ HesaiStatus HesaiHwInterface::check_and_set_config(
     } else {
       logger_->info(
         "Setting up spin rate via TCP." + std::to_string(sensor_configuration->rotation_speed));
-      std::thread t(
-        [this, sensor_configuration] { set_spin_rate(sensor_configuration->rotation_speed); });
-      t.join();
+      set_spin_rate(sensor_configuration->rotation_speed);
     }
     std::this_thread::sleep_for(wait_time);
   }
@@ -1095,13 +1090,9 @@ HesaiStatus HesaiHwInterface::check_and_set_config(
   if (set_flg) {
     std::vector<std::string> list_string;
     boost::split(list_string, desired_host_addr, boost::is_any_of("."));
-    std::thread t([this, sensor_configuration, list_string] {
-      set_destination_ip(
-        std::stoi(list_string[0]), std::stoi(list_string[1]), std::stoi(list_string[2]),
-        std::stoi(list_string[3]), sensor_configuration->data_port,
-        sensor_configuration->gnss_port);
-    });
-    t.join();
+    set_destination_ip(
+      std::stoi(list_string[0]), std::stoi(list_string[1]), std::stoi(list_string[2]),
+      std::stoi(list_string[3]), sensor_configuration->data_port, sensor_configuration->gnss_port);
     std::this_thread::sleep_for(wait_time);
   }
 
@@ -1117,47 +1108,38 @@ HesaiStatus HesaiHwInterface::check_and_set_config(
       logger_->info("current lidar sync: " + std::to_string(hesai_config.sync));
       logger_->info("current lidar sync_angle: " + std::to_string(sensor_sync_angle));
       logger_->info("current configuration sync_angle: " + std::to_string(config_sync_angle));
-      std::thread t(
-        [this, sync_flg, config_sync_angle] { set_sync_angle(sync_flg, config_sync_angle); });
-      t.join();
+      set_sync_angle(sync_flg, config_sync_angle);
       std::this_thread::sleep_for(wait_time);
     }
 
-    std::thread t([this, sensor_configuration] {
-      if (
-        sensor_configuration->sensor_model == SensorModel::HESAI_PANDAR40P ||
-        sensor_configuration->sensor_model == SensorModel::HESAI_PANDAR64 ||
-        sensor_configuration->sensor_model == SensorModel::HESAI_PANDARQT64 ||
-        sensor_configuration->sensor_model == SensorModel::HESAI_PANDARXT16 ||
-        sensor_configuration->sensor_model == SensorModel::HESAI_PANDARXT32 ||
-        sensor_configuration->sensor_model == SensorModel::HESAI_PANDARXT32M) {
-        logger_->info("Trying to set Clock source to PTP");
-        set_clock_source(g_hesai_lidar_ptp_clock_source);
-      }
+    if (
+      sensor_configuration->sensor_model == SensorModel::HESAI_PANDAR40P ||
+      sensor_configuration->sensor_model == SensorModel::HESAI_PANDAR64 ||
+      sensor_configuration->sensor_model == SensorModel::HESAI_PANDARQT64 ||
+      sensor_configuration->sensor_model == SensorModel::HESAI_PANDARXT16 ||
+      sensor_configuration->sensor_model == SensorModel::HESAI_PANDARXT32 ||
+      sensor_configuration->sensor_model == SensorModel::HESAI_PANDARXT32M) {
+      logger_->info("Trying to set Clock source to PTP");
+      set_clock_source(g_hesai_lidar_ptp_clock_source);
+    }
 
-      auto current_ptp = get_ptp_config();
-      bool needs_ptp_update = !ptp_config_matches_desired(*current_ptp, *sensor_configuration);
+    auto current_ptp = get_ptp_config();
+    bool needs_ptp_update = !ptp_config_matches_desired(*current_ptp, *sensor_configuration);
 
-      if (needs_ptp_update) {
-        std::ostringstream tmp_ostringstream;
-        tmp_ostringstream << "Trying to set PTP Config: " << sensor_configuration->ptp_profile
-                          << ", Domain: " << std::to_string(sensor_configuration->ptp_domain)
-                          << ", Transport: " << sensor_configuration->ptp_transport_type
-                          << ", Switch Type: " << sensor_configuration->ptp_switch_type
-                          << " via TCP";
-        logger_->info(tmp_ostringstream.str());
-        set_ptp_config(
-          static_cast<int>(sensor_configuration->ptp_profile), sensor_configuration->ptp_domain,
-          static_cast<int>(sensor_configuration->ptp_transport_type),
-          static_cast<int>(sensor_configuration->ptp_switch_type), g_ptp_log_announce_interval,
-          g_ptp_sync_interval, g_ptp_log_min_delay_interval);
-      }
-      logger_->debug("Setting properties done");
-    });
-    logger_->debug("Waiting for thread to finish");
-
-    t.join();
-    logger_->debug("Thread finished");
+    if (needs_ptp_update) {
+      std::ostringstream tmp_ostringstream;
+      tmp_ostringstream << "Trying to set PTP Config: " << sensor_configuration->ptp_profile
+                        << ", Domain: " << std::to_string(sensor_configuration->ptp_domain)
+                        << ", Transport: " << sensor_configuration->ptp_transport_type
+                        << ", Switch Type: " << sensor_configuration->ptp_switch_type << " via TCP";
+      logger_->info(tmp_ostringstream.str());
+      set_ptp_config(
+        static_cast<int>(sensor_configuration->ptp_profile), sensor_configuration->ptp_domain,
+        static_cast<int>(sensor_configuration->ptp_transport_type),
+        static_cast<int>(sensor_configuration->ptp_switch_type), g_ptp_log_announce_interval,
+        g_ptp_sync_interval, g_ptp_log_min_delay_interval);
+    }
+    logger_->debug("Setting properties done");
 
     switch (sensor_configuration_->sensor_model) {
       case SensorModel::HESAI_PANDAR128_E4X:
@@ -1277,12 +1259,9 @@ HesaiStatus HesaiHwInterface::check_and_set_config(
   }
 
   if (set_flg) {
-    std::thread t([this, sensor_configuration] {
-      set_lidar_range(
-        static_cast<int>(sensor_configuration->cloud_min_angle * 10),
-        static_cast<int>(sensor_configuration->cloud_max_angle * 10));
-    });
-    t.join();
+    set_lidar_range(
+      static_cast<int>(sensor_configuration->cloud_min_angle * 10),
+      static_cast<int>(sensor_configuration->cloud_max_angle * 10));
   }
 
 #ifdef WITH_DEBUG_STDOUT_HESAI_HW_INTERFACE
@@ -1296,12 +1275,11 @@ HesaiStatus HesaiHwInterface::check_and_set_config()
 #ifdef WITH_DEBUG_STDOUT_HESAI_HW_INTERFACE
   logger_->debug("Start CheckAndSetConfig!");
 #endif
-  std::thread t([this] {
+  {
     auto result = get_config();
     check_and_set_config(
       std::static_pointer_cast<const HesaiSensorConfiguration>(sensor_configuration_), result);
-  });
-  t.join();
+  }
 
   if (
     sensor_configuration_->sensor_model == SensorModel::HESAI_PANDARAT128 ||
@@ -1309,12 +1287,11 @@ HesaiStatus HesaiHwInterface::check_and_set_config()
     return Status::OK;
   }
 
-  std::thread t2([this] {
+  {
     auto result = get_lidar_range();
     check_and_set_config(
       std::static_pointer_cast<const HesaiSensorConfiguration>(sensor_configuration_), result);
-  });
-  t2.join();
+  }
 #ifdef WITH_DEBUG_STDOUT_HESAI_HW_INTERFACE
   logger_->debug("End CheckAndSetConfig!");
 #endif


### PR DESCRIPTION
## PR Type

- Bug Fix

## Related Links

- Stacked on top of #463 (must merge first). This PR targets that branch, not `main`.

## Description

Follow-up to #463. Once the throwaway `std::thread`+`join()` wrappers were removed from `check_and_set_config`, a comms fault during sensor setup surfaces as a normal `std::exception` at the call site instead of calling `std::terminate()`. But the call site in `HesaiHwInterfaceWrapper` still did not handle it, so a transient timeout during startup (e.g. `get_lidar_range()` → `"PTC Error: Timeout;"`) would propagate out of node construction — and out of the `on_config_change` parameter callback at runtime.

This PR adds a `configure_sensor()` helper that:

- wraps `check_and_set_config()` in `try/catch (const std::exception &)` and, when `retry_hw` is set, retries up to `g_hw_config_max_attempts` (5) times with `g_hw_retry_delay` (8 s) backoff — the same cadence already used for the TCP-connect step (single best-effort attempt when `retry_hw` is false);
- **throws `std::runtime_error` if configuration still cannot be applied after all attempts**, rather than running a misconfigured sensor.

Failure handling differs by caller, by design:

- **Startup (constructor):** the exception propagates, so the node fails to construct. A sensor we cannot configure is treated as fatal rather than started misconfigured.
- **Runtime (`on_config_change`):** this runs inside an `add_on_set_parameters_callback` handler, where an unhandled exception would take down the *running* node. So it is caught and logged, and the node keeps running with the previously applied configuration.

Retry count and backoff are named constants (`g_hw_config_max_attempts`, `g_hw_retry_delay`); the backoff constant also replaces the previously duplicated `8000 ms` literal in the TCP-connect retry loop. `retry_hw` is stored as a member so both the constructor and `on_config_change` share the retry behaviour.

## Review Procedure

- Confirm a transient comms fault at startup is retried (when `retry_hw`) and, if it persists, aborts node construction with a clear error rather than starting a misconfigured sensor.
- Confirm a persistent failure during a runtime parameter change is logged and does **not** crash the running node.
- Confirm `retry_hw=false` keeps single-attempt behaviour.
- Confirm the success path is unchanged.

## Remarks

Part of a stack hardening the Hesai PTC paths against sensor/network faults. A separate follow-up will bound the response-length allocation in `send_receive` and guard the HW-monitor's `SingleConsumerProcessor` callback.

## CI Checks

- **Build and test for PR**: Required to pass before the merge.

---
Built locally with `colcon build --packages-up-to nebula_hesai` ✅. Formatted with pinned clang-format v22.1.4 via pre-commit.