### PR TITLE
ci(sync-files): sync agnocast_wrapper core headers from autoware.core (Stage 1: groundwork)

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -16,3 +16,40 @@
     - source: .yamllint.yaml
     - source: CPPLINT.cfg
     - source: setup.cfg
+
+# Mirror the autoware::agnocast_wrapper CORE headers (Method-2 Node + pub/sub/tf2/message_filters/
+# diagnostic_updater) from autoware.core into nebula, renamed into the nebula::agnocast_wrapper /
+# NEBULA_ namespace. The polling bridge (polling_subscriber.hpp) is intentionally NOT synced so that
+# nebula never pulls autoware_utils_rclcpp (that file is the wrapper's only autoware_utils dependency).
+- repository: autowarefoundation/autoware.core
+  files:
+    - source: common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+      dest: src/nebula_core/nebula_core_ros/include/nebula_core_ros/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+      pre-commands: |
+        sd 'autoware::agnocast_wrapper' 'nebula::agnocast_wrapper' {source}
+        sd 'AUTOWARE_' 'NEBULA_' {source}
+        sd 'autoware/agnocast_wrapper/' 'nebula_core_ros/agnocast_wrapper/' {source}
+    - source: common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
+      dest: src/nebula_core/nebula_core_ros/include/nebula_core_ros/agnocast_wrapper/node.hpp
+      pre-commands: |
+        sd 'autoware::agnocast_wrapper' 'nebula::agnocast_wrapper' {source}
+        sd 'AUTOWARE_' 'NEBULA_' {source}
+        sd 'autoware/agnocast_wrapper/' 'nebula_core_ros/agnocast_wrapper/' {source}
+    - source: common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+      dest: src/nebula_core/nebula_core_ros/include/nebula_core_ros/agnocast_wrapper/message_filters.hpp
+      pre-commands: |
+        sd 'autoware::agnocast_wrapper' 'nebula::agnocast_wrapper' {source}
+        sd 'AUTOWARE_' 'NEBULA_' {source}
+        sd 'autoware/agnocast_wrapper/' 'nebula_core_ros/agnocast_wrapper/' {source}
+    - source: common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/tf2.hpp
+      dest: src/nebula_core/nebula_core_ros/include/nebula_core_ros/agnocast_wrapper/tf2.hpp
+      pre-commands: |
+        sd 'autoware::agnocast_wrapper' 'nebula::agnocast_wrapper' {source}
+        sd 'AUTOWARE_' 'NEBULA_' {source}
+        sd 'autoware/agnocast_wrapper/' 'nebula_core_ros/agnocast_wrapper/' {source}
+    - source: common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/diagnostic_updater.hpp
+      dest: src/nebula_core/nebula_core_ros/include/nebula_core_ros/agnocast_wrapper/diagnostic_updater.hpp
+      pre-commands: |
+        sd 'autoware::agnocast_wrapper' 'nebula::agnocast_wrapper' {source}
+        sd 'AUTOWARE_' 'NEBULA_' {source}
+        sd 'autoware/agnocast_wrapper/' 'nebula_core_ros/agnocast_wrapper/' {source}


### PR DESCRIPTION
## PR Type

- Improvement

## Related Links

- Adoption follow-up: #467
- Depends on https://github.com/autowarefoundation/autoware_core/pull/1283

## Description

Stage 1 of 2 (CI groundwork only). Adds a `sync-files.yaml` source that mirrors the `autoware::agnocast_wrapper` **core** headers (`node.hpp`, umbrella, `message_filters`, `tf2`, `diagnostic_updater`) from `autowarefoundation/autoware.core` into `nebula_core_ros`, renamed into the `nebula::agnocast_wrapper` / `NEBULA_` namespace.

`polling_subscriber.hpp` is intentionally **excluded** so nebula never pulls `autoware_utils_rclcpp`. No headers are imported and no call sites change in this PR, so nebula keeps building against the current hand-written wrapper.

## Review Procedure

Review the added block in `.github/sync-files.yaml` only. No source or build changes.

## Remarks

Prerequisite: [the clean-core wrapper PR](https://github.com/autowarefoundation/autoware_core/pull/1283) must land in `autowarefoundation/autoware.core` before the sync
produces autoware_utils-free headers. The adoption step (retire the hand-written wrapper + migrate
call sites) is the follow-up #467.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
